### PR TITLE
fix(pricing): prefer exact prefix-strip over fuzzy + sync from models.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ jusage service start
 - [Token Tracker](https://github.com/xiufengsun/TokenTracker): 自动采集 30 款 AI 编码工具 的 token 用量，用一套漂亮的 Dashboard 看真实成本与趋势。
 - [vibe-usage](https://github.com/vibe-cafe/vibe-usage): Token 使用量统计工具（CLI）
 - [OpenUsage](https://github.com/robinebers/openusage): The Only AI Usage Tracker That's Truly Yours
+- [models.dev](https://models.dev): 模型 Token 计价数据源，内置计价表由此增量同步

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev:web": "VITE_API_TARGET=server VITE_API_BASE=https://api.juejin.cn/aiusage_api VITE_BASE=/aiusage/ VITE_ROUTER_BASE=/aiusage/ pnpm --filter @juejin-opensource/jusage-dashboard dev",
     "dev:web:proxy": "DEV_API_PROXY=https://api.juejin.cn/aiusage_api VITE_API_TARGET=server VITE_BASE=/aiusage/ VITE_ROUTER_BASE=/aiusage/ pnpm --filter @juejin-opensource/jusage-dashboard dev",
     "sync": "pnpm --filter @juejin-opensource/jusage sync",
+    "sync:pricing": "pnpm --filter @juejin-opensource/jusage-core sync:pricing",
     "dev:dashboard": "pnpm --filter @juejin-opensource/jusage-dashboard dev",
     "start:dashboard": "pnpm --filter @juejin-opensource/jusage-dashboard preview",
     "dev:desktop": "pnpm --filter \"@juejin-opensource/jusage-desktop^...\" build && pnpm --filter @juejin-opensource/jusage-desktop dev",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && cp src/pricing/pricing.json dist/pricing/pricing.json",
     "dev": "tsc -p tsconfig.json --watch",
+    "sync:pricing": "node scripts/sync-pricing.mjs",
     "test": "pnpm test:compile && node --test dist-test/test/*.test.js",
     "test:compile": "tsc -p tsconfig.test.json && cp src/pricing/pricing.json dist-test/src/pricing/pricing.json"
   },

--- a/packages/core/scripts/sync-pricing.mjs
+++ b/packages/core/scripts/sync-pricing.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Incremental pricing sync from models.dev.
+ *
+ * Merge strategy (highest priority first):
+ *   1. OVERRIDES  — manual corrections for known-bad models.dev prices.
+ *   2. models.dev — official-channel text models from the scoped providers.
+ *   3. current table — entries models.dev does not cover are kept as-is
+ *      (the ~118 hand-supplemented models like claude-mythos-5, gpt-5.5-fast,
+ *      deepseek-v3.2, cursor, tencent/hy3 …), so a re-sync never loses them.
+ *
+ * fuzzy / alias / sourceAlias / default are hand-curated parser-name → model
+ * mappings and are preserved verbatim.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PRICING_PATH = join(__dirname, '..', 'src', 'pricing', 'pricing.json');
+const MODELS_DEV_URL = 'https://models.dev/api.json';
+
+// Official-channel providers kept in the bundle. Everything else in models.dev
+// (third-party / community / AWS / regional relays) is excluded.
+const SCOPED_PROVIDERS = new Set([
+  'anthropic', 'openai', 'google', 'google-vertex', 'google-vertex-anthropic',
+  'xai', 'deepseek', 'alibaba', 'alibaba-cn', 'moonshotai', 'moonshotai-cn',
+  'minimax', 'minimax-cn', 'xiaomi', 'mistral', 'zai', 'zhipuai', 'volcengine',
+  'stepfun', 'meta',
+]);
+
+// Manual overrides for models.dev prices that are known to be wrong / stale.
+// key = `provider/model`, value = rates to pin. Empty for now.
+const OVERRIDES = {};
+
+// Only a model's own vendor's official channel is kept. Cloud-partnership
+// channels (google-vertex / google-vertex-anthropic) and cross-vendor hosting
+// (e.g. `alibaba-cn/glm-5`, `volcengine/deepseek-*`) are excluded.
+const OFFICIAL_PROVIDERS = {
+  claude: ['anthropic'],
+  gpt: ['openai'], o1: ['openai'], o3: ['openai'], o4: ['openai'], codex: ['openai'],
+  gemini: ['google'], deepResearch: ['google'],
+  grok: ['xai'],
+  deepseek: ['deepseek'],
+  qwen: ['alibaba', 'alibaba-cn'], qvq: ['alibaba', 'alibaba-cn'], qwq: ['alibaba', 'alibaba-cn'],
+  tongyi: ['alibaba', 'alibaba-cn'],
+  kimi: ['moonshotai', 'moonshotai-cn'], moonshot: ['moonshotai', 'moonshotai-cn'], k2p6: ['moonshotai', 'moonshotai-cn'],
+  minimax: ['minimax', 'minimax-cn'],
+  mimo: ['xiaomi'],
+  mistral: ['mistral'], codestral: ['mistral'], devstral: ['mistral'], ministral: ['mistral'],
+  magistral: ['mistral'], openMistral: ['mistral'], openMixtral: ['mistral'],
+  pixtral: ['mistral'], voxtral: ['mistral'],
+  glm: ['zai', 'zhipuai'],
+  doubao: ['volcengine'],
+  step: ['stepfun'],
+  muse: ['meta'], llama: ['meta'],
+  hy3: ['tencent'], ling: ['inclusionai'], ring: ['inclusionai'],
+  agnes: ['sapiens'], longcat: ['meituan'],
+};
+const FAMILY_PATTERNS = [
+  ['claude', /^claude-/], ['gpt', /^gpt-/], ['o1', /^o1(?:$|-)/], ['o3', /^o3(?:$|-)/], ['o4', /^o4-/],
+  ['codex', /^codex-/], ['gemini', /^gemini-/], ['deepResearch', /^deep-research/],
+  ['grok', /^grok-/], ['deepseek', /^deepseek-/],
+  ['qwen', /^qwen/], ['qvq', /^qvq-/], ['qwq', /^qwq-/], ['tongyi', /^tongyi-/],
+  ['kimi', /^kimi-/], ['moonshot', /^moonshot-/], ['k2p6', /^k2p6/],
+  ['minimax', /^minimax-/], ['mimo', /^mimo-/],
+  ['mistral', /^mistral-/], ['codestral', /^codestral-/], ['devstral', /^devstral-/],
+  ['ministral', /^ministral-/], ['magistral', /^magistral-/], ['openMistral', /^open-mistral-/],
+  ['openMixtral', /^open-mixtral-/], ['pixtral', /^pixtral-/], ['voxtral', /^voxtral-/],
+  ['glm', /^(?:zai-glm|glm)-/], ['doubao', /^doubao-/], ['step', /^step-/],
+  ['muse', /^muse-/], ['llama', /^llama-/],
+  ['hy3', /^hy3(?:$|-)/], ['ling', /^ling-/], ['ring', /^ring-/], ['agnes', /^agnes-/], ['longcat', /^longcat-/],
+];
+
+function isOfficialKey(key) {
+  const parts = key.split('/');
+  const provider = parts[0];
+  const model = parts[parts.length - 1].toLowerCase();
+  if (provider === 'cursor') return true; // Cursor's own bundled-model pricing
+  for (const [family, re] of FAMILY_PATTERNS) {
+    if (re.test(model)) {
+      return (OFFICIAL_PROVIDERS[family] ?? []).includes(provider);
+    }
+  }
+  return true; // unknown family: keep (permissive)
+}
+
+// Match the bundle's scoping note: exclude audio / video / image / embedding /
+// tts / stt / realtime / transcription / moderation models.
+const EXCLUDE_FAMILY = /embedding|rerank|moderation|tts|stt|audio|speech|video|realtime|live|transcription|midi/i;
+const EXCLUDE_ID = /embedding|rerank|moderation|tts|stt|lyria|-image\b|image-|-live\b|live-|realtime|transcription|speech|robotics|midi/i;
+
+function isTextModel(model) {
+  const family = model?.family ?? '';
+  const id = model?.id ?? '';
+  if (EXCLUDE_FAMILY.test(family)) return false;
+  if (EXCLUDE_ID.test(id)) return false;
+  const mod = model?.modalities;
+  if (mod) {
+    const input = mod.input ?? [];
+    const output = mod.output ?? [];
+    if (!input.includes('text')) return false;
+    if (!output.includes('text')) return false;
+  }
+  return true;
+}
+
+function toRates(cost) {
+  const rates = {};
+  if (typeof cost.input === 'number') rates.input = cost.input;
+  if (typeof cost.output === 'number') rates.output = cost.output;
+  if (typeof cost.cache_read === 'number') rates.cache_read = cost.cache_read;
+  if (typeof cost.cache_write === 'number') rates.cache_write = cost.cache_write;
+  return rates;
+}
+
+async function main() {
+  const current = JSON.parse(readFileSync(PRICING_PATH, 'utf8'));
+  const res = await fetch(MODELS_DEV_URL, { headers: { Accept: 'application/json' } });
+  if (!res.ok) throw new Error(`models.dev fetch failed: HTTP ${res.status}`);
+  const catalog = await res.json();
+
+  // 1. Build the fresh exact table from models.dev (scoped providers, text models with cost).
+  const fresh = {};
+  for (const [provider, entry] of Object.entries(catalog)) {
+    if (!SCOPED_PROVIDERS.has(provider)) continue;
+    for (const [modelId, model] of Object.entries(entry?.models ?? {})) {
+      if (!model?.cost || typeof model.cost.input !== 'number' || typeof model.cost.output !== 'number') continue;
+      if (!isTextModel(model)) continue;
+      fresh[`${provider}/${modelId}`] = toRates(model.cost);
+    }
+  }
+
+  // 2. Merge: keep current entries models.dev does not cover, refresh the rest.
+  const exact = {};
+  for (const [key, rate] of Object.entries(current.exact ?? {})) {
+    exact[key] = OVERRIDES[key] ?? fresh[key] ?? rate;
+  }
+
+  // 3. Add models.dev entries that are new to the table.
+  let added = 0;
+  for (const [key, rate] of Object.entries(fresh)) {
+    if (!(key in exact)) {
+      exact[key] = rate;
+      added += 1;
+    }
+  }
+  // 4. Apply overrides to keys that may not exist yet.
+  for (const [key, rate] of Object.entries(OVERRIDES)) {
+    if (!(key in exact)) added += 1;
+    exact[key] = rate;
+  }
+
+  // 5. Keep only each model's own vendor's official pricing. Cross-vendor
+  // hosting (`alibaba-cn/glm-5`, `volcengine/deepseek-*`) and cloud channels
+  // (`google-vertex/*`, `google-vertex-anthropic/*`) are dropped.
+  const dropped = Object.keys(exact).filter((k) => !isOfficialKey(k));
+  for (const k of dropped) delete exact[k];
+
+  // Diff summary for review.
+  const changes = [];
+  for (const [key, rate] of Object.entries(exact)) {
+    const prev = current.exact?.[key];
+    if (prev && JSON.stringify(prev) !== JSON.stringify(rate)) {
+      changes.push([key, prev, rate]);
+    }
+  }
+  const removed = Object.keys(current.exact ?? {}).filter((k) => !(k in exact));
+
+  const next = {
+    ...current,
+    exact,
+    _meta: {
+      ...(current._meta ?? {}),
+      generated_at: `${new Date().toISOString().slice(0, 10)}T00:00:00.000Z`,
+      note: `${current._meta?.note ?? ''} Incremental models.dev sync on ${new Date().toISOString().slice(0, 10)}: ` +
+        `kept=${Object.keys(exact).length} (added=${added}, changed=${changes.length}, removed=${removed.length}). ` +
+        `Official-only: cross-vendor hosting and cloud-partnership channels dropped.`,
+    },
+  };
+
+  writeFileSync(PRICING_PATH, `${JSON.stringify(next, null, 2)}\n`);
+
+  console.log(`exact: ${Object.keys(current.exact ?? {}).length} -> ${Object.keys(exact).length}`);
+  console.log(`added: ${added}, changed: ${changes.length}, removed: ${removed.length} (incl. ${dropped.length} non-official)`);
+  for (const [key, prev, rate] of changes) {
+    console.log(`  CHANGED ${key}: ${JSON.stringify(prev)} -> ${JSON.stringify(rate)}`);
+  }
+  for (const key of removed) {
+    console.log(`  REMOVED ${key} (was ${JSON.stringify(current.exact[key])})`);
+  }
+  if (changes.length === 0 && removed.length === 0) {
+    console.log('(no price changes — table is already up to date)');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/core/src/pricing/matcher.ts
+++ b/packages/core/src/pricing/matcher.ts
@@ -173,7 +173,32 @@ export function lookupPricing(
     if (aliased) return { ...aliased, source: 'alias' };
   }
 
-  // 4. fuzzy
+  // 4. suffix strip (reasoning-effort suffixes: -high / -low / -fast …)
+  const stripped = stripReasoningSuffix(lookupModel);
+  if (stripped !== lookupModel && exact[stripped]) {
+    return { hit: true, source: 'suffix-strip', value: exact[stripped]! };
+  }
+
+  // 5. provider-prefix strip — exact table is the source of truth, so an
+  // exact-derived hit (e.g. `anthropic/claude-fable-5` for `claude-fable-5`)
+  // must win over a fuzzy guess that could shadow it. Prefer canonical
+  // two-segment keys (`provider/model`) over nested hosts, then
+  // lexicographically smallest.
+  const suffix = `/${lower}`;
+  let best: string | null = null;
+  let bestSegments = Infinity;
+  for (const key of Object.keys(exact)) {
+    if (key.length > suffix.length && key.toLowerCase().endsWith(suffix)) {
+      const segments = key.split('/').length;
+      if (segments < bestSegments || (segments === bestSegments && (best === null || key < best))) {
+        best = key;
+        bestSegments = segments;
+      }
+    }
+  }
+  if (best) return { hit: true, source: 'prefix-strip', value: exact[best]! };
+
+  // 6. fuzzy
   if (Array.isArray(data.fuzzy)) {
     for (const { match, ref } of data.fuzzy) {
       if (!match || !ref) continue;
@@ -185,22 +210,6 @@ export function lookupPricing(
       }
     }
   }
-
-  // 5. suffix strip
-  const stripped = stripReasoningSuffix(lookupModel);
-  if (stripped !== lookupModel && exact[stripped]) {
-    return { hit: true, source: 'suffix-strip', value: exact[stripped]! };
-  }
-
-  // 6. provider-prefix strip
-  const suffix = `/${lower}`;
-  let best: string | null = null;
-  for (const key of Object.keys(exact)) {
-    if (key.length > suffix.length && key.toLowerCase().endsWith(suffix)) {
-      if (best === null || key < best) best = key;
-    }
-  }
-  if (best) return { hit: true, source: 'prefix-strip', value: exact[best]! };
 
   // 7. reverse substring
   for (const key of getSortedKeys(exact)) {

--- a/packages/core/src/pricing/pricing.json
+++ b/packages/core/src/pricing/pricing.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
     "units": "usd_per_million_tokens",
-    "generated_at": "2026-08-27T00:00:00.000Z",
-    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes)."
+    "generated_at": "2026-08-28T00:00:00.000Z",
+    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes). Incremental models.dev sync on 2026-08-28: kept=416 (added=73, changed=13, removed=54). Official-only: cross-vendor hosting and cloud-partnership channels dropped."
   },
   "exact": {
     "alibaba/qvq-max": {
@@ -240,88 +240,6 @@
       "output": 0.47,
       "cache_read": 0.016
     },
-    "alibaba-cn/MiniMax/MiniMax-M2.7": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.06,
-      "cache_write": 0.375
-    },
-    "alibaba-cn/MiniMax-M2.5": {
-      "input": 0.3,
-      "output": 1.2
-    },
-    "alibaba-cn/deepseek-r1-0528": {
-      "input": 0.574,
-      "output": 2.294
-    },
-    "alibaba-cn/deepseek-r1-distill-llama-70b": {
-      "input": 0.287,
-      "output": 0.861
-    },
-    "alibaba-cn/deepseek-r1-distill-qwen-14b": {
-      "input": 0.144,
-      "output": 0.431
-    },
-    "alibaba-cn/deepseek-r1-distill-qwen-32b": {
-      "input": 0.287,
-      "output": 0.861
-    },
-    "alibaba-cn/deepseek-r1-distill-qwen-7b": {
-      "input": 0.072,
-      "output": 0.144
-    },
-    "alibaba-cn/deepseek-r1": {
-      "input": 0.574,
-      "output": 2.294
-    },
-    "alibaba-cn/deepseek-v3-1": {
-      "input": 0.574,
-      "output": 1.721
-    },
-    "alibaba-cn/deepseek-v3-2-exp": {
-      "input": 0.287,
-      "output": 0.431
-    },
-    "alibaba-cn/deepseek-v3": {
-      "input": 0.287,
-      "output": 1.147
-    },
-    "alibaba-cn/glm-5.1": {
-      "input": 0.87,
-      "output": 3.48,
-      "cache_read": 0.17
-    },
-    "alibaba-cn/glm-5.2": {
-      "input": 1.1,
-      "output": 3.851,
-      "cache_read": 0.275,
-      "cache_write": 0
-    },
-    "alibaba-cn/glm-5": {
-      "input": 0.86,
-      "output": 3.15
-    },
-    "alibaba-cn/kimi/kimi-k2.5": {
-      "input": 0.6,
-      "output": 3,
-      "cache_read": 0.1
-    },
-    "alibaba-cn/kimi-k2-thinking": {
-      "input": 0.574,
-      "output": 2.294
-    },
-    "alibaba-cn/kimi-k2.5": {
-      "input": 0.574,
-      "output": 2.411
-    },
-    "alibaba-cn/kimi-k2.6": {
-      "input": 0.929,
-      "output": 3.858
-    },
-    "alibaba-cn/moonshot-kimi-k2-instruct": {
-      "input": 0.574,
-      "output": 2.294
-    },
     "alibaba-cn/qvq-max": {
       "input": 1.147,
       "output": 4.588
@@ -372,7 +290,9 @@
     },
     "alibaba-cn/qwen-plus": {
       "input": 0.115,
-      "output": 0.287
+      "output": 0.287,
+      "cache_read": 0.012,
+      "cache_write": 0.144
     },
     "alibaba-cn/qwen-turbo": {
       "input": 0.044,
@@ -495,8 +415,8 @@
       "output": 1.433525
     },
     "alibaba-cn/qwen3.5-397b-a17b": {
-      "input": 0.43,
-      "output": 2.58
+      "input": 0.172,
+      "output": 1.032
     },
     "alibaba-cn/qwen3.5-flash": {
       "input": 0.172,
@@ -542,22 +462,6 @@
     "alibaba-cn/qwq-plus": {
       "input": 0.23,
       "output": 0.574
-    },
-    "alibaba-cn/siliconflow/deepseek-r1-0528": {
-      "input": 0.5,
-      "output": 2.18
-    },
-    "alibaba-cn/siliconflow/deepseek-v3-0324": {
-      "input": 0.25,
-      "output": 1
-    },
-    "alibaba-cn/siliconflow/deepseek-v3.1-terminus": {
-      "input": 0.27,
-      "output": 1
-    },
-    "alibaba-cn/siliconflow/deepseek-v3.2": {
-      "input": 0.27,
-      "output": 0.42
     },
     "alibaba-cn/tongyi-intent-detect-v3": {
       "input": 0.058,
@@ -633,14 +537,14 @@
       "cache_read": 0.028
     },
     "deepseek/deepseek-v4-flash": {
-      "input": 0.44,
-      "output": 1.32,
-      "cache_read": 0.014
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
     },
     "deepseek/deepseek-v4-pro": {
-      "input": 1.32,
-      "output": 3.96,
-      "cache_read": 0.044
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
     },
     "anthropic/claude-3.5-sonnet": {
       "input": 3,
@@ -737,14 +641,14 @@
       "cache_read": 0.15
     },
     "google/gemini-3.6-flash": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
     },
     "google/gemini-3.7-flash": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
     },
     "google/gemini-3.7-flash-batch": {
       "input": 0.75,
@@ -871,183 +775,18 @@
       "output": 21
     },
     "google/gemini-flash-latest": {
-      "input": 1.5,
-      "output": 9,
-      "cache_read": 0.15
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
     },
     "google/gemini-flash-lite-latest": {
-      "input": 0.25,
-      "output": 1.5,
-      "cache_read": 0.025
+      "input": 0.3,
+      "output": 2.5,
+      "cache_read": 0.03
     },
     "google/gemini-omni-flash-preview": {
       "input": 1.5,
       "output": 17.5
-    },
-    "google-vertex/claude-haiku-4-5@20251001": {
-      "input": 1,
-      "output": 5,
-      "cache_read": 0.1,
-      "cache_write": 1.25
-    },
-    "google-vertex/claude-opus-4-1@20250805": {
-      "input": 15,
-      "output": 75,
-      "cache_read": 1.5,
-      "cache_write": 18.75
-    },
-    "google-vertex/claude-opus-4-5@20251101": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex/claude-opus-4-6@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex/claude-opus-4-7@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex/claude-opus-4-8@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex/claude-opus-4@20250514": {
-      "input": 15,
-      "output": 75,
-      "cache_read": 1.5,
-      "cache_write": 18.75
-    },
-    "google-vertex/claude-opus-5@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex/claude-sonnet-4-5@20250929": {
-      "input": 3,
-      "output": 15,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "google-vertex/claude-sonnet-4-6@default": {
-      "input": 3,
-      "output": 15,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "google-vertex/claude-sonnet-4@20250514": {
-      "input": 3,
-      "output": 15,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "google-vertex/claude-sonnet-5@default": {
-      "input": 2,
-      "output": 10,
-      "cache_read": 0.2,
-      "cache_write": 2.5
-    },
-    "google-vertex/deepseek-ai/deepseek-v3.1-maas": {
-      "input": 0.6,
-      "output": 1.7
-    },
-    "google-vertex/deepseek-ai/deepseek-v3.2-maas": {
-      "input": 0.56,
-      "output": 1.68,
-      "cache_read": 0.056
-    },
-    "google-vertex/gemini-2.5-flash": {
-      "input": 0.3,
-      "output": 2.5,
-      "cache_read": 0.075,
-      "cache_write": 0.383
-    },
-    "google-vertex/gemini-2.5-pro": {
-      "input": 1.25,
-      "output": 10,
-      "cache_read": 0.125
-    },
-    "google-vertex/gemini-3.1-pro-preview-customtools": {
-      "input": 2,
-      "output": 12,
-      "cache_read": 0.2
-    },
-    "google-vertex/gemini-3.1-pro-preview": {
-      "input": 2,
-      "output": 12,
-      "cache_read": 0.2
-    },
-    "google-vertex/meta/llama-3.3-70b-instruct-maas": {
-      "input": 0.72,
-      "output": 0.72
-    },
-    "google-vertex/meta/llama-4-maverick-17b-128e-instruct-maas": {
-      "input": 0.35,
-      "output": 1.15
-    },
-    "google-vertex/moonshotai/kimi-k2-thinking-maas": {
-      "input": 0.6,
-      "output": 2.5
-    },
-    "google-vertex/openai/gpt-oss-120b-maas": {
-      "input": 0.09,
-      "output": 0.36
-    },
-    "google-vertex/openai/gpt-oss-20b-maas": {
-      "input": 0.07,
-      "output": 0.25
-    },
-    "google-vertex/qwen/qwen3-235b-a22b-instruct-2507-maas": {
-      "input": 0.22,
-      "output": 0.88
-    },
-    "google-vertex/zai-org/glm-4.7-maas": {
-      "input": 0.6,
-      "output": 2.2
-    },
-    "google-vertex/zai-org/glm-5-maas": {
-      "input": 1,
-      "output": 3.2,
-      "cache_read": 0.1
-    },
-    "google-vertex-anthropic/claude-opus-4-6@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex-anthropic/claude-opus-4-7@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex-anthropic/claude-opus-4-8@default": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "google-vertex-anthropic/claude-sonnet-4-6@default": {
-      "input": 3,
-      "output": 15,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "google-vertex-anthropic/claude-sonnet-5@default": {
-      "input": 2,
-      "output": 10,
-      "cache_read": 0.2,
-      "cache_write": 2.5
     },
     "minimax/MiniMax-M2.1": {
       "input": 0.3,
@@ -1694,10 +1433,10 @@
       "cache_write": 0.25
     },
     "openai/gpt-5.6-sol": {
-      "input": 5,
-      "output": 30,
-      "cache_read": 0.5,
-      "cache_write": 6.25
+      "input": 4,
+      "output": 20,
+      "cache_read": 0.4,
+      "cache_write": 5
     },
     "openai/gpt-5.6-terra": {
       "input": 2,
@@ -1706,10 +1445,10 @@
       "cache_write": 2.5
     },
     "openai/gpt-5.6": {
-      "input": 5,
-      "output": 30,
-      "cache_read": 0.5,
-      "cache_write": 6.25
+      "input": 4,
+      "output": 20,
+      "cache_read": 0.4,
+      "cache_write": 5
     },
     "openai/o1-pro": {
       "input": 150,
@@ -1873,9 +1612,7 @@
     },
     "zhipuai/glm-4.5v": {
       "input": 0.6,
-      "output": 1.8,
-      "cache_read": 0,
-      "cache_write": 0
+      "output": 1.8
     },
     "zhipuai/glm-4.6": {
       "input": 0.6,
@@ -1885,9 +1622,7 @@
     },
     "zhipuai/glm-4.6v": {
       "input": 0.3,
-      "output": 0.9,
-      "cache_read": 0,
-      "cache_write": 0
+      "output": 0.9
     },
     "zhipuai/glm-4.7": {
       "input": 0.6,
@@ -1983,9 +1718,9 @@
       "cache_read": 0.02
     },
     "stepfun/step-3.7-flash": {
-      "input": 0.2,
-      "output": 1.15,
-      "cache_read": 0.04
+      "input": 0.185,
+      "output": 1.11,
+      "cache_read": 0.037
     },
     "inclusionai/ling-2.6-1t": {
       "input": 0.625,
@@ -2025,6 +1760,234 @@
       "input": 0.45,
       "output": 0.9,
       "cache_read": 0.0038
+    },
+    "meta/muse-spark-1.2": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "meta/muse-spark-1.2-contributor": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "moonshotai/kimi-k2.7-code-highspeed": {
+      "input": 1.9,
+      "output": 8,
+      "cache_read": 0.38
+    },
+    "anthropic/claude-opus-4-5": {
+      "input": 5,
+      "output": 25,
+      "cache_read": 0.5,
+      "cache_write": 6.25
+    },
+    "anthropic/claude-haiku-4-5": {
+      "input": 1,
+      "output": 5,
+      "cache_read": 0.1,
+      "cache_write": 1.25
+    },
+    "zai/glm-4.5-flash": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "zai/glm-5": {
+      "input": 1,
+      "output": 3.2,
+      "cache_read": 0.2,
+      "cache_write": 0
+    },
+    "zai/glm-5.3": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0
+    },
+    "zai/glm-5.2": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0
+    },
+    "zai/glm-5.1": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0
+    },
+    "zai/glm-4.7-flash": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "zai/glm-5.3-flash": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015,
+      "cache_write": 0
+    },
+    "alibaba-cn/qwen3.7-max": {
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.5,
+      "cache_write": 3.125
+    },
+    "alibaba-cn/qwen3.6-flash": {
+      "input": 0.1875,
+      "output": 1.125,
+      "cache_write": 0.234375
+    },
+    "alibaba-cn/qwen3-coder-plus": {
+      "input": 1,
+      "output": 5
+    },
+    "stepfun/step-3.5-flash-2603": {
+      "input": 0.1,
+      "output": 0.3,
+      "cache_read": 0.02
+    },
+    "stepfun/step-2-16k": {
+      "input": 5.21,
+      "output": 16.44,
+      "cache_read": 1.04
+    },
+    "stepfun/step-1-32k": {
+      "input": 2.05,
+      "output": 9.59,
+      "cache_read": 0.41
+    },
+    "volcengine/doubao-seed-2-0-pro-260215": {
+      "input": 0.47499,
+      "output": 2.37494,
+      "cache_read": 0.095
+    },
+    "volcengine/doubao-seed-1-6-251015": {
+      "input": 0.11875,
+      "output": 1.18747,
+      "cache_read": 0.02375
+    },
+    "volcengine/doubao-seed-2-1-pro-260628": {
+      "input": 0.8906,
+      "output": 4.45301,
+      "cache_read": 0.17812
+    },
+    "volcengine/doubao-seed-1-6-flash-250828": {
+      "input": 0.02227,
+      "output": 0.22265,
+      "cache_read": 0.00445
+    },
+    "volcengine/doubao-seed-2-0-lite-260428": {
+      "input": 0.08906,
+      "output": 0.53436,
+      "cache_read": 0.01781
+    },
+    "volcengine/doubao-seed-2-0-code-preview-260215": {
+      "input": 0.47499,
+      "output": 2.37494,
+      "cache_read": 0.095
+    },
+    "volcengine/doubao-seed-1-6-vision-250815": {
+      "input": 0.11875,
+      "output": 1.18747,
+      "cache_read": 0.02375
+    },
+    "volcengine/doubao-seed-2-0-mini-260428": {
+      "input": 0.02969,
+      "output": 0.29687,
+      "cache_read": 0.00594
+    },
+    "volcengine/doubao-seed-2-1-turbo-260628": {
+      "input": 0.4453,
+      "output": 2.22651,
+      "cache_read": 0.08906
+    },
+    "volcengine/doubao-seed-character-260628": {
+      "input": 0.11875,
+      "output": 0.29687,
+      "cache_read": 0.02375
+    },
+    "volcengine/doubao-seed-1-8-251228": {
+      "input": 0.11875,
+      "output": 1.18747,
+      "cache_read": 0.02375
+    },
+    "zhipuai/glm-4.7-flash": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "zhipuai/glm-4.5-flash": {
+      "input": 0,
+      "output": 0,
+      "cache_read": 0,
+      "cache_write": 0
+    },
+    "mistral/labs-devstral-small-2512": {
+      "input": 0,
+      "output": 0
+    },
+    "mistral/voxtral-small-latest": {
+      "input": 0.1,
+      "output": 0.3
+    },
+    "mistral/mistral-medium-latest": {
+      "input": 1.5,
+      "output": 7.5
+    },
+    "moonshotai-cn/kimi-k2.6": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.16
+    },
+    "moonshotai-cn/kimi-k2-thinking": {
+      "input": 0.6,
+      "output": 2.5,
+      "cache_read": 0.15
+    },
+    "moonshotai-cn/kimi-k2.7-code-highspeed": {
+      "input": 1.9,
+      "output": 8,
+      "cache_read": 0.38
+    },
+    "moonshotai-cn/kimi-k2-turbo-preview": {
+      "input": 2.4,
+      "output": 10,
+      "cache_read": 0.6
+    },
+    "moonshotai-cn/kimi-k2-0905-preview": {
+      "input": 0.6,
+      "output": 2.5,
+      "cache_read": 0.15
+    },
+    "moonshotai-cn/kimi-k2.5": {
+      "input": 0.6,
+      "output": 3,
+      "cache_read": 0.1
+    },
+    "moonshotai-cn/kimi-k2-thinking-turbo": {
+      "input": 1.15,
+      "output": 8,
+      "cache_read": 0.15
+    },
+    "moonshotai-cn/kimi-k2-0711-preview": {
+      "input": 0.6,
+      "output": 2.5,
+      "cache_read": 0.15
+    },
+    "moonshotai-cn/kimi-k3": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    },
+    "moonshotai-cn/kimi-k2.7-code": {
+      "input": 0.95,
+      "output": 4,
+      "cache_read": 0.19
     }
   },
   "alias": {
@@ -2115,6 +2078,10 @@
       "ref": "anthropic/claude-mythos-5"
     },
     {
+      "match": "claude-fable-5",
+      "ref": "anthropic/claude-fable-5"
+    },
+    {
       "match": "claude-opus-4",
       "ref": "anthropic/claude-opus-4"
     },
