### PR TITLE
feat(web): persist dashboard time range and cap rank filter popover

### DIFF
--- a/apps/desktop/src/renderer/hooks/useLocalStorage.ts
+++ b/apps/desktop/src/renderer/hooks/useLocalStorage.ts
@@ -1,0 +1,48 @@
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+
+function readStoredValue<T>(
+  key: string,
+  defaultValue: T,
+  isValid?: (value: unknown) => value is T,
+): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw == null) return defaultValue;
+    const parsed: unknown = JSON.parse(raw);
+    if (isValid && !isValid(parsed)) return defaultValue;
+    return parsed as T;
+  } catch {
+    return defaultValue;
+  }
+}
+
+/**
+ * Persist a JSON-serializable value in localStorage.
+ *
+ * Reads once on mount; writes after each change. Private mode / quota errors
+ * are ignored so the in-memory state still works.
+ */
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  isValid?: (value: unknown) => value is T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() =>
+    readStoredValue(key, defaultValue, isValid),
+  );
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore private mode / quota
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/apps/desktop/src/renderer/pages/DashboardPage.tsx
+++ b/apps/desktop/src/renderer/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import { ProjectUsagePanel } from '@/components/ProjectUsagePanel';
 import { ToolModelUsagePanel } from '@/components/ToolModelUsagePanel';
 import { UsageDistributionCard } from '@/components/UsageDistributionCard';
 import { useDashboardData } from '@/hooks/useDashboardData';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { projectDashboardForDate } from '@/lib/dashboard-data';
 import { scheduleAfterPaint } from '@/lib/schedule-after-paint';
 import { DATA_SYNCED_EVENT } from '@/lib/shell-events';
