### PR TITLE
fix(pricing): avoid guessing Cursor models as MiniMax

### DIFF
--- a/packages/core/src/pricing/pricing.json
+++ b/packages/core/src/pricing/pricing.json
@@ -2,7 +2,7 @@
   "_meta": {
     "units": "usd_per_million_tokens",
     "generated_at": "2026-08-27T00:00:00.000Z",
-    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=308."
+    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes)."
   },
   "exact": {
     "alibaba/qvq-max": {
@@ -211,6 +211,34 @@
       "output": 6,
       "cache_read": 0.25,
       "cache_write": 2.5
+    },
+    "alibaba/qwen-coder": {
+      "input": 0.3,
+      "output": 1.5
+    },
+    "alibaba/qwen3-coder-next": {
+      "input": 0.6,
+      "output": 2.4
+    },
+    "alibaba/qwen3.7-flash": {
+      "input": 0.03,
+      "output": 0.13,
+      "cache_read": 0.006
+    },
+    "alibaba/qwen3.8-2.4t-a95b": {
+      "input": 2,
+      "output": 6,
+      "cache_read": 0.25
+    },
+    "alibaba/qwen3.8-27b": {
+      "input": 0.5,
+      "output": 3,
+      "cache_read": 0.1
+    },
+    "alibaba/qwen3.8-flash": {
+      "input": 0.16,
+      "output": 0.47,
+      "cache_read": 0.016
     },
     "alibaba-cn/MiniMax/MiniMax-M2.7": {
       "input": 0.3,
@@ -565,6 +593,174 @@
       "cache_read": 0.5,
       "cache_write": 6.25
     },
+    "anthropic/claude-3-haiku": {
+      "input": 0.25,
+      "output": 1.25,
+      "cache_read": 0.03
+    },
+    "anthropic/claude-3-opus": {
+      "input": 15,
+      "output": 75,
+      "cache_read": 1.5
+    },
+    "anthropic/claude-3.5-haiku": {
+      "input": 0.8,
+      "output": 4,
+      "cache_read": 0.08
+    },
+    "deepseek/deepseek-coder": {
+      "input": 0.14,
+      "output": 0.28
+    },
+    "deepseek/deepseek-r1": {
+      "input": 0.55,
+      "output": 2.19,
+      "cache_read": 0.14
+    },
+    "deepseek/deepseek-v3": {
+      "input": 0.27,
+      "output": 1.1,
+      "cache_read": 0.07
+    },
+    "deepseek/deepseek-v3.1": {
+      "input": 0.56,
+      "output": 1.68,
+      "cache_read": 0.07
+    },
+    "deepseek/deepseek-v3.2": {
+      "input": 0.28,
+      "output": 0.42,
+      "cache_read": 0.028
+    },
+    "deepseek/deepseek-v4-flash": {
+      "input": 0.44,
+      "output": 1.32,
+      "cache_read": 0.014
+    },
+    "deepseek/deepseek-v4-pro": {
+      "input": 1.32,
+      "output": 3.96,
+      "cache_read": 0.044
+    },
+    "anthropic/claude-3.5-sonnet": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    },
+    "anthropic/claude-3.7-sonnet": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    },
+    "anthropic/claude-mythos-5": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1
+    },
+    "anthropic/claude-opus-4": {
+      "input": 15,
+      "output": 75,
+      "cache_read": 1.5
+    },
+    "anthropic/claude-opus-4-1": {
+      "input": 15,
+      "output": 75,
+      "cache_read": 1.5
+    },
+    "anthropic/claude-opus-4-8-fast": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1
+    },
+    "anthropic/claude-opus-5-fast": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1
+    },
+    "anthropic/claude-sonnet-4": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    },
+    "google/gemini-1.5-flash": {
+      "input": 0.075,
+      "output": 0.3,
+      "cache_read": 0.01875
+    },
+    "google/gemini-1.5-pro": {
+      "input": 3.5,
+      "output": 10.5
+    },
+    "google/gemini-2.0-flash": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.025
+    },
+    "google/gemini-2.0-flash-lite": {
+      "input": 0.075,
+      "output": 0.3,
+      "cache_read": 0.01875
+    },
+    "google/gemini-2.5-flash": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
+    },
+    "google/gemini-3-flash": {
+      "input": 0.5,
+      "output": 3,
+      "cache_read": 0.05
+    },
+    "google/gemini-3-pro": {
+      "input": 2,
+      "output": 12,
+      "cache_read": 0.2
+    },
+    "google/gemini-3-pro-preview": {
+      "input": 2,
+      "output": 12,
+      "cache_read": 0.2
+    },
+    "google/gemini-3.1-pro": {
+      "input": 2,
+      "output": 12,
+      "cache_read": 0.2
+    },
+    "google/gemini-3.5-flash-lite": {
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
+    },
+    "google/gemini-3.5-flash-preview": {
+      "input": 1.5,
+      "output": 9,
+      "cache_read": 0.15
+    },
+    "google/gemini-3.6-flash": {
+      "input": 1.5,
+      "output": 7.5,
+      "cache_read": 0.15
+    },
+    "google/gemini-3.7-flash": {
+      "input": 1.5,
+      "output": 7.5,
+      "cache_read": 0.15
+    },
+    "google/gemini-3.7-flash-batch": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
+    "google/gemini-3.7-flash-fast": {
+      "input": 2.7,
+      "output": 13.5,
+      "cache_read": 0.27
+    },
+    "google/gemini-3.7-flash-flex": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
     "anthropic/claude-opus-4-8": {
       "input": 5,
       "output": 25,
@@ -865,6 +1061,26 @@
       "cache_read": 0.06,
       "cache_write": 0.375
     },
