### PR TITLE
fix(desktop): keep pet settings slider from clipping

### DIFF
--- a/.changeset/pet-settings-controls.md
+++ b/.changeset/pet-settings-controls.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复设置里桌面宠物大小滑块被裁切，并在未开启「显示桌面宠物」时禁用形象、大小和跑动等参数。

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -111,7 +111,7 @@ export function SettingsPanel({
           </Tabs.List>
         </Tabs.ListContainer>
 
-        <Tabs.Panel className="h-[50vh] overflow-hidden p-4 text-left" id="pet">
+        <Tabs.Panel className="h-[50vh] min-w-0 overflow-hidden p-4 text-left" id="pet">
           {tab === 'pet' && <DesktopPetSettings />}
         </Tabs.Panel>
         <Tabs.Panel
@@ -285,10 +285,12 @@ function DesktopPetSettings() {
     [],
   );
 
+  const petControlsDisabled = loading || !enabled;
+
   return (
     <div className="flex h-full flex-col gap-4 overflow-hidden">
       {error && <StatusBanner tone="error" title={error} />}
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         <p className="mb-3 text-sm text-muted">
           显示悬浮宠物；拖动它可在桌面上移动。
         </p>
@@ -307,10 +309,10 @@ function DesktopPetSettings() {
             显示桌面宠物
           </Checkbox.Content>
         </Checkbox>
-        <div className="mt-5 flex flex-col gap-5">
+        <div className="mt-5 flex flex-col gap-5 px-4 pb-1">
           <Select
             aria-label="选择桌面宠物"
-            isDisabled={loading}
+            isDisabled={petControlsDisabled}
             value={selectedPetId}
             variant="secondary"
             onChange={onSelectedPetChange}
@@ -341,7 +343,7 @@ function DesktopPetSettings() {
             </Select.Popover>
           </Select>
           <Slider
-            isDisabled={loading}
+            isDisabled={petControlsDisabled}
             maxValue={75}
             minValue={35}
             onChange={(value) => {
@@ -361,7 +363,7 @@ function DesktopPetSettings() {
           </Slider>
           <Checkbox
             id="desktop-pet-auto-move-enabled"
-            isDisabled={loading}
+            isDisabled={petControlsDisabled}
             isSelected={autoMoveEnabled}
             onChange={(checked) => {
               setAutoMoveEnabled(checked);
@@ -376,7 +378,7 @@ function DesktopPetSettings() {
             </Checkbox.Content>
           </Checkbox>
           <NumberField
-            isDisabled={loading || !autoMoveEnabled}
+            isDisabled={petControlsDisabled || !autoMoveEnabled}
             maxValue={120}
             minValue={1}
             onChange={(value) => {
@@ -395,10 +397,12 @@ function DesktopPetSettings() {
               <NumberField.Input />
               <NumberField.IncrementButton />
             </NumberField.Group>
-            <Description>宠物空闲 {autoMoveIntervalMinutes} 分钟后，会在当前屏幕内随机自然跑动。</Description>
+            <Description>
+              宠物空闲 {autoMoveIntervalMinutes} 分钟后，会在当前屏幕内随机自然跑动。
+            </Description>
           </NumberField>
           <Slider
-            isDisabled={loading}
+            isDisabled={petControlsDisabled}
             maxValue={320}
             minValue={120}
             onChange={(value) => {


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

本地使用桌面端设置页时发现：宠物大小滑块在最小值会被裁切；未勾选「显示桌面宠物」时仍可改形象、大小、跑动参数。

### 💡 改动说明

1. **原来有什么问题**
   - 「宠物大小」滑块拉到最小时，左侧滑块被父级 `overflow` 裁掉一半。
   - 拉到最大时，右侧 `75%` 百分比和滑轨末端也会被裁切。
   - 未勾选「显示桌面宠物」时，形象 / 大小 / 自动跑动 / 间隔 / 动作速度仍可调整。
2. **这版怎么改**
   - 给宠物参数区域加水平内边距，让滑块拇指和百分比留在裁切区域内；参数区可滚动，避免底部「动作速度」被挡住。
   - 未开启桌面宠物时，上述参数控件全部禁用（跑动间隔在未开自动跑动时仍保持禁用）。
   - 只改 Desktop 设置页。Web / CLI 面板没有桌面宠物设置，无需同步 `packages/dashboard`。
3. **交互**
   - 开启「显示桌面宠物」后参数可改；关闭后参数灰掉但保留当前值。
   - 把滑块分别拖到 35% 和 75%，左右两端应完整；未勾选时参数不可点。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 修复设置里桌面宠物大小滑块被裁切，并在未开启「显示桌面宠物」时禁用形象、大小和跑动等参数。 |

### 🧪 验证

- [x] `pnpm build`
- [x] `pnpm exec changeset status`

`pnpm --filter @juejin-opensource/jusage-desktop typecheck` 仍会报主分支既有的 3 个 `src/main/index.ts` 中 `app.dock` 可能为空；本 PR 未改该文件，完整 `electron-vite build` 已通过。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改（桌宠设置仅 Desktop 有，无需同步 dashboard）
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过
