### PR TITLE
fix(desktop): hide pet window traffic lights

### DIFF
--- a/.changeset/fix-desktop-pet-traffic-lights.md
+++ b/.changeset/fix-desktop-pet-traffic-lights.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 macOS 桌面宠物悬浮窗意外显示原生红绿灯窗口控制按钮。

--- a/apps/desktop/src/main/DesktopPet.ts
+++ b/apps/desktop/src/main/DesktopPet.ts
@@ -385,7 +385,6 @@ async function ensurePetWindow(): Promise<BrowserWindow> {
     transparent: true,
     backgroundColor: '#00000000',
     title: PET_WINDOW_TITLE,
-    titleBarStyle: 'hidden',
     resizable: false,
     movable: true,
     minimizable: false,
@@ -405,6 +404,9 @@ async function ensurePetWindow(): Promise<BrowserWindow> {
     },
   });
   const window = petWindow;
+  // `titleBarStyle` enables macOS traffic lights even on a frameless window.
+  // A floating pet must never expose native window controls over its sprite.
+  if (process.platform === 'darwin') window.setWindowButtonVisibility(false);
   suppressPetWindowTitle(window);
   window.setAlwaysOnTop(true, 'floating');
   window.on('move', onPetMoved);


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

根据 macOS 桌面宠物截图反馈修复。

### 💡 改动说明

桌面宠物悬浮窗使用 titleBarStyle hidden，导致 macOS 无边框窗口显示原生 traffic lights，并覆盖宠物。

移除该标题栏样式，并在 macOS 上显式隐藏窗口按钮，确保宠物悬浮窗没有原生窗口控制按钮。

<img width="264" height="295" alt="image" src="https://github.com/user-attachments/assets/27a919c5-96f5-49a7-9032-276f78495f2b" />


### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| @juejin-opensource/jusage-desktop | patch | 修复 macOS 桌面宠物悬浮窗意外显示原生红绿灯窗口控制按钮。 |

### ☑️ 自查清单

- [x] 分支命名符合规范
- [x] 已在受影响的端完成生产构建
- [x] 未改动面板 UI，无需同步 Dashboard
- [x] 已执行 changeset
- [x] pnpm --filter @juejin-opensource/jusage-desktop build 通过
- [ ] typecheck：现有 app.dock 可空错误，和本次改动无关