### PR TITLE
feat(cli): add --host flag for panel listen address

### DIFF
--- a/.changeset/cli-listen-host.md
+++ b/.changeset/cli-listen-host.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage": minor
+---
+
+CLI 支持 `--host` 指定面板监听地址（默认 127.0.0.1；局域网访问可用 0.0.0.0）。

--- a/CLI.md
+++ b/CLI.md
@@ -70,6 +70,7 @@ jusage start
 
 ```bash
 jusage start --port 8452
+jusage start --host 0.0.0.0          # 局域网可访问；默认 127.0.0.1
 jusage sync --source=claude          # claude | codex | cursor | all
 jusage upload --force                # 忽略云端同步开关，强制上报
 jusage upload --reconcile            # 全量对账后上报

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,6 +55,7 @@ jusage start                  # 或直接 jusage
 ```bash
 jusage service start
 jusage start --port 8452
+jusage start --host 0.0.0.0          # 局域网可访问；默认 127.0.0.1
 jusage sync --source=claude          # claude | codex | cursor | all
 jusage upload --force                # 忽略云端同步开关，强制上报
 jusage upload --reconcile            # 全量对账后上报

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,139 @@
+import { DEFAULT_PORT } from '@juejin-opensource/jusage-core';
+
+export const DEFAULT_HOST = '127.0.0.1';
+
+export function isWildcardListenHost(host: string): boolean {
+  return host === '0.0.0.0' || host === '::';
+}
+
+export function formatListenUrl(host: string, port: number): string {
+  const display = isWildcardListenHost(host) ? DEFAULT_HOST : host;
+  const formatted =
+    display.includes(':') && !display.startsWith('[') ? `[${display}]` : display;
+  return `http://${formatted}:${port}`;
+}
+
+export interface ParsedArgs {
+  command: string;
+  serviceAction?: string;
+  /** Set only when --port is passed. */
+  port?: number;
+  /** Set only when --host is passed. */
+  host?: string;
+  source?: string;
+  force?: boolean;
+  reconcile?: boolean;
+  /** Hidden debug: seed statsSince to N days ago when missing. Not shown in --help. */
+  days?: number;
+}
+
+export function normalizeListenHost(raw: string): string {
+  const host = raw.trim();
+  if (!host) {
+    throw new Error('--host 不能为空，例如 0.0.0.0 或 127.0.0.1');
+  }
+  if (/[\s/?#]/.test(host)) {
+    throw new Error(`无效的 --host: ${raw}`);
+  }
+  return host;
+}
+
+function isFlagToken(value: string | undefined): boolean {
+  return value != null && value.startsWith('-') && value !== '-';
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  let command = args[0] ?? 'start';
+  let serviceAction: string | undefined;
+  let port: number | undefined;
+  let host: string | undefined;
+  let source: string | undefined;
+  let force = false;
+  let reconcile = false;
+  let days: number | undefined;
+
+  if (
+    command === 'help' ||
+    command === '--help' ||
+    command === '-h' ||
+    args.includes('--help') ||
+    args.includes('-h')
+  ) {
+    return { command: 'help', port, host, source, force, reconcile };
+  }
+
+  if (command === 'service') {
+    serviceAction = args[1];
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--port' && args[i + 1]) {
+      port = Number(args[i + 1]) || DEFAULT_PORT;
+      i += 1;
+    } else if (args[i] === '--host') {
+      if (isFlagToken(args[i + 1]) || args[i + 1] == null) {
+        throw new Error('--host 需要地址，例如 0.0.0.0 或 127.0.0.1');
+      }
+      host = normalizeListenHost(args[i + 1]);
+      i += 1;
+    } else if (args[i]?.startsWith('--host=')) {
+      host = normalizeListenHost(args[i].slice('--host='.length));
+    } else if (args[i] === '--source' && args[i + 1]) {
+      source = args[i + 1];
+      i += 1;
+    } else if (args[i]?.startsWith('--source=')) {
+      source = args[i].slice('--source='.length);
+    } else if (args[i] === '--force') {
+      force = true;
+    } else if (args[i] === '--reconcile') {
+      reconcile = true;
+    } else if (args[i] === '--days' && args[i + 1]) {
+      days = Number(args[i + 1]);
+      i += 1;
+    } else if (args[i]?.startsWith('--days=')) {
+      days = Number(args[i].slice('--days='.length));
+    }
+  }
+  if (command.startsWith('-')) command = 'start';
+  return { command, serviceAction, port, host, source, force, reconcile, days };
+}
+
+export function resolveDaysAgo(days: number | undefined): number | undefined {
+  if (days === undefined) return undefined;
+  if (!Number.isInteger(days) || days <= 0) {
+    throw new Error(`--days 须为正整数，收到: ${days}`);
+  }
+  return days;
+}
+
+export function printHelp(): void {
+  console.log(`Usage: jusage <command> [options]
+
+Commands:
+  start                 前台启动本地面板与同步（默认；桌面已运行时为观察模式）
+  stop                  停止当前进程内的服务
+  status                查看 CLI / 面板当前启动状态
+  sync                  手动同步本地用量数据
+  upload                上报数据到云端
+  service <action>      后台服务与开机自启（macOS / Windows / Linux）
+                        action: start | stop | status
+  help                  显示帮助
+
+Options:
+  --port <number>       面板端口（默认 ${DEFAULT_PORT}）
+  --host <address>      面板监听地址（默认 ${DEFAULT_HOST}；局域网访问用 0.0.0.0）
+  --source <name>       sync 数据源：claude | codex | cursor | qoder | trae | gemini | opencode | copilot | antigravity | openclaw | hermes | zcode | pi | kimi | roocode | droid | kiro | cline | amp | qwen | codebuddy | workbuddy | grok | mimo | every-code | omp | kilo-cli | kilocode | goose | zed | warp | all
+  --force               upload 时忽略云端同步开关，强制上报
+  --reconcile           upload 时做全量对账
+  -h, --help            显示帮助
+
+Examples:
+  jusage
+  jusage start --port 8452
+  jusage start --host 0.0.0.0
+  jusage status
+  jusage sync --source=claude
+  jusage upload --force
+  jusage service start`);
+}

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -20,6 +20,8 @@ import {
   writeRuntimeOwner,
 } from '@juejin-opensource/jusage-core';
 
