### PR TITLE
feat(cli): add Linux systemd user service for background autostart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 dist-test/
 out/
+output/
+output_resource/
+release/
 *.tsbuildinfo
 
 # Tooling caches

--- a/CLI.md
+++ b/CLI.md
@@ -28,12 +28,14 @@ npx @juejin-opensource/jusage start
 
 ## 快速开始
 
-推荐用后台服务启动（常驻，支持开机自启，macOS / Windows）：
+推荐用后台服务启动（常驻，支持开机自启，macOS / Windows / Linux）：
 
 ```bash
 jusage service start
 # 面板: http://127.0.0.1:8452
 ```
+
+Linux 后台服务依赖 systemd 用户实例（`systemctl --user`）。无 systemd 时改用 `jusage start` 前台运行。
 
 首次启动会写入数据目录 `~/.ai-usage/`，尝试注册 Claude / Codex Hook，并同步本地用量。
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -30,7 +30,7 @@ npx @juejin-opensource/jusage@latest service stop
 **Case 3：`config.json` 格式坏了（parse 失败）**
 
 ```bash
-# macOS
+# macOS / Linux
 python3 -m json.tool ~/.ai-usage/config.json
 # 修不好则备份后让应用重建（需重新登录）
 mv ~/.ai-usage/config.json ~/.ai-usage/config.json.bak
@@ -47,7 +47,7 @@ Move-Item $env:USERPROFILE\.ai-usage\config.json $env:USERPROFILE\.ai-usage\conf
 **Case 4：残留进程 / 锁文件**
 
 ```bash
-# macOS
+# macOS / Linux
 killall "Juejin Usage" 2>/dev/null; pkill -f jusage || true
 rm -f ~/.ai-usage/tud.pid
 ```
@@ -57,4 +57,29 @@ rm -f ~/.ai-usage/tud.pid
 Remove-Item $env:USERPROFILE\.ai-usage\tud.pid -ErrorAction SilentlyContinue
 ```
 
-然后重开。日志：macOS `~/.ai-usage/logs/`，Windows `%USERPROFILE%\.ai-usage\logs\`。
+然后重开。日志：macOS / Linux `~/.ai-usage/logs/`，Windows `%USERPROFILE%\.ai-usage\logs\`。
+
+### Linux 上 `jusage service start` 失败？
+
+CLI 后台服务在 Linux 上走 systemd 用户服务。若提示 `systemctl --user` 不可用，可改用前台运行：
+
+```bash
+jusage start
+```
+
+WSL 需先启用 systemd。在 `/etc/wsl.conf` 写入：
+
+```
+[boot]
+systemd=true
+```
+
+然后执行 `wsl --shutdown`，再打开发行版。
+
+排障：
+
+```bash
+journalctl --user -u jusage
+# 以及
+less ~/.ai-usage/logs/daemon.log
+```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Juejin Usage 提供 macOS / Windows 桌面客户端，安装即用，无需额�
 
 ## ⌨️ CLI 使用
 
-需要 Node.js >= 20。安装后后台启动即可打开本地面板：
+需要 Node.js >= 20。macOS / Windows / Linux 安装后后台启动即可打开本地面板：
 
 ```bash
 npm i -g @juejin-opensource/jusage

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,12 +12,14 @@ npm i -g @juejin-opensource/jusage
 
 ## 快速开始
 
-推荐用后台服务启动（常驻，支持开机自启，macOS / Windows）：
+推荐用后台服务启动（常驻，支持开机自启，macOS / Windows / Linux）：
 
 ```bash
 jusage service start
 # 面板: http://127.0.0.1:8452
 ```
+
+Linux 后台服务依赖 systemd 用户实例（`systemctl --user`）。无 systemd 时改用 `jusage start` 前台运行。
 
 首次启动会写入数据目录 `~/.ai-usage/`，尝试注册 Claude / Codex Hook，并同步本地用量。
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,8 @@
     "sync": "node ./bin/jusage.js sync",
     "status": "node ./bin/jusage.js status",
     "upload": "node ./bin/jusage.js upload",
