### PR TITLE
feat(web): remember rank range and polish the download page

### DIFF
--- a/.changeset/web-rank-download.md
+++ b/.changeset/web-rank-download.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-dashboard": patch
+---
+
+排行榜默认显示今天并记住上次选择的时间范围；下载页改为选取 Gitee 最新安装包，并展示支持的工具与 GitHub Star 入口。

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc -b && cross-env VITE_API_TARGET=cli VITE_BASE=/ VITE_ROUTER_BASE=/ vite build",
     "preview": "vite preview",
-    "test": "node --experimental-strip-types --test src/lib/dashboard-fetch-days.test.ts src/lib/dashboard-data.test.ts src/lib/usage-filter.test.ts src/lib/downloads.test.ts src/lib/pricing-catalog.test.ts src/lib/model-provider.test.ts"
+    "test": "node --experimental-strip-types --test src/lib/dashboard-fetch-days.test.ts src/lib/dashboard-data.test.ts src/lib/usage-filter.test.ts src/lib/downloads.test.ts src/lib/leaderboard.test.ts src/lib/pricing-catalog.test.ts src/lib/model-provider.test.ts"
   },
   "dependencies": {
     "@fontsource-variable/jetbrains-mono": "5.2.8",

--- a/packages/dashboard/src/components/AboutContent.tsx
+++ b/packages/dashboard/src/components/AboutContent.tsx
@@ -1,35 +1,9 @@
-import openAIIcon from '@lobehub/icons-static-svg/icons/openai.svg';
 import { Link } from '@heroui/react';
 import { JUEJIN_PRIVACY_POLICY_URL } from '@/components/JuejinLoginConsentModal';
-import { ProviderIcon } from '@/components/ProviderIcon';
-import {
-  APP_DISPLAY_NAME,
-  SUPPORTED_TOOLS,
-  appVersion,
-  formatSupportedTool,
-} from '@/lib/about';
+import { SupportedToolsGrid } from '@/components/SupportedToolsGrid';
+import { APP_DISPLAY_NAME, appVersion } from '@/lib/about';
 
 const FEEDBACK_URL = 'http://github.com/juejin-cn/juejin-usage/issues/new';
-
-const COLOR_BADGE_CLASSES: Record<string, string> = {
-  cline: 'bg-red-500',
-  cursor: 'bg-black',
-  droid: 'bg-blue-500',
-  'every-code': 'bg-emerald-600',
-  goose: 'bg-amber-500',
-  grok: 'bg-violet-600',
-  hermes: 'bg-amber-500',
-  kimi: 'bg-black',
-  'kilo-cli': 'bg-violet-500',
-  kilocode: 'bg-violet-500',
-  mimo: 'bg-rose-400',
-  omp: 'bg-violet-500',
-  opencode: 'bg-blue-600',
-  pi: 'bg-orange-500',
-  roocode: 'bg-green-500',
-  zcode: 'bg-indigo-500',
-  zed: 'bg-orange-500',
-};
 
 /** Shared about body — version + supported tools. */
 export function AboutContent() {
@@ -76,54 +50,8 @@ export function AboutContent() {
         <p className="text-xs text-foreground/55">
           同一系列的多端形态用括号标出。
         </p>
-        <ul className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
-          {SUPPORTED_TOOLS.map((tool) => (
-            <li
-              key={tool.source}
-              className="flex items-center gap-2 rounded-lg bg-black/3 px-2.5 py-1.5 text-sm text-foreground/80 dark:bg-white/5"
-            >
-              <SupportedToolIcon source={tool.source} />
-              <span className="min-w-0 leading-snug">
-                {formatSupportedTool(tool)}
-              </span>
-            </li>
-          ))}
-        </ul>
+        <SupportedToolsGrid />
       </section>
     </div>
   );
-}
-
-function SupportedToolIcon({ source }: { source: string }) {
-  if (source === 'codex') {
-    return (
-      <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-emerald-600">
-        <img
-          alt=""
-          aria-hidden
-          className="size-[15px] invert"
-          src={openAIIcon}
-        />
-      </span>
-    );
-  }
-
-  const badgeClass = COLOR_BADGE_CLASSES[source];
-
-  if (badgeClass) {
-    return (
-      <span
-        className={`flex size-6 shrink-0 items-center justify-center rounded-md ${badgeClass}`}
-      >
-        <ProviderIcon
-          color="#fff"
-          isSelected
-          provider={source}
-          size={15}
-        />
-      </span>
-    );
-  }
-
-  return <ProviderIcon provider={source} size={18} />;
 }

--- a/packages/dashboard/src/components/InstallGuidePage.tsx
+++ b/packages/dashboard/src/components/InstallGuidePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { Check, ChevronDown, Copy, LogoGithub } from '@gravity-ui/icons';
+import { Check, ChevronDown, Copy } from '@gravity-ui/icons';
 import { Button, Popover } from '@heroui/react';
+import { SupportedToolsGrid } from '@/components/SupportedToolsGrid';
 import {
   DOWNLOAD_TARGETS,
   GITEE_REPO_URL,
@@ -118,6 +119,7 @@ export function InstallGuidePage({ reason }: InstallGuidePageProps) {
   const [cliMenuOpen, setCliMenuOpen] = useState(false);
   const [cliVariant, setCliVariant] = useState<CliVariantId>('npx');
   const [copied, setCopied] = useState(false);
+  const [starLabel, setStarLabel] = useState<string | null>(null);
   const userPickedRef = useRef(readSessionTarget() !== null);
 
   const target = getDownloadTarget(targetId);
@@ -192,6 +194,27 @@ export function InstallGuidePage({ reason }: InstallGuidePageProps) {
     return () => window.clearTimeout(timer);
   }, [copied]);
 
+  useEffect(() => {
+    let cancelled = false;
+    void fetch('https://api.github.com/repos/juejin-cn/juejin-usage', {
+      headers: { Accept: 'application/vnd.github+json' },
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload: { stargazers_count?: number } | null) => {
+        const count = payload?.stargazers_count;
+        if (cancelled || typeof count !== 'number' || !Number.isFinite(count)) {
+          return;
+        }
+        setStarLabel(formatStarCount(count));
+      })
+      .catch(() => {
+        // Star count is decorative; the GitHub link still works without it.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const startDownload = (id: DownloadTargetId) => {
     const url = assetUrls[id] ?? releasesFallback;
     const anchor = document.createElement('a');
@@ -215,7 +238,8 @@ export function InstallGuidePage({ reason }: InstallGuidePageProps) {
 
   return (
     <section className="flex min-h-[calc(100svh-9rem)] items-start pt-4 pb-10 sm:pt-6 sm:pb-14 lg:pt-8">
-      <div className="grid w-full items-start gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] lg:gap-16 xl:gap-20">
+      <div className="flex w-full flex-col gap-14 sm:gap-16 lg:gap-20">
+        <div className="grid w-full items-start gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)] lg:gap-16 xl:gap-20">
         <div className="max-w-2xl motion-safe:animate-[fade-up_420ms_ease-out] lg:max-w-none">
           <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-base text-muted">
             <span>{content.badge}</span>
@@ -432,31 +456,45 @@ export function InstallGuidePage({ reason }: InstallGuidePageProps) {
           </p>
 
           <p className="mt-5 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted">
-            <span className="inline-flex items-center gap-2">
-              <a
-                aria-label="前往 Gitee 仓库"
-                className="inline-flex size-8 items-center justify-center rounded-full text-foreground/70 transition-colors hover:bg-surface-secondary hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                href={GITEE_REPO_URL}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <GiteeMark className="size-4.5" />
-              </a>
-              <a
-                aria-label="前往 GitHub 仓库"
-                className="inline-flex size-8 items-center justify-center rounded-full text-foreground/70 transition-colors hover:bg-surface-secondary hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-                href={GITHUB_REPO_URL}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <LogoGithub aria-hidden="true" className="size-4.5" />
-              </a>
-            </span>
-            <span aria-hidden="true">·</span>
             <span>{target.requirement}</span>
             <span aria-hidden="true">·</span>
             <span>CLI 需 Node.js 20+</span>
+            <span aria-hidden="true">·</span>
+            <a
+              className="inline-flex items-center gap-1 text-foreground/70 transition-colors hover:text-foreground"
+              href={GITEE_REPO_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <GiteeMark className="size-3.5" />
+              Gitee
+            </a>
           </p>
+
+          <a
+            aria-label="在 GitHub 上 Star 本项目"
+            className="mt-4 flex w-full max-w-xl items-center gap-4 rounded-2xl border border-border bg-surface-secondary/80 px-5 py-4 shadow-[0_1px_2px_rgb(0_0_0/0.06)] outline-offset-2 transition-colors hover:bg-surface-secondary focus-visible:outline-2 focus-visible:outline-accent dark:bg-overlay/60 dark:hover:bg-overlay/80"
+            href={GITHUB_REPO_URL}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <GithubMark className="size-8 shrink-0" />
+            <span className="min-w-0">
+              <span className="flex items-baseline gap-2">
+                <span className="text-base font-medium text-foreground">
+                  ⭐️ Star
+                </span>
+                {starLabel ? (
+                  <span className="text-sm font-medium tabular-nums text-foreground/55">
+                    {starLabel}
+                  </span>
+                ) : null}
+              </span>
+              <span className="mt-0.5 block text-sm leading-6 text-muted">
+                开源共享，欢迎提 Issue 与贡献代码
+              </span>
+            </span>
+          </a>
         </div>
 
         <div className="min-w-0 motion-safe:animate-[fade-up_520ms_ease-out]">
@@ -472,6 +510,19 @@ export function InstallGuidePage({ reason }: InstallGuidePageProps) {
             />
           </figure>
         </div>
+        </div>
+
+        <section aria-labelledby="supported-tools-heading" className="w-full">
+          <h2
+            className="text-lg font-semibold tracking-tight text-foreground sm:text-xl"
+            id="supported-tools-heading"
+          >
+            支持的工具
+          </h2>
+          <div className="mt-4">
+            <SupportedToolsGrid className="lg:grid-cols-3" collapsible />
+          </div>
+        </section>
       </div>
     </section>
   );
@@ -486,6 +537,29 @@ const downloadBtnClass = cn(
   'dark:bg-[#4b9cff] dark:hover:bg-[#3a8ff0] dark:focus-visible:outline-[#4b9cff]',
   'touch-manipulation',
 );
+
+function formatStarCount(count: number): string {
+  if (count < 1000) return String(Math.floor(count));
+  const thousands = count / 1000;
+  const digits = count >= 10_000 ? 0 : 1;
+  return `${thousands.toFixed(digits).replace(/\.0$/, '')}k`;
+}
+
+/** GitHub Octicon `mark-github` (24×24). */
+function GithubMark({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+      focusable="false"
+      overflow="visible"
+      viewBox="0 0 24 24"
+    >
+      <path d="M10.226 17.284c-2.965-.36-5.054-2.493-5.054-5.256 0-1.123.404-2.336 1.078-3.144-.292-.741-.247-2.314.09-2.965.898-.112 2.111.36 2.83 1.01.853-.269 1.752-.404 2.853-.404 1.1 0 1.999.135 2.807.382.696-.629 1.932-1.1 2.83-.988.315.606.36 2.179.067 2.942.72.854 1.101 2 1.101 3.167 0 2.763-2.089 4.852-5.098 5.234.763.494 1.28 1.572 1.28 2.807v2.336c0 .674.561 1.056 1.235.786 4.066-1.55 7.255-5.615 7.255-10.646C23.5 6.188 18.334 1 11.978 1 5.62 1 .5 6.188.5 12.545c0 4.986 3.167 9.12 7.435 10.669.606.225 1.19-.18 1.19-.786V20.63a2.9 2.9 0 0 1-1.078.224c-1.483 0-2.359-.808-2.987-2.313-.247-.607-.517-.966-1.034-1.033-.27-.023-.359-.135-.359-.27 0-.27.45-.471.898-.471.652 0 1.213.404 1.797 1.235.45.651.921.943 1.483.943.561 0 .92-.202 1.437-.719.382-.381.674-.718.944-.943" />
+    </svg>
+  );
+}
 
 /** Official Apple () mark — bitten apple with leaf, not a fruit icon. */
 function AppleMark({ className }: { className?: string }) {

--- a/packages/dashboard/src/components/SupportedToolsGrid.tsx
+++ b/packages/dashboard/src/components/SupportedToolsGrid.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import { ChevronDown } from '@gravity-ui/icons';
+import { Button } from '@heroui/react';
+import openAIIcon from '@lobehub/icons-static-svg/icons/openai.svg';
+import { ProviderIcon } from '@/components/ProviderIcon';
+import {
+  SUPPORTED_TOOLS,
+  formatSupportedTool,
+  type SupportedToolLine,
+} from '@/lib/about';
+import { cn } from '@/lib/utils';
+
+const COLOR_BADGE_CLASSES: Record<string, string> = {
+  cline: 'bg-red-500',
+  cursor: 'bg-black',
+  droid: 'bg-blue-500',
+  'every-code': 'bg-emerald-600',
+  goose: 'bg-amber-500',
+  grok: 'bg-violet-600',
+  hermes: 'bg-amber-500',
+  kimi: 'bg-black',
+  'kilo-cli': 'bg-violet-500',
+  kilocode: 'bg-violet-500',
+  mimo: 'bg-rose-400',
+  omp: 'bg-violet-500',
+  opencode: 'bg-blue-600',
+  pi: 'bg-orange-500',
+  roocode: 'bg-green-500',
+  zcode: 'bg-indigo-500',
+  zed: 'bg-orange-500',
+};
+
+export function SupportedToolsGrid({
+  className,
+  collapsible = false,
+}: {
+  className?: string;
+  collapsible?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const showAll = !collapsible || expanded;
+
+  return (
+    <div className="flex flex-col items-stretch">
+      {showAll ? (
+        <ToolsList className={className} tools={SUPPORTED_TOOLS} />
+      ) : (
+        <ToolsMarquee />
+      )}
+      {collapsible ? (
+        <Button
+          aria-expanded={expanded}
+          className="mt-4 self-center"
+          onPress={() => setExpanded((open) => !open)}
+          size="sm"
+          variant="tertiary"
+        >
+          {expanded
+            ? '收起'
+            : `查看全部（${SUPPORTED_TOOLS.length}）`}
+          <ChevronDown
+            aria-hidden="true"
+            className={cn(
+              'size-3.5 transition-transform duration-200 motion-reduce:transition-none',
+              expanded && 'rotate-180',
+            )}
+          />
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function ToolsList({
+  className,
+  tools,
+}: {
+  className?: string;
+  tools: readonly SupportedToolLine[];
+}) {
+  return (
+    <ul
+      className={cn(
+        'grid grid-cols-1 gap-1.5 sm:grid-cols-2',
+        'motion-safe:animate-[fade-up_420ms_ease-out]',
+        className,
+      )}
+    >
+      {tools.map((tool) => (
+        <li
+          key={tool.source}
+          className="flex items-center gap-2 rounded-lg bg-black/3 px-2.5 py-1.5 text-sm text-foreground/80 dark:bg-white/5"
+        >
+          <SupportedToolIcon source={tool.source} />
+          <span className="min-w-0 leading-snug">
+            {formatSupportedTool(tool)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ToolsMarquee() {
+  return (
+    <div
+      aria-hidden="true"
+      className="tools-marquee group space-y-1.5 mask-[linear-gradient(to_right,transparent,black_5%,black_95%,transparent)]"
+    >
+      <MarqueeRow />
+      <MarqueeRow reverse />
+    </div>
+  );
+}
+
+function MarqueeRow({ reverse = false }: { reverse?: boolean }) {
+  const items = reverse
+    ? [...SUPPORTED_TOOLS].reverse()
+    : SUPPORTED_TOOLS;
+
+  return (
+    <div className="overflow-hidden">
+      <div
+        className={cn(
+          'flex w-max',
+          reverse
+            ? 'tools-marquee-track-reverse motion-safe:animate-[tools-marquee-reverse_48s_linear_infinite]'
+            : 'tools-marquee-track motion-safe:animate-[tools-marquee_40s_linear_infinite]',
+          'motion-reduce:animate-none',
+        )}
+      >
+        <MarqueeChunk items={items} />
+        <MarqueeChunk items={items} />
+      </div>
+    </div>
+  );
+}
+
+function MarqueeChunk({ items }: { items: readonly SupportedToolLine[] }) {
+  return (
+    <div className="flex shrink-0 gap-1.5 pe-1.5">
+      {items.map((tool) => (
+        <div
+          className="flex shrink-0 items-center gap-2 rounded-lg bg-black/3 px-2.5 py-1.5 text-sm text-foreground/80 dark:bg-white/5"
+          key={tool.source}
+        >
+          <SupportedToolIcon source={tool.source} />
+          <span className="leading-snug whitespace-nowrap">{tool.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SupportedToolIcon({ source }: { source: string }) {
+  if (source === 'codex') {
+    return (
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-emerald-600">
+        <img
+          alt=""
+          aria-hidden
+          className="size-[15px] invert"
+          src={openAIIcon}
+        />
+      </span>
+    );
+  }
+
+  const badgeClass = COLOR_BADGE_CLASSES[source];
+
+  if (badgeClass) {
+    return (
+      <span
+        className={`flex size-6 shrink-0 items-center justify-center rounded-md ${badgeClass}`}
+      >
+        <ProviderIcon
+          color="#fff"
+          isSelected
+          provider={source}
+          size={15}
+        />
+      </span>
+    );
+  }
+
+  return <ProviderIcon provider={source} size={18} />;
+}

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -116,6 +116,29 @@
   }
 }
 
+@keyframes tools-marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes tools-marquee-reverse {
+  from {
+    transform: translateX(-50%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+.tools-marquee:hover .tools-marquee-track,
+.tools-marquee:hover .tools-marquee-track-reverse {
+  animation-play-state: paused !important;
+}
+
 @layer base {
   * {
     scrollbar-width: thin;

--- a/packages/dashboard/src/lib/downloads.test.ts
+++ b/packages/dashboard/src/lib/downloads.test.ts
@@ -110,6 +110,51 @@ describe('release asset matching', () => {
     assert.equal(latest?.tag_name, 'v8');
   });
 
+  it('picks the highest semver tag even when the list is unordered', () => {
+    const latest = pickLatestPublishedRelease([
+      { tag_name: 'v0.1.0' },
+      { tag_name: 'v0.1.6' },
+      { tag_name: 'v0.1.5' },
+    ]);
+    assert.equal(latest?.tag_name, 'v0.1.6');
+  });
+
+  it('prefers a newer tag over an older one listed first', () => {
+    const latest = pickLatestPublishedRelease([
+      {
+        tag_name: 'v0.1.3',
+        created_at: '2026-08-31T12:00:00Z',
+      },
+      {
+        tag_name: 'v0.1.6',
+        created_at: '2026-08-28T00:00:00Z',
+      },
+    ]);
+    assert.equal(latest?.tag_name, 'v0.1.6');
+  });
+
+  it('breaks equal tags with the later created_at', () => {
+    const latest = pickLatestPublishedRelease([
+      {
+        tag_name: 'v0.1.6',
+        created_at: '2026-08-28T00:00:00Z',
+      },
+      {
+        tag_name: 'v0.1.6',
+        created_at: '2026-08-29T00:00:00Z',
+      },
+    ]);
+    assert.equal(latest?.created_at, '2026-08-29T00:00:00Z');
+  });
+
+  it('prefers a stable tag over an earlier prerelease of the same version', () => {
+    const latest = pickLatestPublishedRelease([
+      { tag_name: 'v0.1.1-beta.12' },
+      { tag_name: 'v0.1.1' },
+    ]);
+    assert.equal(latest?.tag_name, 'v0.1.1');
+  });
+
   it('prefers NSIS Setup exe and architecture-specific DMGs', () => {
     assert.equal(
       matchReleaseAsset(assets, 'windows'),

--- a/packages/dashboard/src/lib/downloads.ts
+++ b/packages/dashboard/src/lib/downloads.ts
@@ -23,6 +23,7 @@ export interface PublishedRelease {
   draft?: boolean;
   prerelease?: boolean;
   tag_name: string;
+  created_at?: string;
   assets?: ReleaseAsset[] | null;
 }
 
@@ -35,12 +36,12 @@ export interface DesktopReleaseAssets {
 export const GITEE_REPO_URL = 'https://gitee.com/juejin-cn/juejin-usage';
 export const GITEE_RELEASES_URL = `${GITEE_REPO_URL}/releases`;
 export const GITEE_RELEASES_API =
-  'https://gitee.com/api/v5/repos/juejin-cn/juejin-usage/releases?per_page=8';
+  'https://gitee.com/api/v5/repos/juejin-cn/juejin-usage/releases?per_page=20&direction=desc';
 
 export const GITHUB_REPO_URL = 'https://github.com/juejin-cn/juejin-usage';
 export const GITHUB_RELEASES_URL = `${GITHUB_REPO_URL}/releases`;
 export const GITHUB_RELEASES_API =
-  'https://api.github.com/repos/juejin-cn/juejin-usage/releases?per_page=8';
+  'https://api.github.com/repos/juejin-cn/juejin-usage/releases?per_page=20';
 
 export const CLI_INSTALL_COMMAND = 'npm i -g @juejin-opensource/jusage';
 export const CLI_INSTALL_HINT = `$ ${CLI_INSTALL_COMMAND}`;
@@ -126,10 +127,67 @@ export function resolveDefaultTarget(
   return 'macos-arm';
 }
 
-export function pickLatestPublishedRelease<T extends { draft?: boolean }>(
-  releases: readonly T[],
-): T | null {
-  return releases.find((release) => !release.draft) ?? null;
+function parseReleaseTag(tag: string): {
+  parts: number[];
+  prerelease: string | null;
+} {
+  const raw = tag.trim().replace(/^v/i, '');
+  const dash = raw.indexOf('-');
+  const core = dash === -1 ? raw : raw.slice(0, dash);
+  const prerelease = dash === -1 ? null : raw.slice(dash + 1);
+  const parts = core.split('.').map((piece) => {
+    const value = Number.parseInt(piece, 10);
+    return Number.isFinite(value) ? value : 0;
+  });
+  return { parts, prerelease };
+}
+
+/** Newest tag wins: `v0.1.6` > `v0.1.5` > `v0.1.1` > `v0.1.1-beta.12`. */
+function compareReleaseTags(a: string, b: string): number {
+  const left = parseReleaseTag(a);
+  const right = parseReleaseTag(b);
+  const len = Math.max(left.parts.length, right.parts.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (left.parts[i] ?? 0) - (right.parts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  if (left.prerelease == null && right.prerelease != null) return 1;
+  if (left.prerelease != null && right.prerelease == null) return -1;
+  if (left.prerelease != null && right.prerelease != null) {
+    return left.prerelease.localeCompare(right.prerelease, 'en', {
+      numeric: true,
+    });
+  }
+  return 0;
+}
+
+function createdAtMs(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Pick the newest published release by tag semver, then `created_at`.
+ * API list order is ignored — Gitee may surface an edited older release first.
+ */
+export function pickLatestPublishedRelease<
+  T extends { draft?: boolean; tag_name?: string; created_at?: string },
+>(releases: readonly T[]): T | null {
+  const published = releases.filter((release) => !release.draft);
+  if (published.length === 0) return null;
+
+  return published.reduce((latest, current) => {
+    const tagCmp = compareReleaseTags(
+      current.tag_name ?? '',
+      latest.tag_name ?? '',
+    );
+    if (tagCmp > 0) return current;
+    if (tagCmp < 0) return latest;
+    return createdAtMs(current.created_at) > createdAtMs(latest.created_at)
+      ? current
+      : latest;
+  });
 }
 
 function isInstallerName(name: string): boolean {

--- a/packages/dashboard/src/lib/leaderboard.test.ts
+++ b/packages/dashboard/src/lib/leaderboard.test.ts
@@ -1,6 +1,21 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { uniqueRankModelOptions } from './leaderboard.ts';
+import { uniqueRankModelOptions, isRankRange } from './leaderboard.ts';
+
+describe('isRankRange', () => {
+  it('accepts the four leaderboard ranges', () => {
+    assert.equal(isRankRange('today'), true);
+    assert.equal(isRankRange('week'), true);
+    assert.equal(isRankRange('month'), true);
+    assert.equal(isRankRange('all'), true);
+  });
+
+  it('rejects unknown values', () => {
+    assert.equal(isRankRange('last-7-days'), false);
+    assert.equal(isRankRange(''), false);
+    assert.equal(isRankRange(1), false);
+  });
+});
 
 describe('uniqueRankModelOptions', () => {
   const options = [

--- a/packages/dashboard/src/lib/leaderboard.ts
+++ b/packages/dashboard/src/lib/leaderboard.ts
@@ -2,6 +2,15 @@ import type { LeaderboardMetric, LeaderboardRange } from '@/lib/api';
 
 export type RankRange = LeaderboardRange;
 
+export const RANK_RANGES = ['today', 'week', 'month', 'all'] as const;
+
+export function isRankRange(value: unknown): value is RankRange {
+  return (
+    typeof value === 'string' &&
+    (RANK_RANGES as readonly string[]).includes(value)
+  );
+}
+
 export interface RankModelOption {
   tool: string;
   model: string;

--- a/packages/dashboard/src/pages/RankPage.tsx
+++ b/packages/dashboard/src/pages/RankPage.tsx
@@ -5,6 +5,7 @@ import { RankUserTable } from '@/components/RankModelCards';
 import { StatusBanner } from '@/components/StatusBanner';
 import { useJuejinAuth } from '@/hooks/JuejinAuthContext';
 import { useLeaderboardData } from '@/hooks/useLeaderboardData';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import {
   fetchLeaderboardPreference,
   isCliBackend,
@@ -12,14 +13,22 @@ import {
   type LeaderboardMetric,
 } from '@/lib/api';
 import { isMockDataEnabled } from '@/lib/env';
-import { uniqueRankModelOptions, type RankRange } from '@/lib/leaderboard';
+import {
+  isRankRange,
+  uniqueRankModelOptions,
+  type RankRange,
+} from '@/lib/leaderboard';
 import {
   DATA_SYNCED_EVENT,
   dispatchOpenSettings,
 } from '@/lib/shell-events';
 
 export function RankPage() {
-  const [range, setRange] = useState<RankRange>('week');
+  const [range, setRange] = useLocalStorage<RankRange>(
+    'tud.rankRange',
+    'today',
+    isRankRange,
+  );
   const [tool, setTool] = useState('');
   const [model, setModel] = useState('');
   const [metric, setMetric] = useState<LeaderboardMetric>('tokens');


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 💄 样式与交互改进
- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Web

### 🔗 关联 Issue

在线 Web 排行榜 / 下载页体验优化（默认今天、Gitee 取到旧包、下载页缺少支持的工具与开源引导）。

### 💡 改动说明

1. **排行榜**：默认时间范围从「本周」改为「今天」，并用 `localStorage`（`tud.rankRange`）记住上次选择。
2. **下载安装包**：Gitee 发行版不再取列表第一条；按 tag 语义版本选取最新发布，避免拿到旧包。
3. **下载页**：增加支持的工具滚动预览（「查看全部」展开），以及更大的 GitHub Star 卡片，引导参与开源。Gitee 仅作为文字链接。

桌面端 renderer 没有 Rank / Download 副本，未改 `apps/desktop`。关于页的工具网格抽到共享组件后视觉保持不变。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-dashboard` | patch | 排行榜默认显示今天并记住上次选择的时间范围；下载页改为选取 Gitee 最新安装包，并展示支持的工具与 GitHub Star 入口。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 CONTRIBUTING.md）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过


Made with [Cursor](https://cursor.com)