+    "mistral/codestral-2508": {
+      "input": 0.3,
+      "output": 0.9
+    },
+    "mistral/ministral-14b-2512": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "mistral/ministral-3b-2512": {
+      "input": 0.1,
+      "output": 0.1
+    },
+    "mistral/ministral-8b-2512": {
+      "input": 0.15,
+      "output": 0.15
+    },
+    "mistral/mistral-medium-3-5": {
+      "input": 1.5,
+      "output": 7.5
+    },
     "minimax/MiniMax-M2.5": {
       "input": 0.3,
       "output": 1.2,
@@ -876,6 +1092,48 @@
       "output": 2.4,
       "cache_read": 0.06,
       "cache_write": 0.375
+    },
+    "moonshotai/k2p6": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.16
+    },
+    "moonshotai/kimi-for-coding": {
+      "input": 0.6,
+      "output": 3,
+      "cache_read": 0.1
+    },
+    "moonshotai/kimi-for-coding-highspeed": {
+      "input": 1.8,
+      "output": 9,
+      "cache_read": 0.3
+    },
+    "moonshotai/kimi-k2": {
+      "input": 0.6,
+      "output": 2.5,
+      "cache_read": 0.15
+    },
+    "moonshotai/kimi-k2.7-code": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.19
+    },
+    "moonshotai/kimi-k3": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    },
+    "moonshotai/moonshot-v1-128k": {
+      "input": 2,
+      "output": 5
+    },
+    "moonshotai/moonshot-v1-32k": {
+      "input": 1,
+      "output": 3
+    },
+    "moonshotai/moonshot-v1-8k": {
+      "input": 0.2,
+      "output": 2
     },
     "minimax/MiniMax-M2.7": {
       "input": 0.3,
@@ -1002,6 +1260,229 @@
     "mistral/mistral-medium-2604": {
       "input": 1.5,
       "output": 7.5
+    },
+    "openai/codex-mini-latest": {
+      "input": 1.5,
+      "output": 6,
+      "cache_read": 0.375
+    },
+    "volcengine/doubao-lite-128k": {
+      "input": 0.041,
+      "output": 0.083,
+      "cache_read": 0.008
+    },
+    "volcengine/doubao-pro-128k": {
+      "input": 0.111,
+      "output": 0.277,
+      "cache_read": 0.022
+    },
+    "volcengine/doubao-seed-2.0-code": {
+      "input": 0.449,
+      "output": 2.282,
+      "cache_read": 0.09
+    },
+    "volcengine/doubao-seed-2.0-lite": {
+      "input": 0.083,
+      "output": 0.498,
+      "cache_read": 0.017
+    },
+    "volcengine/doubao-seed-2.0-mini": {
+      "input": 0.028,
+      "output": 0.277,
+      "cache_read": 0.006
+    },
+    "volcengine/doubao-seed-2.0-pro": {
+      "input": 0.442,
+      "output": 2.213,
+      "cache_read": 0.088
+    },
+    "volcengine/doubao-seed-2.1-pro": {
+      "input": 0.829,
+      "output": 4.147,
+      "cache_read": 0.166
+    },
+    "xai/grok-3-beta": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.75
+    },
+    "xai/grok-4": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.75
+    },
+    "xai/grok-4-0709": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.75
+    },
+    "xai/grok-4-fast-non-reasoning": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "xai/grok-4-fast-reasoning": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "xai/grok-4.20": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "xai/grok-4.20-multi-agent": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "xai/grok-4.20-non-reasoning": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "xai/grok-4.20-reasoning": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "xai/grok-code-fast-1": {
+      "input": 0.2,
+      "output": 1.5,
+      "cache_read": 0.02
+    },
+    "volcengine/doubao-seed-2.1-turbo": {
+      "input": 0.415,
+      "output": 2.073,
+      "cache_read": 0.083
+    },
+    "volcengine/doubao-seed-code": {
+      "input": 0.166,
+      "output": 1.106,
+      "cache_read": 0.033
+    },
+    "openai/gpt-5": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125
+    },
+    "openai/gpt-5-codex": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125
+    },
+    "openai/gpt-5.1-codex": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125
+    },
+    "openai/gpt-5.1-codex-max": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125
+    },
+    "openai/gpt-5.1-codex-mini": {
+      "input": 0.25,
+      "output": 2,
+      "cache_read": 0.025
+    },
+    "openai/gpt-5.2-codex": {
+      "input": 1.75,
+      "output": 14,
+      "cache_read": 0.175
+    },
+    "openai/gpt-5.4-codex": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25
+    },
+    "openai/gpt-5.5-codex": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25
+    },
+    "openai/gpt-5.5-fast": {
+      "input": 12.5,
+      "output": 75,
+      "cache_read": 1.25
+    },
+    "openai/gpt-5.5-flex": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25
+    },
+    "openai/gpt-5.6-cyber": {
+      "input": 12.5,
+      "output": 75,
+      "cache_read": 1.25
+    },
+    "openai/gpt-5.6-luna-batch": {
+      "input": 0.1,
+      "output": 0.6,
+      "cache_read": 0.01
+    },
+    "openai/gpt-5.6-luna-fast": {
+      "input": 0.4,
+      "output": 2.4,
+      "cache_read": 0.04
+    },
+    "openai/gpt-5.6-luna-flex": {
+      "input": 0.1,
+      "output": 0.6,
+      "cache_read": 0.01
+    },
+    "openai/gpt-5.6-sol-batch": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25
+    },
+    "openai/gpt-5.6-sol-fast": {
+      "input": 10,
+      "output": 60,
+      "cache_read": 1
+    },
+    "zhipuai/glm-4.5-airx": {
+      "input": 1.1,
+      "output": 4.5
+    },
+    "zhipuai/glm-4.5-x": {
+      "input": 2.2,
+      "output": 8.9
+    },
+    "zhipuai/glm-5-code": {
+      "input": 1.2,
+      "output": 5,
+      "cache_read": 0.3
+    },
+    "openai/gpt-5.6-sol-flex": {
+      "input": 2.5,
+      "output": 15,
+      "cache_read": 0.25
+    },
+    "openai/gpt-5.6-terra-batch": {
+      "input": 1,
+      "output": 6,
+      "cache_read": 0.1
+    },
+    "openai/gpt-5.6-terra-fast": {
+      "input": 4,
+      "output": 24,
+      "cache_read": 0.4
+    },
+    "openai/gpt-5.6-terra-flex": {
+      "input": 1,
+      "output": 6,
+      "cache_read": 0.1
+    },
+    "openai/o1-mini": {
+      "input": 1.1,
+      "output": 4.4,
+      "cache_read": 0.55
+    },
+    "openai/o1-preview": {
+      "input": 15,
+      "output": 60,
+      "cache_read": 7.5
     },
     "mistral/mistral-nemo": {
       "input": 0.15,
@@ -1455,11 +1936,98 @@
       "output": 22,
       "cache_read": 1.2,
       "cache_write": 0
+    },
+    "meta/muse-spark-1.1": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "cursor/auto": {
+      "input": 1.25,
+      "output": 6,
+      "cache_read": 0.25
+    },
+    "cursor/composer-1": {
+      "input": 1.25,
+      "output": 10,
+      "cache_read": 0.125
+    },
+    "cursor/composer-1.5": {
+      "input": 3.5,
+      "output": 17.5,
+      "cache_read": 0.35
+    },
+    "cursor/composer-2": {
+      "input": 0.5,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "cursor/composer-2.5": {
+      "input": 0.5,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "tencent/hy3": {
+      "input": 0.15,
+      "output": 0.59,
+      "cache_read": 0.0375
+    },
+    "tencent/hy3-preview": {
+      "input": 0.18,
+      "output": 0.59,
+      "cache_read": 0.06
+    },
+    "stepfun/step-3.5-flash": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.02
+    },
+    "stepfun/step-3.7-flash": {
+      "input": 0.2,
+      "output": 1.15,
+      "cache_read": 0.04
+    },
+    "inclusionai/ling-2.6-1t": {
+      "input": 0.625,
+      "output": 2.5
+    },
+    "inclusionai/ling-2.6-flash": {
+      "input": 0.083,
+      "output": 0.25
+    },
+    "inclusionai/ling-3.0-flash": {
+      "input": 0.069,
+      "output": 0.208
+    },
+    "inclusionai/ring-2.6-1t": {
+      "input": 0.625,
+      "output": 2.5
+    },
+    "meituan/longcat-2.0": {
+      "input": 0.694,
+      "output": 2.778,
+      "cache_read": 0.014
+    },
+    "sapiens/agnes-2.0-flash": {
+      "input": 0.03,
+      "output": 0.15
+    },
+    "sapiens/agnes-2.5-flash": {
+      "input": 0.03,
+      "output": 0.15
+    },
+    "sapiens/agnes-2.5-pro": {
+      "input": 0.45,
+      "output": 0.9,
+      "cache_read": 0.0038
+    },
+    "sapiens/agnes-2.5-pro-alpha": {
+      "input": 0.45,
+      "output": 0.9,
+      "cache_read": 0.0038
     }
   },
   "alias": {
-    "auto": "minimax/MiniMax-M2.7",
-    "composer": "minimax/MiniMax-M2.7",
     "claude-sonnet-4.5": "anthropic/claude-sonnet-4-5",
     "ox-alpha": "zhipuai/glm-5.3-flash",
     "ox-alpha-free": "zhipuai/glm-5.3-flash",
@@ -1478,10 +2046,6 @@
     },
     "codex": {
       "auto": "openai/gpt-5.3-codex"
-    },
-    "cursor": {
-      "auto": "minimax/MiniMax-M2.7",
-      "composer": "minimax/MiniMax-M2.7"
     },
     "gemini": {
       "auto": "google/gemini-2.5-pro",
@@ -1504,7 +2068,7 @@
     },
     {
       "match": "claude-opus-4-1",
-      "ref": "anthropic/claude-opus-4-6"
+      "ref": "anthropic/claude-opus-4-1"
     },
     {
       "match": "claude-sonnet-4-5",
@@ -1527,6 +2091,46 @@
       "ref": "anthropic/claude-haiku-4-5-20251001"
     },
     {
+      "match": "claude-3-haiku",
+      "ref": "anthropic/claude-3-haiku"
+    },
+    {
+      "match": "claude-3-opus",
+      "ref": "anthropic/claude-3-opus"
+    },
+    {
+      "match": "claude-3.5-haiku",
+      "ref": "anthropic/claude-3.5-haiku"
+    },
+    {
+      "match": "claude-3.5-sonnet",
+      "ref": "anthropic/claude-3.5-sonnet"
+    },
+    {
+      "match": "claude-3.7-sonnet",
+      "ref": "anthropic/claude-3.7-sonnet"
+    },
+    {
+      "match": "claude-mythos-5",
+      "ref": "anthropic/claude-mythos-5"
+    },
+    {
+      "match": "claude-opus-4",
+      "ref": "anthropic/claude-opus-4"
+    },
+    {
+      "match": "claude-opus-4-8-fast",
+      "ref": "anthropic/claude-opus-4-8-fast"
+    },
+    {
+      "match": "claude-opus-5-fast",
+      "ref": "anthropic/claude-opus-5-fast"
+    },
+    {
+      "match": "claude-sonnet-4",
+      "ref": "anthropic/claude-sonnet-4"
+    },
+    {
       "match": "claude",
       "ref": "anthropic/claude-sonnet-4-5"
     },
