### PR TITLE
feat(web): add GitHub repository link to filter chrome actions

### DIFF
--- a/apps/desktop/src/renderer/components/FilterChromeActions.tsx
+++ b/apps/desktop/src/renderer/components/FilterChromeActions.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { ArrowsRotateRight, Gear, NodesRight } from '@gravity-ui/icons';
+import {
+  ArrowsRotateRight,
+  Gear,
+  LogoGithub,
+  NodesRight,
+} from '@gravity-ui/icons';
 import { Button, Tooltip } from '@heroui/react';
 import { JuejinLoginConsentModal } from '@/components/JuejinLoginConsentModal';
 import { ThemeToggle } from '@/components/ThemeToggle';
@@ -17,9 +22,14 @@ import { cn } from '@/lib/utils';
 const linkJuejinBtn =
   'inline-flex h-7 shrink-0 items-center gap-1 rounded-full bg-[#1e80ff] px-2.5 text-[12px] font-medium text-white outline-none transition-colors hover:bg-[#1171ee] focus-visible:ring-2 focus-visible:ring-[#1e80ff]/40 disabled:pointer-events-none disabled:opacity-40 dark:bg-[#4b9cff] dark:hover:bg-[#3a8ff0]';
 const RANK_PAGE_URL = 'https://juejin.cn/aiusage/rank';
+const GITHUB_REPO_URL = 'https://github.com/juejin-cn/juejin-usage';
 
 function openRankPage(): void {
   void window.tud.openExternal(RANK_PAGE_URL);
+}
+
+function openGithubRepository(): void {
+  void window.tud.openExternal(GITHUB_REPO_URL);
 }
 
 function JuejinMark({ className }: { className?: string }) {
@@ -126,6 +136,11 @@ export function FilterChromeActions() {
       >
         排行榜
       </Button>
+      <ChromeAction
+        icon={<LogoGithub className="size-4" />}
+        label="GitHub 仓库"
+        onPress={openGithubRepository}
+      />
       <ChromeAction
         icon={<NodesRight className="size-4" />}
         label="分享"

--- a/packages/dashboard/src/components/FilterChromeActions.tsx
+++ b/packages/dashboard/src/components/FilterChromeActions.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDownToLine,
   ArrowsRotateRight,
   Gear,
+  LogoGithub,
   NodesRight,
 } from '@gravity-ui/icons';
 import { Button, Tooltip } from '@heroui/react';
@@ -11,6 +12,7 @@ import { JuejinLoginConsentModal } from '@/components/JuejinLoginConsentModal';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { useInstallGuideUi } from '@/hooks/InstallGuideUiContext';
 import { fetchConfig, isCliBackend, triggerSync } from '@/lib/api';
+import { GITHUB_REPO_URL } from '@/lib/downloads';
 import { openJuejinLogin } from '@/lib/juejin-client-link';
 import {
   DATA_SYNCED_EVENT,
@@ -33,6 +35,15 @@ function openRankPage(): void {
     return;
   }
   window.location.assign(RANK_PAGE_URL);
+}
+
+function openGithubRepository(): void {
+  const opened = window.open(GITHUB_REPO_URL, '_blank');
+  if (opened) {
+    opened.opener = null;
+    return;
+  }
+  window.location.assign(GITHUB_REPO_URL);
 }
 
 function JuejinMark({ className }: { className?: string }) {
@@ -167,6 +178,11 @@ export function FilterChromeActions() {
           </button>
         )
       ) : null}
+      <ChromeAction
+        icon={<LogoGithub className="size-4" />}
+        label="GitHub 仓库"
+        onPress={openGithubRepository}
+      />
       {cliBackend ? (
         <Button
           className="h-8 min-h-8 shrink-0 px-2.5 text-xs font-normal"

--- a/packages/dashboard/src/components/RankFilter.tsx
+++ b/packages/dashboard/src/components/RankFilter.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { LogoGithub } from '@gravity-ui/icons';
 import { Button, Label, ListBox, Select, Tabs, Tooltip } from '@heroui/react';
 import { Share2 } from 'lucide-react';
 import { ProviderIcon } from '@/components/ProviderIcon';
 import { RankShareModal } from '@/components/RankShareModal';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { GITHUB_REPO_URL } from '@/lib/downloads';
 import type {
   LeaderboardBoard,
   LeaderboardMetric,
@@ -19,6 +21,15 @@ const RANGE_OPTIONS: readonly { id: RankRange; label: string }[] = [
 ];
 
 const FILTER_CONTROL_HEIGHT = '!h-8 !min-h-8';
+
+function openGithubRepository(): void {
+  const opened = window.open(GITHUB_REPO_URL, '_blank');
+  if (opened) {
+    opened.opener = null;
+    return;
+  }
+  window.location.assign(GITHUB_REPO_URL);
+}
 
 export function RankFilter({
   loading,
@@ -99,6 +110,21 @@ export function RankFilter({
         onChange={onModelChange}
       />
       <div className="ml-auto flex shrink-0 items-center gap-1">
+        <Tooltip closeDelay={80} delay={100}>
+          <Button
+            aria-label="GitHub 仓库"
+            className="size-8 min-h-8 min-w-8 shrink-0 p-0"
+            isIconOnly
+            onPress={openGithubRepository}
+            size="sm"
+            variant="tertiary"
+          >
+            <LogoGithub className="size-4" />
+          </Button>
+          <Tooltip.Content placement="bottom">
+            <p>GitHub 仓库</p>
+          </Tooltip.Content>
+        </Tooltip>
         <Tooltip closeDelay={80} delay={100}>
           <Button
             aria-label="分享排行榜"


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 无。

### 💡 需求背景和解决方案

> 1. 仪表盘、桌面端和排行榜都缺少一键跳转到 GitHub 仓库的入口,提 issue、看 changelog、加 star 都不够方便。
> 2. `packages/dashboard/src/components/FilterChromeActions.tsx` 新增 `ChromeAction` 按钮( `LogoGithub` 图标、"GitHub 仓库" 文案),通过 `@/lib/downloads` 中的 `GITHUB_REPO_URL` 在新标签页打开,并隔离 `opener`。
> 3. `packages/dashboard/src/components/RankFilter.tsx` 在分享按钮左侧追加同一入口,行为与主筛选条一致。
> 4. `apps/desktop/src/renderer/components/FilterChromeActions.tsx` 同步加上同一入口,改用 `window.tud.openExternal` 走系统默认浏览器,符合 Electron 安全实践。
> 5. Desktop renderer 仅复用现有 chrome actions 排版,不影响 IPC、主进程和数据同步。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Add a GitHub repository quick link to the dashboard, leaderboard, and desktop filter chrome actions. |
| 🇨🇳 中文 | 仪表盘、排行榜与桌面端顶栏新增 GitHub 仓库快捷入口。 |