@@ -57,7 +58,12 @@ function useDeferredDashboardRange(range: DashboardRange): DashboardRange {
 
 /** HeroUI dashboard backed by the same usage dataset as the root route. */
 export function DashboardPage() {
-  const [range, setRange] = useState<DashboardRange>('last-7-days');
+  const [range, setRange] = useLocalStorage<DashboardRange>(
+    'tud.dashboardRange',
+    'last-7-days',
+    (value): value is DashboardRange =>
+      typeof value === 'string' && value in DASHBOARD_RANGE_DAYS,
+  );
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
   const { publishSnapshot } = useShareSnapshot();

--- a/packages/dashboard/src/components/RankFilter.tsx
+++ b/packages/dashboard/src/components/RankFilter.tsx
@@ -21,6 +21,8 @@ const RANGE_OPTIONS: readonly { id: RankRange; label: string }[] = [
 ];
 
 const FILTER_CONTROL_HEIGHT = '!h-8 !min-h-8';
+const FILTER_POPOVER = 'w-50 !max-h-64 overflow-hidden rounded-xl bg-surface shadow-md';
+const FILTER_POPOVER_LIST = '!max-h-64 overflow-y-auto!';
 
 function openGithubRepository(): void {
   const opened = window.open(GITHUB_REPO_URL, '_blank');
@@ -197,8 +199,8 @@ function ToolSelect({
         </Select.Value>
         <Select.Indicator className="size-3.5 text-muted" />
       </Select.Trigger>
-      <Select.Popover className="w-50 rounded-xl bg-surface shadow-md" placement="bottom start">
-        <ListBox aria-label="工具筛选">
+      <Select.Popover className={FILTER_POPOVER} placement="bottom start">
+        <ListBox aria-label="工具筛选" className={FILTER_POPOVER_LIST}>
           <ListBox.Item id="all" textValue="全部工具">
             全部工具
             <ListBox.ItemIndicator />
@@ -260,8 +262,8 @@ function RankSelect({
         <Select.Value className="min-w-0 max-w-20 !text-xs sm:max-w-40" />
         <Select.Indicator className="size-3.5 text-muted" />
       </Select.Trigger>
-      <Select.Popover className="w-50 rounded-xl bg-surface shadow-md" placement="bottom start">
-        <ListBox aria-label={ariaLabel}>
+      <Select.Popover className={FILTER_POPOVER} placement="bottom start">
+        <ListBox aria-label={ariaLabel} className={FILTER_POPOVER_LIST}>
           {allowEmpty ? (
             <ListBox.Item id="all" textValue={placeholder}>
               {placeholder}

--- a/packages/dashboard/src/hooks/useLocalStorage.ts
+++ b/packages/dashboard/src/hooks/useLocalStorage.ts
@@ -1,0 +1,48 @@
+import {
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+
+function readStoredValue<T>(
+  key: string,
+  defaultValue: T,
+  isValid?: (value: unknown) => value is T,
+): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw == null) return defaultValue;
+    const parsed: unknown = JSON.parse(raw);
+    if (isValid && !isValid(parsed)) return defaultValue;
+    return parsed as T;
+  } catch {
+    return defaultValue;
+  }
+}
+
+/**
+ * Persist a JSON-serializable value in localStorage.
+ *
+ * Reads once on mount; writes after each change. Private mode / quota errors
+ * are ignored so the in-memory state still works.
+ */
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+  isValid?: (value: unknown) => value is T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() =>
+    readStoredValue(key, defaultValue, isValid),
+  );
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore private mode / quota
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+}

--- a/packages/dashboard/src/pages/DashboardPage.tsx
+++ b/packages/dashboard/src/pages/DashboardPage.tsx
@@ -18,6 +18,7 @@ import { ProjectUsagePanel } from '@/components/ProjectUsagePanel';
 import { ToolModelUsagePanel } from '@/components/ToolModelUsagePanel';
 import { UsageDistributionCard } from '@/components/UsageDistributionCard';
 import { useDashboardData } from '@/hooks/useDashboardData';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useShareSnapshot } from '@/hooks/ShareSnapshotContext';
 import { isCliBackend } from '@/lib/api';
 import { projectDashboardForDate } from '@/lib/dashboard-data';
@@ -57,7 +58,12 @@ function useDeferredDashboardRange(range: DashboardRange): DashboardRange {
 
 /** HeroUI dashboard backed by the same usage dataset as the root route. */
 export function DashboardPage() {
-  const [range, setRange] = useState<DashboardRange>('last-7-days');
+  const [range, setRange] = useLocalStorage<DashboardRange>(
+    'tud.dashboardRange',
+    'last-7-days',
+    (value): value is DashboardRange =>
+      typeof value === 'string' && value in DASHBOARD_RANGE_DAYS,
+  );
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
   const { publishSnapshot } = useShareSnapshot();


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交

### 💡 需求背景和解决方案

> 1. 个人用量页（仪表盘）每次刷新都会回到默认「近 7 天」，用户改过的时间范围不会被记住。
> 2. 新增 `useLocalStorage` hook：挂载时读一次、每次变更写回；JSON 解析失败、隐私模式 / 配额写失败时忽略错误，内存态仍可用。非法值（不在 `DASHBOARD_RANGE_DAYS` 内）回退到 `'last-7-days'`。
> 3. `DashboardPage` 用 `tud.dashboardRange` 持久化时间范围，默认仍是 `'last-7-days'`。`apps/desktop/src/renderer` 同步了同名 hook 与页面改动（跨端 UI 副本）。
> 4. 排行榜 `RankFilter` 的工具 / 模型下拉选项较多时，Popover 会撑出视口。抽出 `FILTER_POPOVER` / `FILTER_POPOVER_LIST` 常量，限制最大高度并在列表内滚动。Desktop renderer 无排行榜页面，**无需同步**。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Remember the personal dashboard time range across reloads, and cap the leaderboard filter popover so long option lists scroll instead of overflowing. |
| 🇨🇳 中文 | 个人用量页时间范围刷新后仍保留上次选择；排行榜筛选下拉过长时改为内部滚动，不再撑出视口。 |

### ✅ 验证

- 用量页：切换「今天 / 近 7 天 / 近 30 天 / 近 90 天」后刷新，时间范围应保持上次选择；清空 `localStorage` 的 `tud.dashboardRange` 后应回到「近 7 天」。
- 写入非法值（如 `"foo"`）后刷新，应回退到「近 7 天」。
- 排行榜：选择「全部工具」打开模型下拉，选项较多时应出现内部滚动、不撑出屏幕。
- Desktop：打开桌面端用量页，确认时间范围同样会记住（renderer 已同步）。
