### PR TITLE
✨ 新增桌面端开机静默启动功能

### DIFF
--- a/apps/desktop/src/main/autostart.ts
+++ b/apps/desktop/src/main/autostart.ts
@@ -99,20 +99,18 @@ async function writePrefs(prefs: DesktopPrefs): Promise<void> {
   await writeFile(prefsPath(), `${JSON.stringify(prefs, null, 2)}\n`, 'utf8');
 }
 
+/** Frozen at init: was *this* process started as a silent login launch? */
+let silentThisLaunch = false;
+
 function setOsLoginItem(enabled: boolean, launchHidden: boolean): void {
   if (!app.isPackaged) return;
-  if (process.platform === 'darwin') {
-    // openAsHidden / wasOpenedAsHidden 仅 macOS 支持。
-    app.setLoginItemSettings({
-      openAtLogin: enabled,
-      openAsHidden: launchHidden,
-    });
-    return;
-  }
-  // Windows/Linux：openAsHidden 会被忽略，改为让登录项命令携带
-  // --hidden 参数，启动时经 shouldStartHidden() 检测 process.argv。
+  // Windows: openAsHidden is ignored; --hidden is the real signal.
+  // macOS 13+ SMAppService also ignores openAsHidden (wasOpenedAsHidden stays
+  // false). Pass --hidden on every platform and still set openAsHidden for
+  // older macOS login-item APIs.
   app.setLoginItemSettings({
     openAtLogin: enabled,
+    openAsHidden: launchHidden,
     args: launchHidden ? ['--hidden'] : [],
   });
 }
@@ -202,27 +200,30 @@ export async function initAutostartOnLaunch(): Promise<boolean> {
   const pref = await loadAutostartPref();
   if (pref.isFirstRun) {
     await applyAutostart(true);
+    silentThisLaunch = detectSilentThisLaunch(true);
     return true;
   }
   setOsLoginItem(pref.openAtLogin, pref.launchHidden);
+  silentThisLaunch = detectSilentThisLaunch(pref.launchHidden);
   return pref.openAtLogin;
 }
 
