### PR TITLE
fix(build): use fs.copyFileSync instead of cp for Windows compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,11 +47,11 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && cp src/pricing/pricing.json dist/pricing/pricing.json",
+    "build": "tsc -p tsconfig.json && node -e \"require('node:fs').copyFileSync('src/pricing/pricing.json','dist/pricing/pricing.json')\"",
     "dev": "tsc -p tsconfig.json --watch",
     "sync:pricing": "node scripts/sync-pricing.mjs",
     "test": "pnpm test:compile && node --test dist-test/test/*.test.js",
-    "test:compile": "tsc -p tsconfig.test.json && cp src/pricing/pricing.json dist-test/src/pricing/pricing.json"
+    "test:compile": "tsc -p tsconfig.test.json && node -e \"require('node:fs').copyFileSync('src/pricing/pricing.json','dist-test/src/pricing/pricing.json')\""
   },
   "dependencies": {
     "hono": "^4.7.5"


### PR DESCRIPTION
- build: copy pricing.json via node fs.copyFileSync

- test:compile: same cross-platform replacement