@@ -1536,7 +2140,83 @@
     },
     {
       "match": "gpt-5-codex",
-      "ref": "openai/gpt-5.3-codex"
+      "ref": "openai/gpt-5-codex"
+    },
+    {
+      "match": "codex-mini-latest",
+      "ref": "openai/codex-mini-latest"
+    },
+    {
+      "match": "gpt-5.1-codex",
+      "ref": "openai/gpt-5.1-codex"
+    },
+    {
+      "match": "gpt-5.1-codex-max",
+      "ref": "openai/gpt-5.1-codex-max"
+    },
+    {
+      "match": "gpt-5.1-codex-mini",
+      "ref": "openai/gpt-5.1-codex-mini"
+    },
+    {
+      "match": "gpt-5.2-codex",
+      "ref": "openai/gpt-5.2-codex"
+    },
+    {
+      "match": "gpt-5.4-codex",
+      "ref": "openai/gpt-5.4-codex"
+    },
+    {
+      "match": "gpt-5.5-codex",
+      "ref": "openai/gpt-5.5-codex"
+    },
+    {
+      "match": "gpt-5.5-fast",
+      "ref": "openai/gpt-5.5-fast"
+    },
+    {
+      "match": "gpt-5.5-flex",
+      "ref": "openai/gpt-5.5-flex"
+    },
+    {
+      "match": "gpt-5.6-cyber",
+      "ref": "openai/gpt-5.6-cyber"
+    },
+    {
+      "match": "gpt-5.6-luna-batch",
+      "ref": "openai/gpt-5.6-luna-batch"
+    },
+    {
+      "match": "gpt-5.6-luna-fast",
+      "ref": "openai/gpt-5.6-luna-fast"
+    },
+    {
+      "match": "gpt-5.6-luna-flex",
+      "ref": "openai/gpt-5.6-luna-flex"
+    },
+    {
+      "match": "gpt-5.6-sol-batch",
+      "ref": "openai/gpt-5.6-sol-batch"
+    },
+    {
+      "match": "gpt-5.6-sol-fast",
+      "ref": "openai/gpt-5.6-sol-fast"
+    },
+    {
+      "match": "gpt-5.6-sol-flex",
+      "ref": "openai/gpt-5.6-sol-flex"
+    },
+    {
+      "match": "gpt-5.6-terra-batch",
+      "ref": "openai/gpt-5.6-terra-batch"
+    },
+    {
+      "match": "gpt-5.6-terra-fast",
+      "ref": "openai/gpt-5.6-terra-fast"
+    },
+    {
+      "match": "gpt-5.6-terra-flex",
+      "ref": "openai/gpt-5.6-terra-flex"
     },
     {
       "match": "codex",
@@ -1552,7 +2232,7 @@
     },
     {
       "match": "gpt-5",
-      "ref": "openai/gpt-5.4"
+      "ref": "openai/gpt-5"
     },
     {
       "match": "gpt-4o",
@@ -1561,6 +2241,14 @@
     {
       "match": "o1-pro",
       "ref": "openai/o1-pro"
+    },
+    {
+      "match": "o1-mini",
+      "ref": "openai/o1-mini"
+    },
+    {
+      "match": "o1-preview",
+      "ref": "openai/o1-preview"
     },
     {
       "match": "o1",
@@ -1604,7 +2292,55 @@
     },
     {
       "match": "gemini-2.5-flash",
-      "ref": "google/gemini-2.5-flash-lite"
+      "ref": "google/gemini-2.5-flash"
+    },
+    {
+      "match": "gemini-1.5-flash",
+      "ref": "google/gemini-1.5-flash"
+    },
+    {
+      "match": "gemini-1.5-pro",
+      "ref": "google/gemini-1.5-pro"
+    },
+    {
+      "match": "gemini-2.0-flash",
+      "ref": "google/gemini-2.0-flash"
+    },
+    {
+      "match": "gemini-2.0-flash-lite",
+      "ref": "google/gemini-2.0-flash-lite"
+    },
+    {
+      "match": "gemini-3-flash",
+      "ref": "google/gemini-3-flash"
+    },
+    {
+      "match": "gemini-3.5-flash-lite",
+      "ref": "google/gemini-3.5-flash-lite"
+    },
+    {
+      "match": "gemini-3.5-flash-preview",
+      "ref": "google/gemini-3.5-flash-preview"
+    },
+    {
+      "match": "gemini-3.6-flash",
+      "ref": "google/gemini-3.6-flash"
+    },
+    {
+      "match": "gemini-3.7-flash",
+      "ref": "google/gemini-3.7-flash"
+    },
+    {
+      "match": "gemini-3.7-flash-batch",
+      "ref": "google/gemini-3.7-flash-batch"
+    },
+    {
+      "match": "gemini-3.7-flash-fast",
+      "ref": "google/gemini-3.7-flash-fast"
+    },
+    {
+      "match": "gemini-3.7-flash-flex",
+      "ref": "google/gemini-3.7-flash-flex"
     },
     {
       "match": "gemini",
@@ -1620,7 +2356,43 @@
     },
     {
       "match": "grok-4",
-      "ref": "xai/grok-4.5"
+      "ref": "xai/grok-4"
+    },
+    {
+      "match": "grok-3-beta",
+      "ref": "xai/grok-3-beta"
+    },
+    {
+      "match": "grok-4-0709",
+      "ref": "xai/grok-4-0709"
+    },
+    {
+      "match": "grok-4-fast-non-reasoning",
+      "ref": "xai/grok-4-fast-non-reasoning"
+    },
+    {
+      "match": "grok-4-fast-reasoning",
+      "ref": "xai/grok-4-fast-reasoning"
+    },
+    {
+      "match": "grok-4.20",
+      "ref": "xai/grok-4.20"
+    },
+    {
+      "match": "grok-4.20-multi-agent",
+      "ref": "xai/grok-4.20-multi-agent"
+    },
+    {
+      "match": "grok-4.20-non-reasoning",
+      "ref": "xai/grok-4.20-non-reasoning"
+    },
+    {
+      "match": "grok-4.20-reasoning",
+      "ref": "xai/grok-4.20-reasoning"
+    },
+    {
+      "match": "grok-code-fast-1",
+      "ref": "xai/grok-code-fast-1"
     },
     {
       "match": "grok",
@@ -1628,11 +2400,31 @@
     },
     {
       "match": "deepseek-r1",
-      "ref": "deepseek/deepseek-reasoner"
+      "ref": "deepseek/deepseek-r1"
     },
     {
       "match": "deepseek-v3",
-      "ref": "deepseek/deepseek-chat"
+      "ref": "deepseek/deepseek-v3"
+    },
+    {
+      "match": "deepseek-coder",
+      "ref": "deepseek/deepseek-coder"
+    },
+    {
+      "match": "deepseek-v3.1",
+      "ref": "deepseek/deepseek-v3.1"
+    },
+    {
+      "match": "deepseek-v3.2",
+      "ref": "deepseek/deepseek-v3.2"
+    },
+    {
+      "match": "deepseek-v4-flash",
+      "ref": "deepseek/deepseek-v4-flash"
+    },
+    {
+      "match": "deepseek-v4-pro",
+      "ref": "deepseek/deepseek-v4-pro"
     },
     {
       "match": "deepseek",
@@ -1667,6 +2459,30 @@
       "ref": "alibaba-cn/qwen3-235b-a22b"
     },
     {
+      "match": "qwen-coder",
+      "ref": "alibaba/qwen-coder"
+    },
+    {
+      "match": "qwen3-coder-next",
+      "ref": "alibaba/qwen3-coder-next"
+    },
+    {
+      "match": "qwen3.7-flash",
+      "ref": "alibaba/qwen3.7-flash"
+    },
+    {
+      "match": "qwen3.8-2.4t-a95b",
+      "ref": "alibaba/qwen3.8-2.4t-a95b"
+    },
+    {
+      "match": "qwen3.8-27b",
+      "ref": "alibaba/qwen3.8-27b"
+    },
+    {
+      "match": "qwen3.8-flash",
+      "ref": "alibaba/qwen3.8-flash"
+    },
+    {
       "match": "qwen3",
       "ref": "alibaba-cn/qwen3-max"
     },
@@ -1695,6 +2511,18 @@
       "ref": "zai/glm-5-turbo"
     },
     {
+      "match": "glm-4.5-airx",
+      "ref": "zhipuai/glm-4.5-airx"
+    },
+    {
+      "match": "glm-4.5-x",
+      "ref": "zhipuai/glm-4.5-x"
+    },
+    {
+      "match": "glm-5-code",
+      "ref": "zhipuai/glm-5-code"
+    },
+    {
       "match": "glm",
       "ref": "zai/glm-4.6"
     },