-/**
- * True when OS launched us via a silent login item (tray-only startup).
- * macOS reports it via wasOpenedAsHidden; Windows/Linux detect the --hidden
- * arg that setOsLoginItem registers on the login-item command line.
- */
-export function shouldStartHidden(): boolean {
+function detectSilentThisLaunch(launchHidden: boolean): boolean {
   if (!app.isPackaged) return false;
+  if (process.argv.includes('--hidden')) return true;
   try {
-    if (process.platform === 'darwin') {
-      return Boolean(app.getLoginItemSettings().wasOpenedAsHidden);
-    }
-    return process.argv.includes('--hidden');
+    if (process.platform !== 'darwin') return false;
+    const settings = app.getLoginItemSettings();
+    if (settings.wasOpenedAsHidden) return true;
+    return Boolean(settings.wasOpenedAtLogin) && launchHidden;
   } catch {
     return false;
   }
+}
+
+/** True when *this* process was launched as a tray-only login item. */
+export function shouldStartHidden(): boolean {
+  return silentThisLaunch;
 }
 
 export function registerAutostartIpc(): void {

--- a/apps/desktop/src/main/autostart.ts
+++ b/apps/desktop/src/main/autostart.ts
@@ -12,6 +12,8 @@ import { join } from 'node:path';
 
 const AUTOSTART_GET_CHANNEL = 'autostart:get';
 const AUTOSTART_SET_CHANNEL = 'autostart:set';
+const AUTOSTART_GET_HIDDEN_CHANNEL = 'autostart:get-hidden';
+const AUTOSTART_SET_HIDDEN_CHANNEL = 'autostart:set-hidden';
 
 export interface DesktopPetPosition {
   x: number;
@@ -35,12 +37,15 @@ export const DEFAULT_DESKTOP_PET_AUTO_MOVE_INTERVAL_MINUTES = 2;
 
 interface DesktopPrefs {
   openAtLogin: boolean;
+  /** 开机自启时是否静默启动（仅托盘，不显示主窗口）。默认开启。 */
+  launchHidden: boolean;
   desktopPet?: DesktopPetPref;
 }
 
 export interface AutostartPref {
   openAtLogin: boolean;
   isFirstRun: boolean;
+  launchHidden: boolean;
 }
 
 function prefsPath(): string {
@@ -60,6 +65,9 @@ async function readPrefsFile(): Promise<DesktopPrefs | null> {
       && Number.isFinite(desktopPet.position.y);
     return {
       openAtLogin: parsed.openAtLogin,
+      launchHidden: typeof parsed.launchHidden === 'boolean'
+        ? parsed.launchHidden
+        : true,
       desktopPet: desktopPet && typeof desktopPet.enabled === 'boolean'
         ? {
             enabled: desktopPet.enabled,
@@ -91,27 +99,68 @@ async function writePrefs(prefs: DesktopPrefs): Promise<void> {
   await writeFile(prefsPath(), `${JSON.stringify(prefs, null, 2)}\n`, 'utf8');
 }
 
-function setOsLoginItem(enabled: boolean): void {
+function setOsLoginItem(enabled: boolean, launchHidden: boolean): void {
   if (!app.isPackaged) return;
+  if (process.platform === 'darwin') {
+    // openAsHidden / wasOpenedAsHidden 仅 macOS 支持。
+    app.setLoginItemSettings({
+      openAtLogin: enabled,
+      openAsHidden: launchHidden,
+    });
+    return;
+  }
+  // Windows/Linux：openAsHidden 会被忽略，改为让登录项命令携带
+  // --hidden 参数，启动时经 shouldStartHidden() 检测 process.argv。
   app.setLoginItemSettings({
     openAtLogin: enabled,
-    openAsHidden: true,
+    args: launchHidden ? ['--hidden'] : [],
   });
 }
 
 export async function loadAutostartPref(): Promise<AutostartPref> {
   const existing = await readPrefsFile();
   if (!existing) {
-    return { openAtLogin: true, isFirstRun: true };
+    return { openAtLogin: true, isFirstRun: true, launchHidden: true };
   }
-  return { openAtLogin: existing.openAtLogin, isFirstRun: false };
+  return {
+    openAtLogin: existing.openAtLogin,
+    isFirstRun: false,
+    launchHidden: existing.launchHidden,
+  };
 }
 
-export async function applyAutostart(enabled: boolean): Promise<boolean> {
+export async function applyAutostart(
+  enabled: boolean,
+  launchHidden?: boolean,
+): Promise<boolean> {
   const existing = await readPrefsFile();
-  await writePrefs({ openAtLogin: enabled, desktopPet: existing?.desktopPet });
-  setOsLoginItem(enabled);
+  const hidden = launchHidden ?? existing?.launchHidden ?? true;
+  await writePrefs({
+    openAtLogin: enabled,
+    launchHidden: hidden,
+    desktopPet: existing?.desktopPet,
+  });
+  setOsLoginItem(enabled, hidden);
   return enabled;
+}
+
+/** 读取「开机静默启动」偏好，默认开启。 */
+export async function loadLaunchHidden(): Promise<boolean> {
+  const existing = await readPrefsFile();
+  return existing?.launchHidden ?? true;
+}
+
+/** 切换「开机静默启动」偏好并同步到系统登录项。 */
+export async function setLaunchHidden(hidden: boolean): Promise<boolean> {
+  const existing = await readPrefsFile();
+  const openAtLogin = existing?.openAtLogin ?? true;
+  await writePrefs({
+    openAtLogin,
+    launchHidden: hidden,
+    desktopPet: existing?.desktopPet,
+  });
+  setOsLoginItem(openAtLogin, hidden);
+  return hidden;
 }
 
 export async function loadDesktopPetPref(): Promise<DesktopPetPref> {
@@ -130,6 +179,7 @@ export async function saveDesktopPetPref(pref: DesktopPetPref): Promise<DesktopP
   const existing = await readPrefsFile();
   await writePrefs({
     openAtLogin: existing?.openAtLogin ?? true,
+    launchHidden: existing?.launchHidden ?? true,
     desktopPet: pref,
   });
   return pref;
@@ -154,15 +204,22 @@ export async function initAutostartOnLaunch(): Promise<boolean> {
     await applyAutostart(true);
     return true;
   }
-  setOsLoginItem(pref.openAtLogin);
+  setOsLoginItem(pref.openAtLogin, pref.launchHidden);
   return pref.openAtLogin;
 }
 
-/** True when OS launched us via login item with openAsHidden. */
+/**
+ * True when OS launched us via a silent login item (tray-only startup).
+ * macOS reports it via wasOpenedAsHidden; Windows/Linux detect the --hidden
+ * arg that setOsLoginItem registers on the login-item command line.
+ */
 export function shouldStartHidden(): boolean {
   if (!app.isPackaged) return false;
   try {
-    return Boolean(app.getLoginItemSettings().wasOpenedAsHidden);
+    if (process.platform === 'darwin') {
+      return Boolean(app.getLoginItemSettings().wasOpenedAsHidden);
+    }
+    return process.argv.includes('--hidden');
   } catch {
     return false;
   }
@@ -182,9 +239,22 @@ export function registerAutostartIpc(): void {
     }
     return applyAutostart(enabled);
   });
+
+  ipcMain.removeHandler(AUTOSTART_GET_HIDDEN_CHANNEL);
+  ipcMain.handle(AUTOSTART_GET_HIDDEN_CHANNEL, async () => loadLaunchHidden());
+
+  ipcMain.removeHandler(AUTOSTART_SET_HIDDEN_CHANNEL);
+  ipcMain.handle(AUTOSTART_SET_HIDDEN_CHANNEL, async (_event, hidden: unknown) => {
+    if (typeof hidden !== 'boolean') {
+      throw new Error('launchHidden must be a boolean');
+    }
+    return setLaunchHidden(hidden);
+  });
 }
 
 export function unregisterAutostartIpc(): void {
   ipcMain.removeHandler(AUTOSTART_GET_CHANNEL);
   ipcMain.removeHandler(AUTOSTART_SET_CHANNEL);
+  ipcMain.removeHandler(AUTOSTART_GET_HIDDEN_CHANNEL);
+  ipcMain.removeHandler(AUTOSTART_SET_HIDDEN_CHANNEL);
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -445,6 +445,10 @@ void acquireDesktopInstanceLock().then((gotLock) => {
     }
 
     app.on('activate', () => {
+      // macOS emits activate at login launch as well as dock-click. A silent
+      // login start has no window yet; creating one here would undo tray-only
+      // startup. Dock is hidden in that mode — later opens go through the tray.
+      if (shouldStartHidden() && !getMainWindow()) return;
       showMainWindow();
     });
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -27,6 +27,8 @@ const THEME_SET_CHANNEL = 'theme:set';
 const THEME_CHANGED_CHANNEL = 'theme:changed';
 const AUTOSTART_GET_CHANNEL = 'autostart:get';
 const AUTOSTART_SET_CHANNEL = 'autostart:set';
+const AUTOSTART_GET_HIDDEN_CHANNEL = 'autostart:get-hidden';
+const AUTOSTART_SET_HIDDEN_CHANNEL = 'autostart:set-hidden';
 const DESKTOP_PET_GET_CHANNEL = 'desktop-pet:get';
 const DESKTOP_PET_SET_ENABLED_CHANNEL = 'desktop-pet:set-enabled';
 const DESKTOP_PET_SET_MOUSE_IGNORE_CHANNEL = 'desktop-pet:set-ignore-mouse-events';
@@ -101,6 +103,12 @@ const tudApi = {
 
   setOpenAtLogin: (enabled: boolean): Promise<boolean> =>
     ipcRenderer.invoke(AUTOSTART_SET_CHANNEL, enabled),
+
+  getLaunchHidden: (): Promise<boolean> =>
+    ipcRenderer.invoke(AUTOSTART_GET_HIDDEN_CHANNEL),
+
+  setLaunchHidden: (hidden: boolean): Promise<boolean> =>
+    ipcRenderer.invoke(AUTOSTART_SET_HIDDEN_CHANNEL, hidden),
 
   getDesktopPet: (): Promise<{
     enabled: boolean;

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -796,10 +796,7 @@ function AppSettingsPanel() {
       )}
 
       {cliMode && (
-        <div>
-          <p className="mb-3 text-sm text-muted">
-            开机后在托盘后台启动，可从菜单栏图标打开主窗口。
-          </p>
+        <div className="flex flex-col gap-2">
           <Checkbox
             id="desktop-open-at-login"
             isDisabled={autostartLoading}
@@ -815,21 +812,30 @@ function AppSettingsPanel() {
               开机时自动启动
             </Checkbox.Content>
           </Checkbox>
-          <Checkbox
-            id="desktop-launch-hidden"
-            isDisabled={autostartLoading || !openAtLogin}
-            isSelected={launchHidden}
-            onChange={(checked) => {
-              void onLaunchHiddenChange(checked);
-            }}
-          >
-            <Checkbox.Content>
-              <Checkbox.Control>
-                <Checkbox.Indicator />
-              </Checkbox.Control>
-              开机时静默启动（不显示主窗口，仅托盘）
-            </Checkbox.Content>
-          </Checkbox>
+          {openAtLogin && (
+            <>
+              <Checkbox
+                id="desktop-launch-hidden"
+                isDisabled={autostartLoading}
+                isSelected={launchHidden}
+                onChange={(checked) => {
+                  void onLaunchHiddenChange(checked);
+                }}
+              >
+                <Checkbox.Content>
+                  <Checkbox.Control>
+                    <Checkbox.Indicator />
+                  </Checkbox.Control>
+                  静默启动
+                </Checkbox.Content>
+              </Checkbox>
+              {launchHidden && (
+                <p className="text-xs text-muted">
+                  开机后只出现托盘，不弹出主窗口
+                </p>
+              )}
+            </>
+          )}
         </div>
       )}
 

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -703,6 +703,7 @@ function AppSettingsPanel() {
   const [openAtLogin, setOpenAtLogin] = useState(true);
   const [autostartLoading, setAutostartLoading] = useState(true);
   const [autostartError, setAutostartError] = useState<string | null>(null);
+  const [launchHidden, setLaunchHidden] = useState(true);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -739,6 +740,12 @@ function AppSettingsPanel() {
           setAutostartError(null);
         }
       })
+      .then(() => {
+        if (cancelled) return;
+        return window.tud.getLaunchHidden().then((value) => {
+          if (!cancelled) setLaunchHidden(value);
+        });
+      })
       .catch((e) => {
         if (!cancelled) {
           setAutostartError(
@@ -768,6 +775,19 @@ function AppSettingsPanel() {
     }
   };
 
+  const onLaunchHiddenChange = async (next: boolean) => {
+    const prev = launchHidden;
+    setLaunchHidden(next);
+    try {
+      await window.tud.setLaunchHidden(next);
+    } catch (e) {
+      setLaunchHidden(prev);
+      setAutostartError(
+        e instanceof Error ? e.message : '更新静默启动设置失败',
+      );
+    }
+  };
+
   return (
     <div className="flex h-full flex-col gap-5 overflow-y-auto pr-1">
       {error && <StatusBanner tone="error" title={error} />}
@@ -793,6 +813,21 @@ function AppSettingsPanel() {
                 <Checkbox.Indicator />
               </Checkbox.Control>
               开机时自动启动
+            </Checkbox.Content>
+          </Checkbox>
+          <Checkbox
+            id="desktop-launch-hidden"
+            isDisabled={autostartLoading || !openAtLogin}
+            isSelected={launchHidden}
+            onChange={(checked) => {
+              void onLaunchHiddenChange(checked);
+            }}
+          >
+            <Checkbox.Content>
+              <Checkbox.Control>
+                <Checkbox.Indicator />
+              </Checkbox.Control>
+              开机时静默启动（不显示主窗口，仅托盘）
             </Checkbox.Content>
           </Checkbox>
         </div>

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -32,6 +32,8 @@ declare global {
       onThemeChanged: (callback: (theme: 'light' | 'dark') => void) => () => void;
       getOpenAtLogin: () => Promise<boolean>;
       setOpenAtLogin: (enabled: boolean) => Promise<boolean>;
+      getLaunchHidden: () => Promise<boolean>;
+      setLaunchHidden: (hidden: boolean) => Promise<boolean>;
       getDesktopPet: () => Promise<{
         enabled: boolean;
         selectedPetId: string;


### PR DESCRIPTION
- 新增「开机静默启动」偏好与设置开关（默认开启）：开机自启时仅显示托盘、不弹主窗口
- 跨平台登录项注册：macOS 用 openAsHidden，Windows/Linux 用 --hidden 参数
- 启动时按平台检测静默标记（wasOpenedAsHidden / --hidden），隐藏主窗口到托盘
- 新增 autostart:get-hidden / set-hidden IPC 通道与 preload 桥接