@@ -2129,6 +2096,14 @@
     {
       "match": "claude-sonnet-4",
       "ref": "anthropic/claude-sonnet-4"
+    },
+    {
+      "match": "claude-4.6-opus",
+      "ref": "anthropic/claude-opus-4-6"
+    },
+    {
+      "match": "claude-fable-5",
+      "ref": "anthropic/claude-fable-5"
     },
     {
       "match": "claude",
@@ -2223,12 +2198,28 @@
       "ref": "openai/gpt-5.3-codex"
     },
     {
+      "match": "gpt-5.4-mini",
+      "ref": "openai/gpt-5.4-mini"
+    },
+    {
       "match": "gpt-5.4",
       "ref": "openai/gpt-5.4"
     },
     {
       "match": "gpt-5.1",
       "ref": "openai/gpt-5.1"
+    },
+    {
+      "match": "gpt-5.5",
+      "ref": "openai/gpt-5.5"
+    },
+    {
+      "match": "gpt-5.6-sol",
+      "ref": "openai/gpt-5.6-sol"
+    },
+    {
+      "match": "gpt-5.6-terra",
+      "ref": "openai/gpt-5.6-terra"
     },
     {
       "match": "gpt-5",
@@ -2353,6 +2344,10 @@
     {
       "match": "grok-4.3",
       "ref": "xai/grok-4.3"
+    },
+    {
+      "match": "grok-4.6",
+      "ref": "xai/grok-4.6"
     },
     {
       "match": "grok-4",
@@ -2773,6 +2768,14 @@
     {
       "match": "muse-spark-1.1",
       "ref": "meta/muse-spark-1.1"
+    },
+    {
+      "match": "composer-2-fast",
+      "ref": "cursor/composer-2"
+    },
+    {
+      "match": "composer-2.5-fast",
+      "ref": "cursor/composer-2.5"
     }
   ],
   "default": {

--- a/packages/core/test/pricing.test.ts
+++ b/packages/core/test/pricing.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -17,7 +18,7 @@ import {
   startPricingRefresh,
   validatePricingData,
 } from '../src/pricing/index.js';
-import { lookupPricingStacked, type PricingData } from '../src/pricing/matcher.js';
+import { lookupPricing, lookupPricingStacked, type PricingData } from '../src/pricing/matcher.js';
 import { pricingOverlayPath } from '../src/paths.js';
 
 function makeRow(partial: Partial<QueueBucket> & Pick<QueueBucket, 'source' | 'model'>): QueueBucket {
@@ -44,6 +45,162 @@ test('getModelPricing resolves claude-opus-4-6 from pricing table', () => {
   const p = getModelPricing('claude-opus-4-6');
   assert.ok(p.input > 0);
   assert.ok(p.output > 0);
+});
+
+test('claude-fable-5 resolves to its own price, not the fuzzy claude catch-all', () => {
+  const p = getModelPricing('claude-fable-5', { source: 'claude' });
+  assert.equal(p.input, 10);
+  assert.equal(p.output, 50);
+  assert.equal(p.cache_read, 1);
+  assert.equal(p.cache_write, 12.5);
+});
+
+test('claude-fable-5 with spaces normalizes and still avoids the catch-all', () => {
+  const p = getModelPricing('Claude Fable 5', { source: 'claude' });
+  assert.equal(p.input, 10);
+  assert.equal(p.output, 50);
+});
+
+test('bare claude still falls through to the fuzzy catch-all', () => {
+  const p = getModelPricing('claude', { source: 'claude' });
+  assert.equal(p.input, 3);
+  assert.equal(p.output, 15);
+});
+
+test('gpt-5-mini resolves to its own price, not the gpt-5 catch-all', () => {
+  const p = getModelPricing('gpt-5-mini');
+  assert.equal(p.input, 0.25);
+  assert.equal(p.output, 2);
+});
+
+test('claude-sonnet-5 resolves to 2/10, not the sonnet-4-5 catch-all', () => {
+  const p = getModelPricing('claude-sonnet-5');
+  assert.equal(p.input, 2);
+  assert.equal(p.output, 10);
+});
+
+test('claude-opus-4 resolves to its own price, not the claude-opus family rule', () => {
+  const p = getModelPricing('claude-opus-4');
+  assert.equal(p.input, 15);
+  assert.equal(p.output, 75);
+});
+
+test('gemini-3.1-pro resolves to 2/12, not the gemini catch-all', () => {
+  const p = getModelPricing('gemini-3.1-pro');
+  assert.equal(p.input, 2);
+  assert.equal(p.output, 12);
+});
+
+test('deepseek-v3.2 resolves to 0.28/0.42, not the deepseek-v3 rule', () => {
+  const p = getModelPricing('deepseek-v3.2');
+  assert.equal(p.input, 0.28);
+  assert.equal(p.output, 0.42);
+});
+
+test('grok-4.20 resolves to 1.25/2.5, not the grok-4 rule', () => {
+  const p = getModelPricing('grok-4.20');
+  assert.equal(p.input, 1.25);
+  assert.equal(p.output, 2.5);
+});
+
+test('kimi-k2.7-code resolves to 0.95/4, not the kimi-k2 rule', () => {
+  const p = getModelPricing('kimi-k2.7-code');
+  assert.equal(p.input, 0.95);
+  assert.equal(p.output, 4);
+});
+
+test('exact-derived match beats every fuzzy catch-all: each exact short name resolves to its own price or a same-name regional variant', () => {
+  const data = JSON.parse(
+    readFileSync(new URL('../src/pricing/pricing.json', import.meta.url), 'utf8'),
+  ) as PricingData;
+  const exact = data.exact;
+  const shortOf = (k: string): string => (k.includes('/') ? k.slice(k.lastIndexOf('/') + 1) : k);
+  const sameRates = (a: PricingData['exact'][string] | null, b: PricingData['exact'][string] | null): boolean =>
+    !!a &&
+    !!b &&
+    a.input === b.input &&
+    a.output === b.output &&
+    (a.cache_read ?? 0) === (b.cache_read ?? 0) &&
+    (a.cache_write ?? 0) === (b.cache_write ?? 0);
+
+  const byShort = new Map<string, PricingData['exact'][string][]>();
+  for (const k of Object.keys(exact)) {
+    const s = shortOf(k).toLowerCase();
+    const list = byShort.get(s) ?? [];
+    list.push(exact[k]!);
+    byShort.set(s, list);
+  }
+
+  const mismatches: string[] = [];
+  for (const k of Object.keys(exact)) {
+    const short = shortOf(k);
+    const r = lookupPricing(short, data, null);
+    if (!r.value) {
+      mismatches.push(`${short}: unresolved`);
+      continue;
+    }
+    const allowed = byShort.get(short.toLowerCase()) ?? [];
+    if (!allowed.some((v) => sameRates(v, r.value))) {
+      mismatches.push(
+        `${short}: got ${JSON.stringify(r.value)} via ${r.source}, expected one of ${allowed
+          .map((a) => JSON.stringify(a))
+          .join(' | ')}`,
+      );
+    }
+  }
+  assert.equal(
+    mismatches.length,
+    0,
+    `shadowed exact short names (${mismatches.length}):\n${mismatches.slice(0, 12).join('\n')}`,
+  );
+});
+
+test('cursor gpt-5.5 reasoning tiers resolve to gpt-5.5, not the gpt-5 catch-all', () => {
+  for (const m of ['gpt-5.5-extra-high', 'gpt-5.5-extra-high-fast', 'gpt-5.5-medium']) {
+    const p = getModelPricing(m, { source: 'cursor' });
+    assert.equal(p.input, 5, m);
+    assert.equal(p.output, 30, m);
+  }
+});
+
+test('cursor claude-4.6-opus reasoning tiers resolve to opus-4-6, not sonnet', () => {
+  for (const m of ['claude-4.6-opus-high-thinking', 'claude-4.6-opus-medium-thinking']) {
+    const p = getModelPricing(m, { source: 'cursor' });
+    assert.equal(p.input, 5, m);
+    assert.equal(p.output, 25, m);
+  }
+});
+
+test('cursor gpt-5.6 sol/terra tiers resolve to their own model', () => {
+  const sol = getModelPricing('gpt-5.6-sol-xhigh-fast', { source: 'cursor' });
+  assert.equal(sol.input, 4);
+  assert.equal(sol.output, 20);
+  const terra = getModelPricing('gpt-5.6-terra-medium', { source: 'cursor' });
+  assert.equal(terra.input, 2);
+  assert.equal(terra.output, 12);
+});
+
+test('cursor gpt-5.4-mini tier resolves to mini, not gpt-5.4', () => {
+  const p = getModelPricing('gpt-5.4-mini-medium', { source: 'cursor' });
+  assert.equal(p.input, 0.75);
+  assert.equal(p.output, 4.5);
+});
+
+test('cursor claude-fable-5 reasoning tiers resolve to fable-5, not sonnet', () => {
+  for (const m of ['claude-fable-5-thinking-max', 'claude-fable-5-thinking-high']) {
+    const p = getModelPricing(m, { source: 'cursor' });
+    assert.equal(p.input, 10, m);
+    assert.equal(p.output, 50, m);
+  }
+});
+
+test('cursor composer fast tiers fall back to their base composer price', () => {
+  const c2 = getModelPricing('composer-2-fast', { source: 'cursor' });
+  assert.equal(c2.input, 0.5);
+  assert.equal(c2.output, 2.5);
+  const c25 = getModelPricing('composer-2.5-fast', { source: 'cursor' });
+  assert.equal(c25.input, 0.5);
+  assert.equal(c25.output, 2.5);
 });
 
 test('cursor auto uses the Cursor-specific price instead of a global alias', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他问题（是关于什么的改动？）

### 🔗 相关 Issue

> 无关联 Issue。问题在定价匹配逻辑排查中发现。

### 💡 需求背景和解决方案

> 这个 PR 把同一类问题的根因修复和数据源刷新合并到一起：

**1. 根因修复：matcher 优先级重排，exact 永远赢 fuzzy**

- **要解决的问题**：`source=claude, model=claude-fable-5` 这类短模型名会被 fuzzy 表里的兜底规则抢先命中。例如 fuzzy 的 `{ match: 'claude', ref: 'anthropic/claude-sonnet-4-5' }` 会把 `claude-fable-5` 错配成 sonnet-4-5（3/15/0.3/3.75），而 exact 表其实有 `anthropic/claude-fable-5`（10/50/1/12.5）本应被 prefix-strip 命中。同类问题影响 gpt-5-mini、claude-sonnet-5、claude-opus-4、gemini-3.1-pro、deepseek-v3.2、grok-4.20、kimi-k2.7-code，以及 cursor 的 gpt-5.5 / claude-4.6-opus / gpt-5.6 sol·terra / gpt-5.4-mini / claude-fable-5-thinking / composer-2·2.5-fast 等推理档位。
- **解决方案**：在 matcher 里把 suffix-strip 和 provider-prefix-strip 提前到 fuzzy 之前，让 exact 表的任何派生匹配（哪怕只是 `provider/short-name`）都能赢过 fuzzy 兜底。多个 prefix-strip 候选同时命中时，优先选择规范的 `provider/model` 两段形式（而不是 `vendor/host/model`），再按字典序取最小。fuzzy 现在作为最后兜底，只有当没有任何 exact 派生匹配时才生效。
- **防御加固**：按既有 `claude-mythos-5` 的写法，在 fuzzy 兜底规则 `{ match: 'claude', … }` 之前新增 `{ match: 'claude-fable-5', ref: 'anthropic/claude-fable-5' }`。即使将来 matcher 顺序被还原，也仍然走对。
- **测试**：新增覆盖裸名 / 空格归一化名 / 兜底规则仍生效（bare `claude` → sonnet-4-5）三种 fable-5 场景，并补齐上述所有短名与 cursor 推理档位的回归用例；外加一个扫表测试，断言 exact 表里每一个短名要么解到自己、要么解到一个同价区域变体。

**2. 数据源刷新：models.dev 增量同步脚本 + 一次性同步**

- **要解决的问题**：内置 `pricing.json` 需要持续跟随上游定价变化，但目前完全手动维护，第三方/社区/AWS ARN/区域中转渠道已经被剥离。
- **解决方案**：新增 `packages/core/scripts/sync-pricing.mjs`（脚本入口 `pnpm sync:pricing`），按 OVERRIDES（人工修正）→ models.dev 官方渠道 → 既有手工补充项的合并优先级做增量同步；hand-curated 的 fuzzy / alias / sourceAlias / default 完整保留，因此 ~118 条人工补充项（claude-mythos-5、gpt-5.5-fast、deepseek-v3.2、cursor、tencent/hy3 …）永不会被覆盖式同步静默删除。
- **本次执行结果**：在原有 426 条基础上 kept=416，added=73、changed=13、removed=54（移除跨厂商托管与云合作渠道）。
- **测试**：核心包测试套件 233/233 通过。

### 📝 更新日志

| 语言 | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Exact-derived prices now beat fuzzy catch-alls in the matcher (fixes claude-fable-5 → sonnet-4-5 mispricing and 10+ similar shadows). Pricing bundle is now incrementally synced from models.dev via `pnpm sync:pricing`. |
| 🇨🇳 中文 | matcher 现在让 prefix-strip 优先于 fuzzy，修复了 claude-fable-5 被错配成 sonnet-4-5 等十余处类似问题。内置定价表可通过 `pnpm sync:pricing` 从 models.dev 增量同步。 |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)