### PR TITLE
fix(dashboard): prevent cost axis labels from clipping

### DIFF
--- a/.changeset/fix-cost-axis-labels.md
+++ b/.changeset/fix-cost-axis-labels.md
@@ -1,0 +1,7 @@
+---
+"@juejin-opensource/jusage": patch
+"@juejin-opensource/jusage-dashboard": patch
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 Desktop、CLI 与 Web 面板每日趋势费用刻度被裁切，较大金额现在可完整显示。

--- a/apps/desktop/src/renderer/components/DailyUsageTrendCard.tsx
+++ b/apps/desktop/src/renderer/components/DailyUsageTrendCard.tsx
@@ -183,7 +183,7 @@ export const DailyUsageTrendCard = memo(function DailyUsageTrendCard({
                   tickFormatter={(value: number) => formatUsd(value)}
                   tickLine={false}
                   tickMargin={8}
-                  width={58}
+                  width="auto"
                 />
               )}
               <ChartTooltip

--- a/packages/dashboard/src/components/DailyUsageTrendCard.tsx
+++ b/packages/dashboard/src/components/DailyUsageTrendCard.tsx
@@ -183,7 +183,7 @@ export function DailyUsageTrendCard({
                   tickFormatter={(value: number) => formatUsd(value)}
                   tickLine={false}
                   tickMargin={8}
-                  width={58}
+                  width="auto"
                 />
               )}
               <ChartTooltip


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [x] Web

### 🔗 关联 Issue

Closes #35

### 💡 改动说明

每日趋势切换到「费用」后，Y 轴固定使用 `58px` 宽度。Recharts 仍会为隐藏的 tick line 保留默认 tick size，再叠加 `tickMargin={8}`，导致格式化后的四位数刻度 `$1000.00` 超出 SVG 左边界并显示成 `000.00`。

本 PR：

1. 将 Dashboard 与 Desktop renderer 的费用 Y 轴同步改为 Recharts 3.8 原生支持的 `width="auto"`，让轴宽根据实际刻度文本测量。
2. 不设置或修改 `domain`、`ticks`、`tickCount`，继续由当前可见的每日/小时 `costUsd` 数据动态生成范围与 nice ticks。
3. 使用自适应宽度而不是扩大为另一个固定像素值，避免金额进入五位数或格式变化后再次裁切。

显示变化：

- 修改前：`$1000.00` → `000.00`
- 修改后：`$1000.00` 完整显示

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | 修复 Desktop、CLI 与 Web 面板每日趋势费用刻度被裁切，较大金额现在可完整显示。 |
| `@juejin-opensource/jusage-desktop` | patch | 修复 Desktop、CLI 与 Web 面板每日趋势费用刻度被裁切，较大金额现在可完整显示。 |
| `@juejin-opensource/jusage-dashboard` | patch | 修复 Desktop、CLI 与 Web 面板每日趋势费用刻度被裁切，较大金额现在可完整显示。 |

### 🧪 验证

- [x] `pnpm --filter @juejin-opensource/jusage-core build`
- [x] `pnpm --filter @juejin-opensource/jusage-dashboard test`（44/44）
- [x] `pnpm exec changeset status`
- [x] `pnpm build`
- [x] `git diff --check`

补充检查：`pnpm --filter @juejin-opensource/jusage-desktop typecheck` 仍报告主分支既有的 3 个 `src/main/index.ts` 中 `app.dock` 可能为空错误；相关文件未被本 PR 修改，完整 Electron build 已通过。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过
- [x] 已同步修改 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 两份同构代码
- [x] 已执行 `pnpm changeset` 并提交 changeset
- [x] `pnpm build` 通过