### PR TITLE
fix(web): deduplicate leaderboard model options

### DIFF
--- a/packages/dashboard/src/lib/leaderboard.test.ts
+++ b/packages/dashboard/src/lib/leaderboard.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { uniqueRankModelOptions } from './leaderboard.ts';
+
+describe('uniqueRankModelOptions', () => {
+  const options = [
+    { tool: 'cursor', model: 'claude-sonnet-4-6' },
+    { tool: 'cursor', model: 'gpt-5' },
+    { tool: 'claude-code', model: 'claude-sonnet-4-6' },
+    { tool: 'claude-code', model: 'claude-opus-4' },
+  ];
+
+  it('deduplicates models when all tools are selected', () => {
+    assert.deepEqual(uniqueRankModelOptions(options), [
+      { tool: 'cursor', model: 'claude-sonnet-4-6' },
+      { tool: 'cursor', model: 'gpt-5' },
+      { tool: 'claude-code', model: 'claude-opus-4' },
+    ]);
+  });
+
+  it('filters by tool before deduplicating', () => {
+    assert.deepEqual(uniqueRankModelOptions(options, 'claude-code'), [
+      { tool: 'claude-code', model: 'claude-sonnet-4-6' },
+      { tool: 'claude-code', model: 'claude-opus-4' },
+    ]);
+  });
+
+  it('ignores empty model ids', () => {
+    assert.deepEqual(
+      uniqueRankModelOptions([
+        { tool: 'cursor', model: '' },
+        { tool: 'cursor', model: 'gpt-5' },
+      ]),
+      [{ tool: 'cursor', model: 'gpt-5' }],
+    );
+  });
+});

--- a/packages/dashboard/src/lib/leaderboard.ts
+++ b/packages/dashboard/src/lib/leaderboard.ts
@@ -2,6 +2,36 @@ import type { LeaderboardMetric, LeaderboardRange } from '@/lib/api';
 
 export type RankRange = LeaderboardRange;
 
+export interface RankModelOption {
+  tool: string;
+  model: string;
+}
+
+/**
+ * Return the model options that can be rendered by a single Select collection.
+ *
+ * The API stores tool/model pairs, so a model used by more than one tool can
+ * occur more than once when no tool is selected. HeroUI's ListBox is keyed by
+ * the option id (the model name in RankFilter), and duplicate ids corrupt
+ * React Aria's collection when the options change asynchronously.
+ */
+export function uniqueRankModelOptions(
+  options: readonly RankModelOption[],
+  tool = '',
+): RankModelOption[] {
+  const seen = new Set<string>();
+  const result: RankModelOption[] = [];
+
+  for (const option of options) {
+    if (tool && option.tool !== tool) continue;
+    if (!option.model || seen.has(option.model)) continue;
+    seen.add(option.model);
+    result.push(option);
+  }
+
+  return result;
+}
+
 export function formatRankPosition(rank: number | null | undefined): string {
   if (rank === null || rank === undefined || !Number.isFinite(rank) || rank < 1) {
     return '—';

--- a/packages/dashboard/src/pages/RankPage.tsx
+++ b/packages/dashboard/src/pages/RankPage.tsx
@@ -12,7 +12,7 @@ import {
   type LeaderboardMetric,
 } from '@/lib/api';
 import { isMockDataEnabled } from '@/lib/env';
-import type { RankRange } from '@/lib/leaderboard';
+import { uniqueRankModelOptions, type RankRange } from '@/lib/leaderboard';
 import {
   DATA_SYNCED_EVENT,
   dispatchOpenSettings,
@@ -78,7 +78,7 @@ export function RankPage() {
 
   const filterOptions = data?.filterOptions;
   const modelOptions = useMemo(
-    () => (filterOptions?.models ?? []).filter((item) => !tool || item.tool === tool),
+    () => uniqueRankModelOptions(filterOptions?.models ?? [], tool),
     [filterOptions?.models, tool],
   );
 


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 线上问题：排行榜在切换到“全部”时间范围、选择模型后，再切回“全部模型”时出现 `RangeError: Invalid array length`。

### 💡 需求背景和解决方案

> 1. 当选择“全部工具”时，接口返回的模型列表可能包含来自不同工具的同名模型。
> 2. 模型筛选器使用模型名作为 `ListBox.Item` 的 `id` 和 `key`，重复模型名会生成重复的 collection key，导致 React Aria 集合在筛选切换时异常。
> 3. 新增模型选项去重逻辑：指定工具时先过滤工具，再按模型名去重，同时忽略空模型名。
> 4. 增加模型选项去重、工具过滤和空模型名的回归测试。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix the leaderboard model filter crash when switching back to all models. |
| 🇨🇳 中文 | 修复排行榜切换模型筛选后返回全部模型时页面异常的问题。 |