-    "service": "node ./bin/jusage.js service"
+    "service": "node ./bin/jusage.js service",
+    "test": "tsc -p tsconfig.json && node --test \"test/**/*.test.js\""
   },
   "dependencies": {
     "@juejin-opensource/jusage-core": "workspace:*"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -181,7 +181,7 @@ Commands:
   status                查看 CLI / 面板当前启动状态
   sync                  手动同步本地用量数据
   upload                上报数据到云端
-  service <action>      后台服务与开机自启（macOS / Windows）
+  service <action>      后台服务与开机自启（macOS / Windows / Linux）
                         action: start | stop | status
   help                  显示帮助
 

--- a/packages/cli/src/service-linux.ts
+++ b/packages/cli/src/service-linux.ts
@@ -1,0 +1,156 @@
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+import { daemonLogPath, ensureDaemonLogDir, resolveServiceCommand } from './daemon.js';
+
+export const LINUX_UNIT_NAME = 'jusage';
+
+const SYSTEMD_HINT =
+  '可用 jusage start 前台运行。若在 WSL，请在 /etc/wsl.conf 启用 [boot] systemd=true 后执行 wsl --shutdown 再打开。';
+
+function systemdConfigHome(): string {
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  return xdg || join(homedir(), '.config');
+}
+
+export function linuxUnitPath(): string {
+  return join(systemdConfigHome(), 'systemd', 'user', `${LINUX_UNIT_NAME}.service`);
+}
+
+function defaultPath(nodePath: string, home: string): string {
+  const parts = [
+    dirname(nodePath),
+    '/usr/local/bin',
+    join(home, '.local', 'bin'),
+    '/usr/bin',
+    '/bin',
+    '/usr/sbin',
+    '/sbin',
+  ];
+  return [...new Set(parts)].join(':');
+}
+
+/** Quote a systemd unit value; `%` is a specifier and must be doubled. */
+export function systemdQuote(value: string): string {
+  const escapedPct = value.replace(/%/g, '%%');
+  if (/^[A-Za-z0-9_./:@+=,-]+$/.test(value)) return escapedPct;
+  return `"${escapedPct.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function envLine(key: string, value: string): string {
+  const assignment = `${key}=${value.replace(/%/g, '%%')}`;
+  if (/^[A-Za-z0-9_]+=[A-Za-z0-9_./:@+=,-]+$/.test(`${key}=${value}`)) {
+    return `Environment=${key}=${value}`;
+  }
+  return `Environment="${assignment.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+export function buildLinuxUnit(
+  nodePath: string,
+  args: readonly string[],
+  home: string,
+  logPath: string,
+): string {
+  const execStart = [nodePath, ...args].map(systemdQuote).join(' ');
+  const quotedHome = systemdQuote(home);
+  const output = `append:${systemdQuote(logPath)}`;
+  return `[Unit]
+Description=Juejin Usage CLI
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=${execStart}
+WorkingDirectory=${quotedHome}
+Restart=always
+RestartSec=3
+${envLine('HOME', home)}
+${envLine('LANG', 'en_US.UTF-8')}
+${envLine('LC_ALL', 'en_US.UTF-8')}
+${envLine('PATH', defaultPath(nodePath, home))}
+StandardOutput=${output}
+StandardError=${output}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function isCommandMissing(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === 'ENOENT'
+  );
+}
+
+function runSystemctl(args: string[]): { ok: boolean; stderr: string; missing: boolean } {
+  const result = spawnSync('systemctl', ['--user', ...args], {
+    encoding: 'utf8',
+    timeout: 8_000,
+  });
+  const missing = isCommandMissing(result.error);
+  const stderr = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim();
+  return { ok: result.status === 0 && !missing, stderr, missing };
+}
+
+function assertSystemdUser(): void {
+  const probe = runSystemctl(['show-environment']);
+  if (probe.missing) {
+    throw new Error(
+      `jusage service 在 Linux 上需要 systemd 用户服务，未找到 systemctl。${SYSTEMD_HINT}`,
+    );
+  }
+  if (!probe.ok) {
+    throw new Error(
+      `jusage service 在 Linux 上需要可用的 systemd 用户实例（systemctl --user）。${probe.stderr ? ` ${probe.stderr}` : ''} ${SYSTEMD_HINT}`,
+    );
+  }
+}
+
+export async function isLinuxAutostartRegistered(): Promise<boolean> {
+  return existsSync(linuxUnitPath());
+}
+
+export async function registerLinuxAutostart(cliBinPath: string, dataDir: string): Promise<void> {
+  assertSystemdUser();
+  await ensureDaemonLogDir(dataDir);
+
+  // Stop the previous unit before rewrite so Restart=always does not fight us.
+  await unregisterLinuxAutostart();
+
+  const unitPath = linuxUnitPath();
+  await mkdir(dirname(unitPath), { recursive: true });
+  const { nodePath, args } = resolveServiceCommand(cliBinPath);
+  await writeFile(unitPath, buildLinuxUnit(nodePath, args, homedir(), daemonLogPath(dataDir)), 'utf8');
+
+  const reloaded = runSystemctl(['daemon-reload']);
+  if (!reloaded.ok) {
+    throw new Error(`注册 Linux 自启失败（daemon-reload）: ${reloaded.stderr || 'systemctl 返回非零'}`);
+  }
+
+  const enabled = runSystemctl(['enable', '--now', `${LINUX_UNIT_NAME}.service`]);
+  if (!enabled.ok) {
+    throw new Error(`注册 Linux 自启失败: ${enabled.stderr || 'systemctl enable --now 返回非零'}`);
+  }
+}
+
+export async function unregisterLinuxAutostart(): Promise<void> {
+  runSystemctl(['disable', '--now', `${LINUX_UNIT_NAME}.service`]);
+  runSystemctl(['stop', `${LINUX_UNIT_NAME}.service`]);
+
+  const unitPath = linuxUnitPath();
+  if (existsSync(unitPath)) {
+    try {
+      await unlink(unitPath);
+    } catch {
+      // ignore
+    }
+  }
+
+  runSystemctl(['daemon-reload']);
+}

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -17,6 +17,11 @@ import {
   waitForServiceReady,
 } from './daemon.js';
 import {
+  isLinuxAutostartRegistered,
+  registerLinuxAutostart,
+  unregisterLinuxAutostart,
+} from './service-linux.js';
+import {
   isMacosAutostartRegistered,
   registerMacosAutostart,
   unregisterMacosAutostart,
@@ -27,16 +32,19 @@ import {
   unregisterWindowsAutostart,
 } from './service-windows.js';
 
-function assertSupportedPlatform(): 'darwin' | 'win32' {
+type ServicePlatform = 'darwin' | 'win32' | 'linux';
+
+function assertSupportedPlatform(): ServicePlatform {
   const p = platform();
-  if (p === 'darwin' || p === 'win32') return p;
-  throw new Error(`jusage service 仅支持 macOS 与 Windows（当前: ${p}）`);
+  if (p === 'darwin' || p === 'win32' || p === 'linux') return p;
+  throw new Error(`jusage service 仅支持 macOS、Windows 与 Linux（当前: ${p}）`);
 }
 
 async function isAutostartRegistered(): Promise<boolean> {
   const p = assertSupportedPlatform();
   if (p === 'darwin') return isMacosAutostartRegistered();
-  return isWindowsAutostartRegistered();
+  if (p === 'win32') return isWindowsAutostartRegistered();
+  return isLinuxAutostartRegistered();
 }
 
 async function registerAutostart(cliBinPath: string, dataDir: string): Promise<void> {
@@ -45,7 +53,11 @@ async function registerAutostart(cliBinPath: string, dataDir: string): Promise<v
     await registerMacosAutostart(cliBinPath, dataDir);
     return;
   }
-  await registerWindowsAutostart(cliBinPath, dataDir);
+  if (p === 'win32') {
+    await registerWindowsAutostart(cliBinPath, dataDir);
+    return;
+  }
+  await registerLinuxAutostart(cliBinPath, dataDir);
 }
 
 async function unregisterAutostart(): Promise<void> {
@@ -54,7 +66,11 @@ async function unregisterAutostart(): Promise<void> {
     await unregisterMacosAutostart();
     return;
   }
-  await unregisterWindowsAutostart();
+  if (p === 'win32') {
+    await unregisterWindowsAutostart();
+    return;
+  }
+  await unregisterLinuxAutostart();
 }
 
 export async function cmdServiceStart(cliBinPath: string, daysAgo?: number): Promise<void> {

--- a/packages/cli/test/service-linux.test.js
+++ b/packages/cli/test/service-linux.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildLinuxUnit, systemdQuote } from '../dist/service-linux.js';
+
+test('buildLinuxUnit writes ExecStart, Restart, and log paths', () => {
+  const unit = buildLinuxUnit(
+    '/usr/bin/node',
+    ['/usr/lib/node_modules/@juejin-opensource/jusage/bin/jusage.js', 'start'],
+    '/home/dev',
+    '/home/dev/.ai-usage/logs/daemon.log',
+  );
+
+  assert.match(
+    unit,
+    /ExecStart=\/usr\/bin\/node \/usr\/lib\/node_modules\/@juejin-opensource\/jusage\/bin\/jusage\.js start/,
+  );
+  assert.match(unit, /^Restart=always$/m);
+  assert.match(unit, /^RestartSec=3$/m);
+  assert.match(unit, /^WorkingDirectory=\/home\/dev$/m);
+  assert.match(unit, /^Environment=HOME=\/home\/dev$/m);
+  assert.match(unit, /StandardOutput=append:\/home\/dev\/\.ai-usage\/logs\/daemon\.log/);
+  assert.match(unit, /StandardError=append:\/home\/dev\/\.ai-usage\/logs\/daemon\.log/);
+  assert.match(unit, /^WantedBy=default\.target$/m);
+  assert.match(unit, /\/home\/dev\/\.local\/bin/);
+});
+
+test('systemdQuote and buildLinuxUnit escape spaces and percent', () => {
+  assert.equal(systemdQuote('/usr/bin/node'), '/usr/bin/node');
+  assert.equal(systemdQuote('/home/foo bar/node'), '"/home/foo bar/node"');
+  assert.equal(systemdQuote('/tmp/100%ready/node'), '"/tmp/100%%ready/node"');
+
+  const unit = buildLinuxUnit(
+    '/home/foo bar/node',
+    ['/home/foo bar/jusage.js', 'start'],
+    '/home/foo bar',
+    '/home/foo bar/.ai-usage/logs/daemon.log',
+  );
+  assert.match(unit, /ExecStart="\/home\/foo bar\/node" "\/home\/foo bar\/jusage\.js" start/);
+  assert.match(unit, /WorkingDirectory="\/home\/foo bar"/);
+  assert.match(unit, /StandardOutput=append:"\/home\/foo bar\/\.ai-usage\/logs\/daemon\.log"/);
+});


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [x] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 无关联 Issue。

### 💡 需求背景和解决方案

> 1. `jusage service` 原先只支持 macOS（launchd）和 Windows（计划任务），Linux 上直接被 `assertSupportedPlatform` 拒绝，无法后台常驻 / 开机自启。
> 2. 新增 `service-linux.ts`：用 systemd **用户**单元（`~/.config/systemd/user/jusage.service`，尊重 `XDG_CONFIG_HOME`）实现与 macOS/Windows 同一套 `service start | stop | status`。注册前探测 `systemctl --user`；无 systemd 时给出前台 `jusage start` 与 WSL 启用 systemd 的提示。
> 3. unit 内容由 `buildLinuxUnit` 生成：`Type=simple`、`Restart=always`、日志 append 到 `~/.ai-usage/logs/daemon.log`；路径含空格 / `%` 时按 systemd 规则转义。重写 unit 前先 `unregister`，避免 `Restart=always` 和新进程打架。
> 4. 文档（根 README / CLI.md / packages/cli README / FAQ）补上 Linux 与 WSL 排障。CLI 增加 `test` 脚本，覆盖 unit 生成与 quoting。`.gitignore` 顺带忽略本地 `output/`、`output_resource/`、`release/`。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Add Linux support for `jusage service` via a systemd user unit, with a clear fallback when systemd is unavailable (including WSL). |
| 🇨🇳 中文 | Linux 上 `jusage service` 走 systemd 用户服务实现后台与开机自启；无 systemd（含未启用的 WSL）时给出改用前台 `jusage start` 的提示。 |

### ✅ 验证

- Linux（有 systemd 用户实例）：`jusage service start` 后面板 `http://127.0.0.1:8452` 可开；`systemctl --user status jusage` 为 active；重启用户会话后仍会拉起。`jusage service status` 显示已注册；`jusage service stop` 后单元取消、进程退出。
- 无 systemd / `systemctl --user` 不可用：`jusage service start` 应失败并提示改用 `jusage start`；WSL 可按 FAQ 在 `/etc/wsl.conf` 启用 systemd 后再试。
- macOS / Windows：`jusage service start|stop|status` 行为与原来一致。
- `pnpm --filter @juejin-opensource/jusage test`：unit 生成与空格/`%` 转义用例通过。

Made with [Cursor](https://cursor.com)