@@ -1717,6 +2545,38 @@
     {
       "match": "kimi-k2",
       "ref": "moonshotai/kimi-k2-0905-preview"
+    },
+    {
+      "match": "k2p6",
+      "ref": "moonshotai/k2p6"
+    },
+    {
+      "match": "kimi-for-coding",
+      "ref": "moonshotai/kimi-for-coding"
+    },
+    {
+      "match": "kimi-for-coding-highspeed",
+      "ref": "moonshotai/kimi-for-coding-highspeed"
+    },
+    {
+      "match": "kimi-k2.7-code",
+      "ref": "moonshotai/kimi-k2.7-code"
+    },
+    {
+      "match": "kimi-k3",
+      "ref": "moonshotai/kimi-k3"
+    },
+    {
+      "match": "moonshot-v1-8k",
+      "ref": "moonshotai/moonshot-v1-8k"
+    },
+    {
+      "match": "moonshot-v1-32k",
+      "ref": "moonshotai/moonshot-v1-32k"
+    },
+    {
+      "match": "moonshot-v1-128k",
+      "ref": "moonshotai/moonshot-v1-128k"
     },
     {
       "match": "kimi",
@@ -1775,12 +2635,32 @@
       "ref": "mistral/mistral-large-2512"
     },
     {
+      "match": "mistral-medium-3-5",
+      "ref": "mistral/mistral-medium-3-5"
+    },
+    {
+      "match": "ministral-3b-2512",
+      "ref": "mistral/ministral-3b-2512"
+    },
+    {
+      "match": "ministral-8b-2512",
+      "ref": "mistral/ministral-8b-2512"
+    },
+    {
+      "match": "ministral-14b-2512",
+      "ref": "mistral/ministral-14b-2512"
+    },
+    {
       "match": "mistral-large",
       "ref": "mistral/mistral-large-latest"
     },
     {
       "match": "codestral-latest",
       "ref": "mistral/codestral-latest"
+    },
+    {
+      "match": "codestral-2508",
+      "ref": "mistral/codestral-2508"
     },
     {
       "match": "codestral",
@@ -1797,6 +2677,102 @@
     {
       "match": "devstral",
       "ref": "mistral/devstral-latest"
+    },
+    {
+      "match": "hy3",
+      "ref": "tencent/hy3"
+    },
+    {
+      "match": "hy3-preview",
+      "ref": "tencent/hy3-preview"
+    },
+    {
+      "match": "doubao-seed-evolving",
+      "ref": "volcengine/doubao-seed-evolving"
+    },
+    {
+      "match": "doubao-seed-2.0-code",
+      "ref": "volcengine/doubao-seed-2.0-code"
+    },
+    {
+      "match": "doubao-seed-2.0-lite",
+      "ref": "volcengine/doubao-seed-2.0-lite"
+    },
+    {
+      "match": "doubao-seed-2.0-mini",
+      "ref": "volcengine/doubao-seed-2.0-mini"
+    },
+    {
+      "match": "doubao-seed-2.0-pro",
+      "ref": "volcengine/doubao-seed-2.0-pro"
+    },
+    {
+      "match": "doubao-seed-2.1-pro",
+      "ref": "volcengine/doubao-seed-2.1-pro"
+    },
+    {
+      "match": "doubao-seed-2.1-turbo",
+      "ref": "volcengine/doubao-seed-2.1-turbo"
+    },
+    {
+      "match": "doubao-seed-code",
+      "ref": "volcengine/doubao-seed-code"
+    },
+    {
+      "match": "doubao-lite-128k",
+      "ref": "volcengine/doubao-lite-128k"
+    },
+    {
+      "match": "doubao-pro-128k",
+      "ref": "volcengine/doubao-pro-128k"
+    },
+    {
+      "match": "step-3.5-flash",
+      "ref": "stepfun/step-3.5-flash"
+    },
+    {
+      "match": "step-3.7-flash",
+      "ref": "stepfun/step-3.7-flash"
+    },
+    {
+      "match": "ling-2.6-1t",
+      "ref": "inclusionai/ling-2.6-1t"
+    },
+    {
+      "match": "ling-2.6-flash",
+      "ref": "inclusionai/ling-2.6-flash"
+    },
+    {
+      "match": "ling-3.0-flash",
+      "ref": "inclusionai/ling-3.0-flash"
+    },
+    {
+      "match": "ring-2.6-1t",
+      "ref": "inclusionai/ring-2.6-1t"
+    },
+    {
+      "match": "longcat-2.0",
+      "ref": "meituan/longcat-2.0"
+    },
+    {
+      "match": "agnes-2.0-flash",
+      "ref": "sapiens/agnes-2.0-flash"
+    },
+    {
+      "match": "agnes-2.5-flash",
+      "ref": "sapiens/agnes-2.5-flash"
+    },
+    {
+      "match": "agnes-2.5-pro",
+      "ref": "sapiens/agnes-2.5-pro"
+    },
+    {
+      "match": "agnes-2.5-pro-alpha",
+      "ref": "sapiens/agnes-2.5-pro-alpha"
+    },
+    {
+      "match": "muse-spark-1.1",
+      "ref": "meta/muse-spark-1.1"
     }
   ],
   "default": {

--- a/packages/core/test/pricing.test.ts
+++ b/packages/core/test/pricing.test.ts
@@ -46,18 +46,23 @@ test('getModelPricing resolves claude-opus-4-6 from pricing table', () => {
   assert.ok(p.output > 0);
 });
 
-test('cursor auto resolves via sourceAlias', () => {
+test('cursor auto uses the Cursor-specific price instead of a global alias', () => {
   const p = getModelPricing('auto', { source: 'cursor' });
-  assert.equal(p.input, 0.3);
-  assert.equal(p.output, 1.2);
-  assert.equal(p.cache_read, 0.06);
+  assert.equal(p.input, 1.25);
+  assert.equal(p.output, 6);
+  assert.equal(p.cache_read, 0.25);
 });
 
-test('cursor composer alias uses MiniMax rates', () => {
+test('cursor composer without a concrete version does not resolve to MiniMax', () => {
   const p = getModelPricing('composer', { source: 'cursor' });
-  assert.equal(p.input, 0.3);
-  assert.equal(p.output, 1.2);
-  assert.equal(p.cache_read, 0.06);
+  assert.notEqual(p.input, 0.3);
+  assert.notEqual(p.output, 1.2);
+});
+
+test('auto does not globally resolve to MiniMax', () => {
+  const p = getModelPricing('auto');
+  assert.notEqual(p.input, 0.3);
+  assert.notEqual(p.output, 1.2);
 });
 
 test('codex row folds reasoning into output cost only', () => {
@@ -98,7 +103,7 @@ test('cursor row without reported_cost falls back to pricing table', () => {
     total_tokens: 1_000_000,
   });
   const cost = computeRowCost(row);
-  assert.ok(Math.abs(cost - 0.3) < 0.001);
+  assert.ok(Math.abs(cost - 1.25) < 0.001);
 });
 
 test('unknown model uses builtin default rates', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

请确保填写以下 pull request 的信息，谢谢！
-->

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 暂无关联 Issue。

### 💡 需求背景和解决方案

> **问题背景**
>
> `packages/core/src/pricing/pricing.json` 中将通用模型名 `auto`、`composer` 映射到了 `minimax/MiniMax-M2.7`。Cursor 导出的模型名可能只是动态占位名称，无法据此确认实际使用的模型，因此会导致 Cursor 用量被错误计价为 MiniMax。
>
> **解决方案**
>
> - 移除全局 `alias.auto` 和 `alias.composer` 到 MiniMax 的映射。
> - 移除 Cursor 作用域下对未带具体版本的 `auto`、`composer` 的不确定映射。
> - 保留已有的 `cursor/auto`、`cursor/composer-*` 具体定价，优先使用 Cursor 自身的模型价格。
> - 增加回归测试，确保 `auto` 和未版本化的 `composer` 不再错误解析为 MiniMax。

### 📝 更新日志

> - 不再将 Cursor 的动态模型名 `auto`、`composer` 错误计价为 MiniMax。
> - Cursor 的 `auto` 使用已有 Cursor 专属定价；具体版本的 `composer-*` 定价保持不变。

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix incorrect Cursor `auto` / `composer` pricing caused by unverified MiniMax aliases. |
| 🇨🇳 中文 | 修复 Cursor 的 `auto` / `composer` 因不确定的 MiniMax 别名导致的错误计价。 |

### ✅ 验证

- `pnpm test:compile && node --test dist-test/test/pricing.test.js`：21/21 通过
- `pnpm build`：通过
- `pricing.json` JSON 校验：通过
- `git diff --check`：通过

> 说明：完整 Core 测试仍存在仓库中与本次改动无关的既有 `pricing-coverage` / `pricing-sanity` 失败。
