### PR TITLE
fix(cli): rollback failed Linux service registration

### DIFF
--- a/.changeset/tidy-tools-smile.md
+++ b/.changeset/tidy-tools-smile.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage": patch
+---
+
+修复 Linux systemd 服务注册失败后残留 unit，并避免将未启用的服务误报为已注册。

--- a/packages/cli/src/service-linux.ts
+++ b/packages/cli/src/service-linux.ts
@@ -113,7 +113,9 @@ function assertSystemdUser(): void {
 }
 
 export async function isLinuxAutostartRegistered(): Promise<boolean> {
-  return existsSync(linuxUnitPath());
+  const unitPath = linuxUnitPath();
+  if (!existsSync(unitPath)) return false;
+  return runSystemctl(['is-enabled', '--quiet', `${LINUX_UNIT_NAME}.service`]).ok;
 }
 
 export async function registerLinuxAutostart(cliBinPath: string, dataDir: string): Promise<void> {
@@ -130,11 +132,13 @@ export async function registerLinuxAutostart(cliBinPath: string, dataDir: string
 
   const reloaded = runSystemctl(['daemon-reload']);
   if (!reloaded.ok) {
+    await unregisterLinuxAutostart();
     throw new Error(`注册 Linux 自启失败（daemon-reload）: ${reloaded.stderr || 'systemctl 返回非零'}`);
   }
 
   const enabled = runSystemctl(['enable', '--now', `${LINUX_UNIT_NAME}.service`]);
   if (!enabled.ok) {
+    await unregisterLinuxAutostart();
     throw new Error(`注册 Linux 自启失败: ${enabled.stderr || 'systemctl enable --now 返回非零'}`);
   }
 }

--- a/packages/cli/test/service-linux.test.js
+++ b/packages/cli/test/service-linux.test.js
@@ -1,7 +1,68 @@
 import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
 import test from 'node:test';
 
-import { buildLinuxUnit, systemdQuote } from '../dist/service-linux.js';
+import {
+  buildLinuxUnit,
+  isLinuxAutostartRegistered,
+  registerLinuxAutostart,
+  systemdQuote,
+} from '../dist/service-linux.js';
+
+function restoreEnv(name, value) {
+  if (value == null) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function linuxServiceFixture(t, failAction) {
+  const root = await mkdtemp(join(tmpdir(), 'jusage-linux-service-'));
+  const fakeBin = join(root, 'bin');
+  const configHome = join(root, 'config');
+  const unitPath = join(configHome, 'systemd', 'user', 'jusage.service');
+  const previousEnv = {
+    path: process.env.PATH,
+    configHome: process.env.XDG_CONFIG_HOME,
+    failAction: process.env.JUSAGE_TEST_FAIL_ACTION,
+    unitPath: process.env.JUSAGE_TEST_UNIT_PATH,
+  };
+  t.after(async () => {
+    restoreEnv('PATH', previousEnv.path);
+    restoreEnv('XDG_CONFIG_HOME', previousEnv.configHome);
+    restoreEnv('JUSAGE_TEST_FAIL_ACTION', previousEnv.failAction);
+    restoreEnv('JUSAGE_TEST_UNIT_PATH', previousEnv.unitPath);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(
+    join(fakeBin, 'systemctl'),
+    `#!/bin/sh
+action="$2"
+if [ "$JUSAGE_TEST_FAIL_ACTION" = "is-enabled" ] && [ "$action" = "is-enabled" ]; then
+  exit 1
+fi
+if [ "$JUSAGE_TEST_FAIL_ACTION" = "enable" ] && [ "$action" = "enable" ]; then
+  echo "simulated enable failure" >&2
+  exit 1
+fi
+if [ "$JUSAGE_TEST_FAIL_ACTION" = "daemon-reload" ] && [ "$action" = "daemon-reload" ] && [ -f "$JUSAGE_TEST_UNIT_PATH" ]; then
+  echo "simulated reload failure" >&2
+  exit 1
+fi
+exit 0
+`,
+    { encoding: 'utf8', mode: 0o755 },
+  );
+
+  process.env.PATH = `${fakeBin}${delimiter}${previousEnv.path ?? ''}`;
+  process.env.XDG_CONFIG_HOME = configHome;
+  process.env.JUSAGE_TEST_FAIL_ACTION = failAction;
+  process.env.JUSAGE_TEST_UNIT_PATH = unitPath;
+  return { dataDir: join(root, 'data'), unitPath };
+}
 
 test('buildLinuxUnit writes ExecStart, Restart, and log paths', () => {
   const unit = buildLinuxUnit(
@@ -40,3 +101,49 @@ test('systemdQuote and buildLinuxUnit escape spaces and percent', () => {
   assert.match(unit, /WorkingDirectory="\/home\/foo bar"/);
   assert.match(unit, /StandardOutput=append:"\/home\/foo bar\/\.ai-usage\/logs\/daemon\.log"/);
 });
+
+test(
+  'isLinuxAutostartRegistered checks whether systemd enabled the unit',
+  { skip: process.platform === 'win32' },
+  async (t) => {
+    const fixture = await linuxServiceFixture(t, 'is-enabled');
+    await mkdir(dirname(fixture.unitPath), { recursive: true });
+    await writeFile(fixture.unitPath, '[Unit]\nDescription=Juejin Usage CLI\n', 'utf8');
+
+    assert.equal(await isLinuxAutostartRegistered(), false);
+    process.env.JUSAGE_TEST_FAIL_ACTION = '';
+    assert.equal(await isLinuxAutostartRegistered(), true);
+  },
+);
+
+test(
+  'registerLinuxAutostart removes the unit when enable fails',
+  { skip: process.platform === 'win32' },
+  async (t) => {
+    const fixture = await linuxServiceFixture(t, 'enable');
+
+    await assert.rejects(
+      registerLinuxAutostart('/tmp/jusage.js', fixture.dataDir),
+      /注册 Linux 自启失败: simulated enable failure/,
+    );
+
+    assert.equal(existsSync(fixture.unitPath), false);
+    assert.equal(await isLinuxAutostartRegistered(), false);
+  },
+);
+
+test(
+  'registerLinuxAutostart removes the unit when daemon-reload fails',
+  { skip: process.platform === 'win32' },
+  async (t) => {
+    const fixture = await linuxServiceFixture(t, 'daemon-reload');
+
+    await assert.rejects(
+      registerLinuxAutostart('/tmp/jusage.js', fixture.dataDir),
+      /注册 Linux 自启失败（daemon-reload）: simulated reload failure/,
+    );
+
+    assert.equal(existsSync(fixture.unitPath), false);
+    assert.equal(await isLinuxAutostartRegistered(), false);
+  },
+);


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🔗 相关 Issue

无关联 Issue。

### 💡 问题与解决方案

Linux 服务注册会先写入 user unit，再执行 `systemctl --user daemon-reload` 和 `enable --now`。后两步任一步失败时，原实现会抛出错误，但保留已经写入的 unit。此后 `jusage service status` 仅根据文件是否存在判断状态，会把未启用的服务误报为已注册。

本次修改：

1. `daemon-reload` 或 `enable --now` 失败时调用现有注销逻辑，删除残留 unit 并刷新 systemd。
2. 状态检查在确认 unit 存在后，再通过 `systemctl --user is-enabled --quiet jusage.service` 判断是否实际启用。
3. 增加隔离的 Linux 回归测试，分别覆盖未启用的残留 unit、`enable --now` 失败回滚和 `daemon-reload` 失败回滚。

### ✅ 本地验证

- 使用临时 `XDG_CONFIG_HOME` 和伪造的 `systemctl` 稳定复现：注册失败后残留 unit，旧状态判断会误报为已注册。
- `pnpm --filter @juejin-opensource/jusage test`：5/5 通过，新增三个场景均实际执行。
- `pnpm build:cli`：通过。
- `pnpm changeset status`：通过，CLI 包为 patch 变更。
- `git diff --check`：通过。