+import { DEFAULT_HOST, formatListenUrl } from './args.js';
+
 export {
   clearPid,
   getRunningOwner,
@@ -52,9 +54,12 @@ async function readLivePid(dataDir: string): Promise<number | null> {
 }
 
 /** True when local-api `/health` returns `{ ok: true }`. */
-export async function probeLocalHealth(port: number): Promise<boolean> {
+export async function probeLocalHealth(
+  port: number,
+  host = DEFAULT_HOST,
+): Promise<boolean> {
   try {
-    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+    const res = await fetch(`${formatListenUrl(host, port)}/health`, {
       signal: AbortSignal.timeout(400),
     });
     if (!res.ok) return false;
@@ -131,20 +136,21 @@ export interface ServiceReady {
 export async function waitForServiceReady(
   dataDir: string,
   port: number,
+  host = DEFAULT_HOST,
   timeoutMs = 15_000,
 ): Promise<ServiceReady> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const pid = await readLivePid(dataDir);
-    if (pid != null) return { pid, health: await probeLocalHealth(port) };
-    if (await probeLocalHealth(port)) {
+    if (pid != null) return { pid, health: await probeLocalHealth(port, host) };
+    if (await probeLocalHealth(port, host)) {
       return { pid: await recoverPidFromHealth(dataDir, port), health: true };
     }
     await new Promise((r) => setTimeout(r, 200));
   }
   const pid = (await readLivePid(dataDir)) ?? (await getRunningPid(dataDir));
-  if (pid != null) return { pid, health: await probeLocalHealth(port) };
-  if (await probeLocalHealth(port)) {
+  if (pid != null) return { pid, health: await probeLocalHealth(port, host) };
+  if (await probeLocalHealth(port, host)) {
     return { pid: await recoverPidFromHealth(dataDir, port), health: true };
   }
   return { pid: null, health: false };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,8 +43,18 @@ import {
   type TudConfig,
 } from '@juejin-opensource/jusage-core';
 
+import {
+  DEFAULT_HOST,
+  formatListenUrl,
+  isWildcardListenHost,
+  parseArgs,
+  printHelp,
+  resolveDaysAgo,
+} from './args.js';
 import { writePid } from './daemon.js';
 import { cmdServiceStart, cmdServiceStatus, cmdServiceStop } from './service.js';
+
+export { parseArgs } from './args.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -112,94 +122,6 @@ function resolveCliBinPath(): string {
   return fileURLToPath(new URL('../bin/jusage.js', import.meta.url));
 }
 
-export function parseArgs(argv: string[]): {
-  command: string;
-  serviceAction?: string;
-  port: number;
-  source?: string;
-  force?: boolean;
-  reconcile?: boolean;
-  /** Hidden debug: seed statsSince to N days ago when missing. Not shown in --help. */
-  days?: number;
-} {
-  const args = argv.slice(2);
-  let command = args[0] ?? 'start';
-  let serviceAction: string | undefined;
-  let port = DEFAULT_PORT;
-  let source: string | undefined;
-  let force = false;
-  let reconcile = false;
-  let days: number | undefined;
-
-  if (command === 'help' || command === '--help' || command === '-h' || args.includes('--help') || args.includes('-h')) {
-    return { command: 'help', port, source, force, reconcile };
-  }
-
-  if (command === 'service') {
-    serviceAction = args[1];
-  }
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--port' && args[i + 1]) {
-      port = Number(args[i + 1]) || DEFAULT_PORT;
-      i += 1;
-    } else if (args[i] === '--source' && args[i + 1]) {
-      source = args[i + 1];
-      i += 1;
-    } else if (args[i]?.startsWith('--source=')) {
-      source = args[i].slice('--source='.length);
-    } else if (args[i] === '--force') {
-      force = true;
-    } else if (args[i] === '--reconcile') {
-      reconcile = true;
-    } else if (args[i] === '--days' && args[i + 1]) {
-      days = Number(args[i + 1]);
-      i += 1;
-    } else if (args[i]?.startsWith('--days=')) {
-      days = Number(args[i].slice('--days='.length));
-    }
-  }
-  if (command.startsWith('-')) command = 'start';
-  return { command, serviceAction, port, source, force, reconcile, days };
-}
-
-function resolveDaysAgo(days: number | undefined): number | undefined {
-  if (days === undefined) return undefined;
-  if (!Number.isInteger(days) || days <= 0) {
-    throw new Error(`--days 须为正整数，收到: ${days}`);
-  }
-  return days;
-}
-
-function printHelp(): void {
-  console.log(`Usage: jusage <command> [options]
-
-Commands:
-  start                 前台启动本地面板与同步（默认；桌面已运行时为观察模式）
-  stop                  停止当前进程内的服务
-  status                查看 CLI / 面板当前启动状态
-  sync                  手动同步本地用量数据
-  upload                上报数据到云端
-  service <action>      后台服务与开机自启（macOS / Windows / Linux）
-                        action: start | stop | status
-  help                  显示帮助
-
-Options:
-  --port <number>       面板端口（默认 ${DEFAULT_PORT}）
-  --source <name>       sync 数据源：claude | codex | cursor | qoder | trae | gemini | opencode | copilot | antigravity | openclaw | hermes | zcode | pi | kimi | roocode | droid | kiro | cline | amp | qwen | codebuddy | workbuddy | grok | mimo | every-code | omp | kilo-cli | kilocode | goose | zed | warp | all
-  --force               upload 时忽略云端同步开关，强制上报
-  --reconcile           upload 时做全量对账
-  -h, --help            显示帮助
-
-Examples:
-  jusage
-  jusage start --port 8452
-  jusage status
-  jusage sync --source=claude
-  jusage upload --force
-  jusage service start`);
-}
-
 async function refreshRuntimeFromDisk(
   results?: SyncResult[],
 ): Promise<void> {
@@ -244,7 +166,7 @@ async function refreshRuntimeFromDisk(
   }
 }
 
-async function cmdStart(port: number, daysAgo?: number): Promise<void> {
+async function cmdStart(portArg?: number, hostArg?: string, daysAgo?: number): Promise<void> {
   const { dir, config } = await loadConfig();
 
   const existing = await getRunningOwner(dir);
@@ -269,7 +191,10 @@ async function cmdStart(port: number, daysAgo?: number): Promise<void> {
   }
 
   await touchStatsSince(dir, config, daysAgo != null ? { daysAgo } : undefined);
+  const port = portArg ?? config.serverPort ?? DEFAULT_PORT;
+  const host = hostArg ?? config.serverHost ?? DEFAULT_HOST;
   config.serverPort = port;
+  config.serverHost = host;
   await saveConfig(dir, config);
 
   console.log(`设备 UUID: ${config.deviceId}`);
@@ -368,12 +293,13 @@ async function cmdStart(port: number, daysAgo?: number): Promise<void> {
   const httpServer = createHttpServer({
     honoApp: app,
     staticDir: resolveDashboardDir(),
+    host,
     port,
   });
 
   let actualPort: number;
   try {
-    ({ port: actualPort } = await listenServer(httpServer, '127.0.0.1', port));
+    ({ port: actualPort } = await listenServer(httpServer, host, port));
   } catch (err) {
     if (ownedPid) {
       await releaseRuntimeOwner(dir);
@@ -419,9 +345,12 @@ async function cmdStart(port: number, daysAgo?: number): Promise<void> {
       .finally(scheduleNextPoll);
   }
 
-  const url = `http://127.0.0.1:${actualPort}`;
+  const url = formatListenUrl(host, actualPort);
   console.log(`\n✓ Juejin Usage 已启动${isObserver ? '（观察模式）' : ''}`);
   console.log(`  面板: ${url}`);
+  if (isWildcardListenHost(host)) {
+    console.log(`  监听: ${host}:${actualPort}（局域网可访问）`);
+  }
   console.log(`  数据: ${dir}`);
   console.log(`  调试日志: ${join(dir, 'logs')}`);
   if (isObserver) {
@@ -479,6 +408,7 @@ async function cmdStatus(): Promise<void> {
   const owner = await getRunningOwner(dir);
   const panelUp = server != null;
   const port = config.serverPort || DEFAULT_PORT;
+  const host = config.serverHost || DEFAULT_HOST;
 
   if (owner != null) {
     console.log(
@@ -492,7 +422,7 @@ async function cmdStatus(): Promise<void> {
       `本进程面板: 运行中${runtimeRole === 'observer' ? '（观察模式，只读）' : ''}`,
     );
   }
-  console.log(`面板: http://127.0.0.1:${port}`);
+  console.log(`面板: ${formatListenUrl(host, port)}`);
   console.log(`数据目录: ${dir}`);
   console.log(`设备 UUID: ${config.deviceId}`);
   console.log(`上报 Token: ${config.juejin.token ?? '(未配置)'}`);
@@ -564,11 +494,15 @@ async function cmdStop(): Promise<void> {
   console.log(wasObserver ? '观察面板已停止' : '服务已停止');
 }
 
-async function cmdService(action: string | undefined, daysAgo?: number): Promise<void> {
+async function cmdService(
+  action: string | undefined,
+  daysAgo?: number,
+  listen?: { port?: number; host?: string },
+): Promise<void> {
   const cliBinPath = resolveCliBinPath();
   switch (action) {
     case 'start':
-      await cmdServiceStart(cliBinPath, daysAgo);
+      await cmdServiceStart(cliBinPath, daysAgo, listen);
       break;
     case 'stop':
       await cmdServiceStop();
@@ -583,7 +517,7 @@ async function cmdService(action: string | undefined, daysAgo?: number): Promise
 }
 
 async function main(): Promise<void> {
-  const { command, serviceAction, port, source, force, reconcile, days } = parseArgs(process.argv);
+  const { command, serviceAction, port, host, source, force, reconcile, days } = parseArgs(process.argv);
 
   try {
     const daysAgo = resolveDaysAgo(days);
@@ -592,7 +526,7 @@ async function main(): Promise<void> {
         printHelp();
         break;
       case 'start':
-        await cmdStart(port, daysAgo);
+        await cmdStart(port, host, daysAgo);
         break;
       case 'sync':
         await cmdSync(source);
@@ -607,7 +541,7 @@ async function main(): Promise<void> {
         await cmdStop();
         break;
       case 'service':
-        await cmdService(serviceAction, daysAgo);
+        await cmdService(serviceAction, daysAgo, { port, host });
         break;
       default:
         console.error(`未知命令: ${command}`);

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -6,6 +6,7 @@ import {
   getRunningOwner,
   loadConfig,
   runtimeKindLabel,
+  saveConfig,
   touchStatsSince,
 } from '@juejin-opensource/jusage-core';
 
@@ -16,6 +17,7 @@ import {
   stopPid,
   waitForServiceReady,
 } from './daemon.js';
+import { DEFAULT_HOST, formatListenUrl } from './args.js';
 import {
   isLinuxAutostartRegistered,
   registerLinuxAutostart,
@@ -73,7 +75,11 @@ async function unregisterAutostart(): Promise<void> {
   await unregisterLinuxAutostart();
 }
 
-export async function cmdServiceStart(cliBinPath: string, daysAgo?: number): Promise<void> {
+export async function cmdServiceStart(
+  cliBinPath: string,
+  daysAgo?: number,
+  listen?: { port?: number; host?: string },
+): Promise<void> {
   assertSupportedPlatform();
   const startedAt = Date.now();
   const waitTimer = setInterval(() => {
@@ -82,16 +88,25 @@ export async function cmdServiceStart(cliBinPath: string, daysAgo?: number): Pro
   }, 3_000);
 
   try {
-    await cmdServiceStartBody(cliBinPath, daysAgo);
+    await cmdServiceStartBody(cliBinPath, daysAgo, listen);
   } finally {
     clearInterval(waitTimer);
   }
 }
 
-async function cmdServiceStartBody(cliBinPath: string, daysAgo?: number): Promise<void> {
+async function cmdServiceStartBody(
+  cliBinPath: string,
+  daysAgo?: number,
+  listen?: { port?: number; host?: string },
+): Promise<void> {
   const { dir, config } = await loadConfig();
   // Seed statsSince before launchd starts `jusage start` (do not bake --days into plist).
   await touchStatsSince(dir, config, daysAgo != null ? { daysAgo } : undefined);
+  if (listen?.port != null) config.serverPort = listen.port;
+  if (listen?.host != null) config.serverHost = listen.host;
+  if (listen?.port != null || listen?.host != null) {
+    await saveConfig(dir, config);
+  }
   const existing = await getRunningOwner(dir);
 
   if (existing != null) {
@@ -110,13 +125,14 @@ async function cmdServiceStartBody(cliBinPath: string, daysAgo?: number): Promis
       console.log('  提示: 当前 runtime owner 是桌面端，同步/上报由桌面负责');
       console.log('  如需浏览器面板，可另开终端执行 jusage start（观察模式，只读）');
     }
-    console.log(`  面板: http://127.0.0.1:${config.serverPort || DEFAULT_PORT}`);
+    console.log(`  面板: ${formatListenUrl(config.serverHost || DEFAULT_HOST, config.serverPort || DEFAULT_PORT)}`);
     return;
   }
 
   await registerAutostart(cliBinPath, dir);
   const port = config.serverPort || DEFAULT_PORT;
-  const ready = await waitForServiceReady(dir, port);
+  const host = config.serverHost || DEFAULT_HOST;
+  const ready = await waitForServiceReady(dir, port, host);
   if (ready.pid == null && !ready.health) {
     const logPath = daemonLogPath(dir);
     const tail = await readDaemonLogTail(dir);
@@ -128,12 +144,13 @@ async function cmdServiceStartBody(cliBinPath: string, daysAgo?: number): Promis
 
   const { config: refreshed } = await loadConfig(dir);
   const panelPort = refreshed.serverPort || DEFAULT_PORT;
+  const panelHost = refreshed.serverHost || DEFAULT_HOST;
   if (ready.pid != null) {
     console.log(`✓ 服务已在后台启动 (pid ${ready.pid})`);
   } else {
     console.log('✓ 服务已在后台启动（面板 /health 已就绪）');
   }
-  console.log(`  面板: http://127.0.0.1:${panelPort}`);
+  console.log(`  面板: ${formatListenUrl(panelHost, panelPort)}`);
   console.log(`  数据: ${dir}`);
   console.log(`  开机自启: 已注册`);
   console.log(`  日志: ${dir}/logs/daemon.log`);
@@ -170,6 +187,7 @@ export async function cmdServiceStatus(): Promise<void> {
   const owner = await getRunningOwner(dir);
   const registered = await isAutostartRegistered();
   const port = config.serverPort || DEFAULT_PORT;
+  const host = config.serverHost || DEFAULT_HOST;
 
   if (owner != null) {
     console.log(
@@ -179,7 +197,7 @@ export async function cmdServiceStatus(): Promise<void> {
     console.log('服务: 未运行');
   }
   console.log(`开机自启: ${registered ? '已注册' : '未注册'}`);
-  console.log(`面板: http://127.0.0.1:${port}`);
+  console.log(`面板: ${formatListenUrl(host, port)}`);
   console.log(`数据: ${dir || DEFAULT_DATA_DIR}`);
   console.log(`云端同步: ${config.juejin.enabled ? '已开启' : '未开启'} → ${config.juejin.apiUrl}`);
   console.log(`上次同步: ${config.lastSyncAt ?? '从未'}`);

--- a/packages/cli/test/args.test.js
+++ b/packages/cli/test/args.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { formatListenUrl, normalizeListenHost, parseArgs } from '../dist/args.js';
+
+test('parseArgs reads --host and --port without defaulting them', () => {
+  const parsed = parseArgs(['node', 'jusage', 'start', '--host', '0.0.0.0', '--port', '9000']);
+  assert.equal(parsed.command, 'start');
+  assert.equal(parsed.host, '0.0.0.0');
+  assert.equal(parsed.port, 9000);
+});
+
+test('parseArgs accepts --host= form and IPv6', () => {
+  const parsed = parseArgs(['node', 'jusage', 'start', '--host=::1']);
+  assert.equal(parsed.host, '::1');
+  assert.equal(parsed.port, undefined);
+});
+
+test('parseArgs leaves host/port unset when omitted', () => {
+  const parsed = parseArgs(['node', 'jusage', 'start']);
+  assert.equal(parsed.host, undefined);
+  assert.equal(parsed.port, undefined);
+});
+
+test('jusage --host 0.0.0.0 is treated as start', () => {
+  const parsed = parseArgs(['node', 'jusage', '--host', '0.0.0.0']);
+  assert.equal(parsed.command, 'start');
+  assert.equal(parsed.host, '0.0.0.0');
+});
+
+test('service start keeps --host', () => {
+  const parsed = parseArgs(['node', 'jusage', 'service', 'start', '--host', '0.0.0.0']);
+  assert.equal(parsed.command, 'service');
+  assert.equal(parsed.serviceAction, 'start');
+  assert.equal(parsed.host, '0.0.0.0');
+});
+
+test('normalizeListenHost rejects empty or path-like values', () => {
+  assert.equal(normalizeListenHost(' 0.0.0.0 '), '0.0.0.0');
+  assert.throws(() => normalizeListenHost(''), /不能为空/);
+  assert.throws(() => normalizeListenHost('0.0.0.0/foo'), /无效/);
+});
+
+test('parseArgs throws when --host has no value', () => {
+  assert.throws(() => parseArgs(['node', 'jusage', 'start', '--host']), /需要地址/);
+});
+
+test('formatListenUrl maps wildcard bind to loopback', () => {
+  assert.equal(formatListenUrl('0.0.0.0', 8452), 'http://127.0.0.1:8452');
+  assert.equal(formatListenUrl('::1', 8452), 'http://[::1]:8452');
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -384,6 +384,7 @@ export interface TudConfig {
     ttlMs?: number | null;
   };
   serverPort?: number;
+  serverHost?: string;
   lastSyncAt?: string | null;
   lastUploadAt?: string | null;
 }


### PR DESCRIPTION
<!--
提交前请对照 CONTRIBUTING.md 确认：
- 分支从 main 拉出，也 PR 回 main，命名为 <type>/<end>/<short-desc>
- 影响用户的改动已执行 pnpm changeset，并把生成的文件一起提交
- 下面的信息填完整，维护者 review 通过后合并
-->

### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [ ] Web

### 🔗 关联 Issue

本地讨论：CLI 启动只能改 `--port`，监听地址写死 `127.0.0.1`，局域网无法打开面板。

### 💡 改动说明

1. CLI 面板原先只绑 `127.0.0.1`，没有 `--host`，局域网设备访问不了本地面板。
2. 增加 `--host`（默认 `127.0.0.1`；局域网用 `0.0.0.0`），并写入 `~/.ai-usage/config.json` 的 `serverHost`，与 `--port` / `serverPort` 同一套持久化。未传参数时沿用上次配置，避免 `jusage service start` 把自定义 host/port 冲掉。core 只加了可选字段 `serverHost`。
3. 无 UI 改动。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | minor | CLI 支持 `--host` 指定面板监听地址（默认 127.0.0.1；局域网访问可用 0.0.0.0）。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过

## Summary
- CLI 增加 `--host`，默认 `127.0.0.1`，局域网可用 `0.0.0.0`
- 写入 `config.json` 的 `serverHost`，`start` / `service start` 未传参数时沿用
- core 仅增加可选字段 `serverHost`，与现有 `serverPort` 对齐

## Test plan
- [x] `pnpm --filter @juejin-opensource/jusage test`
- [x] `pnpm build:cli && pnpm --filter @juejin-opensource/jusage start -- --host 0.0.0.0`
- [x] `curl -s http://127.0.0.1:8452/health` 返回 ok；`lsof` 看到 `*:8452`
- [x] 确认 `~/.ai-usage/config.json` 出现 `"serverHost": "0.0.0.0"`；再无参数启动仍绑 0.0.0.0
- [x] `--host 127.0.0.1` 可改回 loopback


Made with [Cursor](https://cursor.com)