### PR TITLE
⚡ 优化托盘驻留内存：隐藏即销毁窗口，按需重建

### DIFF
--- a/apps/desktop/src/main/DesktopPet.ts
+++ b/apps/desktop/src/main/DesktopPet.ts
@@ -399,7 +399,9 @@ export async function syncDesktopPet(): Promise<void> {
   latestPosition = pref.position;
   if (!pref.enabled) {
     stopAutoMove();
-    if (isPetWindow(petWindow)) petWindow.hide();
+    // Disabling the pet releases its renderer process entirely instead of
+    // keeping a hidden window (and its Chromium process) resident.
+    if (isPetWindow(petWindow)) petWindow.destroy();
     return;
   }
   const window = await ensurePetWindow();

--- a/apps/desktop/src/main/DesktopPet.ts
+++ b/apps/desktop/src/main/DesktopPet.ts
@@ -339,16 +339,22 @@ function stopDragTicker(): void {
 }
 
 async function loadPetRenderer(window: BrowserWindow): Promise<void> {
-  const devUrl = process.env['ELECTRON_RENDERER_URL'];
-  if (!app.isPackaged && devUrl) {
-    const url = new URL(devUrl);
-    url.searchParams.set('view', 'desktop-pet');
-    await window.loadURL(url.toString());
-    return;
+  try {
+    const devUrl = process.env['ELECTRON_RENDERER_URL'];
+    if (!app.isPackaged && devUrl) {
+      const url = new URL(devUrl);
+      url.searchParams.set('view', 'desktop-pet');
+      await window.loadURL(url.toString());
+      return;
+    }
+    await window.loadFile(path.join(__dirname, '../renderer/index.html'), {
+      search: '?view=desktop-pet',
+    });
+  } catch (err) {
+    // Window destroyed mid-load (pet disabled / toggled away) — swallow.
+    if (window.isDestroyed()) return;
+    throw err;
   }
-  await window.loadFile(path.join(__dirname, '../renderer/index.html'), {
-    search: '?view=desktop-pet',
-  });
 }
 
 async function ensurePetWindow(): Promise<BrowserWindow> {
@@ -381,19 +387,41 @@ async function ensurePetWindow(): Promise<BrowserWindow> {
       nodeIntegration: false,
     },
   });
-  petWindow.setAlwaysOnTop(true, 'floating');
-  petWindow.on('move', onPetMoved);
-  petWindow.on('closed', () => {
+  const window = petWindow;
+  window.setAlwaysOnTop(true, 'floating');
+  window.on('move', onPetMoved);
+  window.on('closed', () => {
     stopAutoMove();
-    petWindow = null;
-    lastBounds = null;
+    // Only clear the ref if it still points at this window; a newer window
+    // created by a queued toggle must not be nulled out by the old one.
+    if (petWindow === window) {
+      petWindow = null;
+      lastBounds = null;
+    }
   });
-  await loadPetRenderer(petWindow);
+  await loadPetRenderer(window);
   sendPreferences(pref);
-  return petWindow;
+  return window;
 }
 
-export async function syncDesktopPet(): Promise<void> {
+/**
+ * Rapid toggles previously raced: one call was mid-loadURL while another
+ * destroyed the window, killing the navigation with ERR_FAILED (-2). Serialize
+ * through a promise chain so each toggle runs to completion before the next.
+ */
+let syncQueue: Promise<void> = Promise.resolve();
+
+export function syncDesktopPet(): Promise<void> {
+  const run = syncQueue.then(() => doSyncDesktopPet());
+  // Keep the chain alive even if one run rejects so later toggles still apply.
+  syncQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+async function doSyncDesktopPet(): Promise<void> {
   const pref = await loadDesktopPetPref();
   stopAutoMove();
   latestPosition = pref.position;
@@ -405,6 +433,7 @@ export async function syncDesktopPet(): Promise<void> {
     return;
   }
   const window = await ensurePetWindow();
+  if (window.isDestroyed()) return;
   const { width, height } = petDimensions(pref.scale);
   const bounds = window.getBounds();
   const position = clampPosition({

--- a/apps/desktop/src/main/DesktopWindow.ts
+++ b/apps/desktop/src/main/DesktopWindow.ts
@@ -105,12 +105,14 @@ export class DesktopWindow {
       this.browserWindow.setWindowButtonVisibility(true);
     }
 
-    // Close (X / traffic light) hides to tray; real exit goes through
+    // Close (X / traffic light) destroys the window and frees its renderer
+    // process — the app stays alive in the tray and rebuilds the window on
+    // demand (see index.ts showMainWindowAsync). Real exit goes through
     // tray "退出" / app:quit which sets appIsQuitting first.
     this.browserWindow.on('close', (e) => {
       if (appIsQuitting) return;
       e.preventDefault();
-      this.browserWindow.hide();
+      this.browserWindow.destroy();
       if (isMac) {
         app.dock.hide();
       }
@@ -118,7 +120,10 @@ export class DesktopWindow {
 
     this.browserWindow.on('ready-to-show', () => {
       if (options.startHidden) {
-        this.browserWindow.hide();
+        // Start hidden (login autostart): destroy the window like close-to-
+        // tray does, so no renderer process stays resident. Rebuild on tray
+        // click via showMainWindowAsync.
+        this.browserWindow.destroy();
         if (isMac) {
           app.dock.hide();
         }

--- a/apps/desktop/src/main/DesktopWindow.ts
+++ b/apps/desktop/src/main/DesktopWindow.ts
@@ -59,7 +59,7 @@ export function resolveAppIconPath(): string {
  *  3. 应用菜单 `null`，单窗 `autoHideMenuBar: true` — 不占用渲染区域。
  *  4. 注册 `window:minimize / toggle-maximize / close` IPC 监听；
  *     转发 maximize / unmaximize 事件到渲染层，更新图标状态。
- *  5. 点关闭按钮隐藏窗口（托盘保活），真正退出由托盘菜单触发。
+ *  5. 点关闭按钮销毁窗口（托盘保活），真正退出由托盘菜单触发。
  *
  * `main/index.ts` 仅负责 app 生命周期。
  */
@@ -174,14 +174,20 @@ export class DesktopWindow {
 
   /** dev 模式由 electron-vite 注入 URL；生产模式加载本地静态文件 */
   private async loadRenderer(): Promise<void> {
-    const devUrl = process.env['ELECTRON_RENDERER_URL'];
-    if (!app.isPackaged && devUrl) {
-      await this.browserWindow.loadURL(devUrl);
-      return;
+    try {
+      const devUrl = process.env['ELECTRON_RENDERER_URL'];
+      if (!app.isPackaged && devUrl) {
+        await this.browserWindow.loadURL(devUrl);
+        return;
+      }
+      await this.browserWindow.loadFile(
+        path.join(__dirname, '../renderer/index.html'),
+      );
+    } catch (err) {
+      // Close-to-tray destroy() aborts an in-flight load; same as the pet window.
+      if (this.browserWindow.isDestroyed()) return;
+      throw err;
     }
-    await this.browserWindow.loadFile(
-      path.join(__dirname, '../renderer/index.html'),
-    );
   }
 
   get window(): BrowserWindow {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -181,6 +181,7 @@ async function showMainWindowAsync(): Promise<void> {
       // in the foreground like the existing-window path below.
       app.focus({ steal: true });
     }
+    flushPendingConfigResetNotice();
     return;
   }
   if (process.platform === 'darwin' && !app.dock.isVisible()) {
@@ -199,6 +200,7 @@ async function showMainWindowAsync(): Promise<void> {
   if (process.platform === 'darwin') {
     app.focus({ steal: true });
   }
+  flushPendingConfigResetNotice();
 }
 
 function showMainWindow(): void {
@@ -211,8 +213,10 @@ function sendToMainWindowWhenReady(
   w: BrowserWindow,
   send: (window: BrowserWindow) => void,
 ): void {
+  let sent = false;
   const fire = () => {
-    if (w.isDestroyed()) return;
+    if (sent || w.isDestroyed()) return;
+    sent = true;
     // Small delay so AppShell's listeners are attached after first paint.
     setTimeout(() => {
       if (!w.isDestroyed()) send(w);
@@ -220,9 +224,18 @@ function sendToMainWindowWhenReady(
   };
   if (w.webContents.isLoading()) {
     w.webContents.once('did-finish-load', fire);
+    // Load can finish between isLoading() and once(); don't hang.
+    if (!w.webContents.isLoading()) fire();
     return;
   }
   fire();
+}
+
+function flushPendingConfigResetNotice(): void {
+  if (!pendingConfigResetNotice) return;
+  const main = getMainWindow();
+  if (!main) return;
+  sendToMainWindowWhenReady(main, () => broadcastConfigResetNotice());
 }
 
 async function openSettings(detail?: OpenSettingsPayload): Promise<void> {
@@ -390,17 +403,16 @@ void acquireDesktopInstanceLock().then((gotLock) => {
     }
     resumeLocalRuntimeWatchdog();
 
-    createWindow({ startHidden: shouldStartHidden() });
-    if (pendingConfigResetNotice) {
-      const main = getMainWindow();
-      if (main && !main.isDestroyed()) {
-        const send = () => broadcastConfigResetNotice();
-        if (main.webContents.isLoading()) {
-          main.webContents.once('did-finish-load', send);
-        } else {
-          setTimeout(send, 80);
-        }
+    // Login autostart (openAsHidden): stay tray-only. Creating a window just
+    // to destroy it on ready-to-show still pays for a full dashboard load and
+    // drops IPC (config-reset / deep-link) aimed at that doomed window.
+    if (shouldStartHidden()) {
+      if (process.platform === 'darwin') {
+        app.dock.hide();
       }
+    } else {
+      createWindow();
+      flushPendingConfigResetNotice();
     }
     await syncDesktopPet();
     createTrayPopover({

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -154,7 +154,22 @@ async function showMainWindowAsync(): Promise<void> {
   pokeSyncOnForeground();
   const w = getMainWindow();
   if (!w) {
+    // Window was destroyed on close (tray-resident app). Rebuild it. On
+    // macOS the dock was hidden at close; await the accessory→regular
+    // transform so the freshly built window is not hidden by macOS mid-flight.
+    if (process.platform === 'darwin' && !app.dock.isVisible()) {
+      try {
+        await app.dock.show();
+      } catch {
+        // ignore: window is still created below even if the dock stays hidden
+      }
+    }
     createWindow();
+    if (process.platform === 'darwin') {
+      // Rebuilt window shows on ready-to-show; activate the app so it lands
+      // in the foreground like the existing-window path below.
+      app.focus({ steal: true });
+    }
     return;
   }
   if (process.platform === 'darwin' && !app.dock.isVisible()) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -116,6 +116,7 @@ function registerThemeIpc(): void {
     if (!isTheme(nextTheme) || nextTheme === currentTheme) return;
     currentTheme = nextTheme;
     for (const desktopWindow of windows) {
+      if (desktopWindow.window.isDestroyed()) continue;
       desktopWindow.setThemeBackground(currentTheme);
     }
     for (const window of BrowserWindow.getAllWindows()) {
@@ -143,8 +144,18 @@ function registerShareCardIpc(): void {
 }
 
 function getMainWindow(): BrowserWindow | null {
-  const w = [...windows][0]?.window;
-  return w && !w.isDestroyed() ? w : null;
+  // destroy() marks the BrowserWindow dead before 'closed' removes the
+  // wrapper from the set. Skip (and drop) stale entries so a just-rebuilt
+  // window is still found.
+  for (const wrapper of [...windows]) {
+    const w = wrapper.window;
+    if (!w || w.isDestroyed()) {
+      windows.delete(wrapper);
+      continue;
+    }
+    return w;
+  }
+  return null;
 }
 
 async function showMainWindowAsync(): Promise<void> {
@@ -194,21 +205,33 @@ function showMainWindow(): void {
   void showMainWindowAsync();
 }
 
+/** After a tray rebuild the page may still be loading, and SettingsPanel
+ *  only subscribes in useEffect — wait for both before sending IPC. */
+function sendToMainWindowWhenReady(
+  w: BrowserWindow,
+  send: (window: BrowserWindow) => void,
+): void {
+  const fire = () => {
+    if (w.isDestroyed()) return;
+    // Small delay so AppShell's listeners are attached after first paint.
+    setTimeout(() => {
+      if (!w.isDestroyed()) send(w);
+    }, 50);
+  };
+  if (w.webContents.isLoading()) {
+    w.webContents.once('did-finish-load', fire);
+    return;
+  }
+  fire();
+}
+
 async function openSettings(detail?: OpenSettingsPayload): Promise<void> {
   await showMainWindowAsync();
   const w = getMainWindow();
   if (!w) return;
-  // Defer until the renderer has subscribed (cold start / newly created window).
-  const send = () => {
-    if (w.isDestroyed()) return;
-    w.webContents.send(OPEN_SETTINGS_CHANNEL, detail ?? {});
-  };
-  if (w.webContents.isLoading()) {
-    w.webContents.once('did-finish-load', send);
-  } else {
-    // Small delay so AppShell's onOpenSettings listener is attached.
-    setTimeout(send, 50);
-  }
+  sendToMainWindowWhenReady(w, (window) => {
+    window.webContents.send(OPEN_SETTINGS_CHANNEL, detail ?? {});
+  });
 }
 
 /** Silent login callback: focus window + notify renderer (no settings modal). */
@@ -219,15 +242,9 @@ async function notifyJuejinLinkResult(detail: {
   await showMainWindowAsync();
   const w = getMainWindow();
   if (!w) return;
-  const send = () => {
-    if (w.isDestroyed()) return;
-    w.webContents.send(JUEJIN_LINK_RESULT_CHANNEL, detail);
-  };
-  if (w.webContents.isLoading()) {
-    w.webContents.once('did-finish-load', send);
-  } else {
-    setTimeout(send, 50);
-  }
+  sendToMainWindowWhenReady(w, (window) => {
+    window.webContents.send(JUEJIN_LINK_RESULT_CHANNEL, detail);
+  });
 }
 
 async function handleDeepLinkUrl(raw: string): Promise<void> {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -194,8 +194,8 @@ function showMainWindow(): void {
   void showMainWindowAsync();
 }
 
-function openSettings(detail?: OpenSettingsPayload): void {
-  showMainWindow();
+async function openSettings(detail?: OpenSettingsPayload): Promise<void> {
+  await showMainWindowAsync();
   const w = getMainWindow();
   if (!w) return;
   // Defer until the renderer has subscribed (cold start / newly created window).
@@ -212,11 +212,11 @@ function openSettings(detail?: OpenSettingsPayload): void {
 }
 
 /** Silent login callback: focus window + notify renderer (no settings modal). */
-function notifyJuejinLinkResult(detail: {
+async function notifyJuejinLinkResult(detail: {
   ok: boolean;
   message?: string;
-}): void {
-  showMainWindow();
+}): Promise<void> {
+  await showMainWindowAsync();
   const w = getMainWindow();
   if (!w) return;
   const send = () => {
@@ -236,7 +236,7 @@ async function handleDeepLinkUrl(raw: string): Promise<void> {
     console.warn('[tud-desktop] ignored invalid deep link:', raw);
     // Avoid createWindow before app.whenReady (macOS open-url can be early).
     if (runtimeReady || getMainWindow()) {
-      notifyJuejinLinkResult({
+      void notifyJuejinLinkResult({
         ok: false,
         message: '无效的关联链接',
       });
@@ -258,7 +258,7 @@ async function handleDeepLinkUrl(raw: string): Promise<void> {
   }
   // Silent association (same as CLI): no settings modal. Renderer hides
   // 「关联掘金」via link-changed event; optional toast for success/failure.
-  notifyJuejinLinkResult({
+  void notifyJuejinLinkResult({
     ok: result.ok,
     message: result.ok
       ? undefined
@@ -408,7 +408,7 @@ void acquireDesktopInstanceLock().then((gotLock) => {
       if (runtimeReady) {
         void handleDeepLinkUrl(url);
       } else {
-        notifyJuejinLinkResult({
+        void notifyJuejinLinkResult({
           ok: false,
           message: '本地服务未就绪，无法完成关联',
         });

--- a/apps/desktop/src/renderer/components/DesktopPetView.tsx
+++ b/apps/desktop/src/renderer/components/DesktopPetView.tsx
@@ -10,7 +10,7 @@ import {
 import { useAnimatedNumber } from '@/hooks/useAnimatedNumber';
 import { fetchSummary } from '@/lib/api';
 import { formatTokens, formatTokensExact, formatUsd } from '@/lib/format';
-import { getDesktopPet } from '@/pets';
+import { getDesktopPet, loadPetSpritesheet } from '@/pets';
 import {
   DESKTOP_PET_SOURCE_HEIGHT,
   DESKTOP_PET_SOURCE_WIDTH,
@@ -57,6 +57,7 @@ export function DesktopPetView() {
   const [isTokenTooltipOpen, setIsTokenTooltipOpen] = useState(false);
   const [summary, setSummary] = useState<{ totalTokens: number; totalCostUsd: number } | null>(null);
   const [summaryError, setSummaryError] = useState(false);
+  const [spritesheetUrl, setSpritesheetUrl] = useState<string | null>(null);
   const alphaCanvas = useRef<HTMLCanvasElement | null>(null);
   const ignored = useRef(false);
   const dragState = useRef<{
@@ -104,6 +105,18 @@ export function DesktopPetView() {
   }, []);
 
   useEffect(() => { alphaCanvas.current = null; }, [selectedPetId]);
+
+  // Load only the selected pet's atlas; unchosen spritesheets stay unloaded.
+  useEffect(() => {
+    let cancelled = false;
+    setSpritesheetUrl(null);
+    void loadPetSpritesheet(selectedPetId).then((url) => {
+      if (!cancelled) setSpritesheetUrl(url);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPetId]);
 
   useEffect(() => {
     if (!isTokenTooltipOpen) return;
@@ -220,7 +233,7 @@ export function DesktopPetView() {
     <div className="desktop-pet-root" onMouseMove={(event) => {
       if (!dragState.current && event.target === event.currentTarget) setMouseIgnored(true);
     }}>
-      <img alt="" aria-hidden="true" className="hidden" src={pet.spritesheet} onLoad={(event) => loadAlphaMap(event.currentTarget)} />
+      <img alt="" aria-hidden="true" className="hidden" src={spritesheetUrl ?? undefined} onLoad={(event) => loadAlphaMap(event.currentTarget)} />
       <Popover isOpen={isTokenTooltipOpen} onOpenChange={setIsTokenTooltipOpen}>
         <Popover.Trigger
           className="desktop-pet-popover-trigger"
@@ -249,7 +262,7 @@ export function DesktopPetView() {
             style={{
               width,
               height,
-              backgroundImage: `url(${pet.spritesheet})`,
+              backgroundImage: spritesheetUrl ? `url(${spritesheetUrl})` : undefined,
               backgroundPosition: `${-currentFrame * width}px ${-row * height}px`,
               backgroundSize: `${SPRITESHEET_WIDTH * scale}px ${SPRITESHEET_HEIGHT * scale}px`,
               transform: renderedAnimation.mirrorX ? 'scaleX(-1)' : undefined,

--- a/apps/desktop/src/renderer/components/PetRunningLoader.tsx
+++ b/apps/desktop/src/renderer/components/PetRunningLoader.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties } from 'react';
-import { DESKTOP_PETS, getDesktopPet } from '@/pets';
+import { DESKTOP_PETS, getDesktopPet, loadPetSpritesheet } from '@/pets';
 import {
   DESKTOP_PET_SOURCE_HEIGHT,
   DESKTOP_PET_SOURCE_WIDTH,
@@ -40,14 +40,26 @@ export function PetRunningLoader({
   scale?: number;
 }) {
   const [petId, setPetId] = useState(() => pickRandomPetId());
+  const [spritesheets, setSpritesheets] = useState<Record<string, string>>({});
   const spriteRef = useRef<HTMLDivElement>(null);
 
-  // Decode all sheets up front so swaps never flash empty.
+  // Load every atlas up front (the loader swaps pets randomly) so swaps
+  // never flash empty once ready.
   useEffect(() => {
-    for (const pet of DESKTOP_PETS) {
-      const img = new Image();
-      img.src = pet.spritesheet;
-    }
+    let cancelled = false;
+    void Promise.all(
+      DESKTOP_PETS.map((pet) =>
+        loadPetSpritesheet(pet.id).then((url) => ({ id: pet.id, url })),
+      ),
+    ).then((entries) => {
+      if (cancelled) return;
+      setSpritesheets(
+        Object.fromEntries(entries.map((entry) => [entry.id, entry.url])),
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -66,10 +78,12 @@ export function PetRunningLoader({
     const sheetW = CELL_WIDTH * SHEET_COLS * scale;
     const sheetH = CELL_HEIGHT * SHEET_ROWS * scale;
     const pet = getDesktopPet(petId);
+    const sheet = spritesheets[pet.id];
+    if (!sheet) return;
 
     el.style.width = `${width}px`;
     el.style.height = `${height}px`;
-    el.style.backgroundImage = `url(${pet.spritesheet})`;
+    el.style.backgroundImage = `url(${sheet})`;
     el.style.backgroundSize = `${sheetW}px ${sheetH}px`;
     el.style.backgroundRepeat = 'no-repeat';
 
@@ -118,7 +132,7 @@ export function PetRunningLoader({
 
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [petId, scale]);
+  }, [petId, scale, spritesheets]);
 
   const pet = getDesktopPet(petId);
   const width = Math.round(CELL_WIDTH * scale);

--- a/apps/desktop/src/renderer/pets.ts
+++ b/apps/desktop/src/renderer/pets.ts
@@ -1,12 +1,7 @@
-import clickSpritesheet from '@/assets/pets/click/click-spritesheet.webp';
-import hawkingSpritesheet from '@/assets/pets/hawking/hawking-spritesheet.webp';
-import yoyoSpritesheet from '@/assets/pets/yoyo/yoyo-spritesheet.webp';
-
 export interface DesktopPetDefinition {
   id: string;
   displayName: string;
   description: string;
-  spritesheet: string;
   glow: {
     primary: string;
     accent: string;
@@ -15,14 +10,15 @@ export interface DesktopPetDefinition {
 
 /**
  * The desktop-pet catalog. To add an IP, place its v2 atlas under
- * `assets/pets/<id>/` and register its display metadata and WebP here.
+ * `assets/pets/<id>/` and register its display metadata and WebP loader here.
+ * Spritesheets are loaded on demand (loadPetSpritesheet) so the pet renderer
+ * only decodes the atlas it actually displays.
  */
 export const DESKTOP_PETS: DesktopPetDefinition[] = [
   {
     id: 'hawking',
     displayName: 'Hawking',
     description: '橙色、锐眼的土星伙伴',
-    spritesheet: hawkingSpritesheet,
     glow: {
       primary: '#ff7a1a',
       accent: '#ffd21f',
@@ -32,7 +28,6 @@ export const DESKTOP_PETS: DesktopPetDefinition[] = [
     id: 'yoyo',
     displayName: 'Yoyo',
     description: '蓝色、胸前带星标的伙伴',
-    spritesheet: yoyoSpritesheet,
     glow: {
       primary: '#2f7df6',
       accent: '#ffd84a',
@@ -42,7 +37,6 @@ export const DESKTOP_PETS: DesktopPetDefinition[] = [
     id: 'click',
     displayName: 'Click',
     description: '青绿色、亮眼的克里克伙伴',
-    spritesheet: clickSpritesheet,
     glow: {
       primary: '#51d6a2',
       accent: '#ff7b8d',
@@ -52,4 +46,19 @@ export const DESKTOP_PETS: DesktopPetDefinition[] = [
 
 export function getDesktopPet(id: string): DesktopPetDefinition {
   return DESKTOP_PETS.find((pet) => pet.id === id) ?? DESKTOP_PETS[0]!;
+}
+
+/** Dynamic imports so an unchosen pet's WebP is never loaded by the pet window. */
+const SPRITESHEET_LOADERS: Record<string, () => Promise<string>> = {
+  hawking: () =>
+    import('@/assets/pets/hawking/hawking-spritesheet.webp').then((m) => m.default),
+  yoyo: () =>
+    import('@/assets/pets/yoyo/yoyo-spritesheet.webp').then((m) => m.default),
+  click: () =>
+    import('@/assets/pets/click/click-spritesheet.webp').then((m) => m.default),
+};
+
+export function loadPetSpritesheet(id: string): Promise<string> {
+  const loader = SPRITESHEET_LOADERS[id] ?? SPRITESHEET_LOADERS.hawking!;
+  return loader();
 }


### PR DESCRIPTION
- 主窗口关闭或启动隐藏时销毁窗口及渲染进程，从托盘显示时按需重建
- 宠物禁用时销毁宠物窗口，释放独立渲染进程
- 宠物 spritesheet 改为按需动态加载，未选中的 WebP 不再加载