### PR TITLE
fix(web): dedupe leaderboard model filter options by model name

### DIFF
--- a/packages/dashboard/src/components/RankFilter.tsx
+++ b/packages/dashboard/src/components/RankFilter.tsx
@@ -93,7 +93,10 @@ export function RankFilter({
       <ToolSelect tools={tools} value={tool} onChange={onToolChange} />
       <RankSelect
         ariaLabel="模型筛选"
-        options={modelOptions.map((item) => ({ id: item.model, label: item.model }))}
+        options={[...new Set(modelOptions.map((item) => item.model))].map((model) => ({
+          id: model,
+          label: model,
+        }))}
         placeholder="全部模型"
         value={model}
         onChange={onModelChange}


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 无关联 Issue。
>
> **与 #8 重叠**：#8（`fix(web): deduplicate leaderboard model options`）修复的是同一根因，且实现更完整（抽出可测试的纯函数、额外过滤空模型名、附带单元测试）。本 PR 在提交前才发现 #8 已存在，保留提交主要为补充**线上影响的实测数据**，供判断合并优先级。**若 #8 先合入，本 PR 应直接关闭。**

### 💡 需求背景和解决方案

> **现象**
>
> 排行榜（`/rank`）的「模型」筛选下拉中大量模型缺失。选择「全部工具」时最严重，几乎选不到有意义的模型。
>
> **根因**
>
> 1. 接口返回的 `filterOptions.models` 是 `{ tool, model }` 对，同一模型被多个工具使用时会出现多次。选择「全部工具」时 `RankPage.tsx` 的过滤条件短路（`!tool || ...`），所有跨工具重复项都会进入下游。
> 2. `RankFilter.tsx` 直接用裸模型名作 `ListBox.Item` 的 `id` / `key`，于是产生重复 key。
> 3. React Aria 的 collection 按 key 建索引：重复 key 时存活的节点是**最后一次出现**的那个，而遍历沿该节点的 `nextKey` 前进。因此首次出现与末次出现之间的所有条目全部不可达；若末次出现恰好是数组最后一个元素，`nextKey` 为 `null`，整条链直接终止。
>
> **线上实测影响**（`https://juejin.cn/aiusage/` 全部工具 / 全部时间）
>
> | 指标 | 数量 |
> | --- | --- |
> | 接口返回的 `(tool, model)` 对 | 174 |
> | 唯一模型名 | 121 |
> | 出现重名的模型名 | 26 |
> | **下拉里实际可选** | **14** |
> | 静默丢失 | 107 |
>
> 更严重的是，可见的 14 个里有 8 个是占位名——`auto`、`custom_model`、`gmodel`、`kmodel_latest`、`lite`、`qmodel`、`qmodel_38max`、`unknown`，用户几乎无法按真实模型筛选。
>
> **解决方案**
>
> 生成选项前按模型名去重（`RankFilter.tsx`，1 行）。
>
> 这与上游契约一致：`useLeaderboardData` 的 `requestKey` 为 `` `${range}|${tool}|${model}` ``，`tool` 与 `model` 是独立查询参数且 `model` 取裸名，因此「一个模型名对应一个条目」才是正确粒度，去重不会丢失任何可表达的查询。
>
> **影响范围**
>
> 仅 `packages/dashboard`。Desktop renderer 无排行榜页面（`apps/desktop/src/renderer` 下无任何 rank 相关文件），**无需同步**。不改动任何查询语义：选中模型后发出的请求与修复前完全一致。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix the leaderboard model filter dropping most models when several tools report the same model name. |
| 🇨🇳 中文 | 修复排行榜模型筛选在多个工具上报同名模型时大量模型无法选择的问题。 |

### ✅ 验证

- `pnpm --filter @juejin-opensource/jusage-dashboard test`：44 tests / 8 suites / **44 pass / 0 fail**
- `pnpm --filter @juejin-opensource/jusage-dashboard build`（`tsc -b` + `vite build`）：通过
- **线上真实数据 before/after**（同一浏览器会话，`git stash` 前后各测一次）：下拉可见条目 **15 → 122**
- **mock 数据**（`VITE_ENABLE_MOCK_DATA=true`，fixture 为 12 对 / 9 个唯一名）：**2 → 10**

> 上述条目数含「全部模型」这一项，故为 `唯一模型数 + 1`。



---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
