### PR TITLE
fix(cli): show sync result toast

### DIFF
--- a/.changeset/sync-toast-feedback.md
+++ b/.changeset/sync-toast-feedback.md
@@ -1,0 +1,6 @@
+---
+"@juejin-opensource/jusage-dashboard": patch
+"@juejin-opensource/jusage-desktop": patch
+---
+
+同步数据后会提示成功或失败结果。

--- a/apps/desktop/src/renderer/components/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/AppShell.tsx
@@ -8,6 +8,7 @@ import { ToastQueue } from '@heroui/react';
 //   writeSidebarCollapsed,
 // } from './AppSidebar';
 import { AboutModal } from './AboutModal';
+import { AppToastProvider as AppToastQueueProvider } from './AppToastContext';
 import { AutoUpdateNotice } from './AutoUpdateNotice';
 import {
   AppToastProvider,
@@ -100,10 +101,11 @@ export function AppShell() {
   // };
 
   return (
-    <ShareSnapshotProvider>
-      <div className="flex min-h-svh flex-col bg-background text-foreground">
-      <AppToastProvider queue={toastQueue} />
-      <AutoUpdateNotice toastQueue={toastQueue} />
+    <AppToastQueueProvider queue={toastQueue}>
+      <ShareSnapshotProvider>
+        <div className="flex min-h-svh flex-col bg-background text-foreground">
+        <AppToastProvider queue={toastQueue} />
+        <AutoUpdateNotice toastQueue={toastQueue} />
       {/* Fixed title chrome: transparent until scrolled, then frosted; always draggable. */}
       <div
         className={`desktop-window-drag-region fixed inset-x-0 top-0 z-50 flex items-stretch transition-[background-color,backdrop-filter] duration-200 ${
@@ -148,7 +150,8 @@ export function AppShell() {
         <AboutModal hideTrigger isOpen={aboutOpen} onOpenChange={setAboutOpen} />
         <ShareActivityModal />
       </div>
-      </div>
-    </ShareSnapshotProvider>
+        </div>
+      </ShareSnapshotProvider>
+    </AppToastQueueProvider>
   );
 }

--- a/apps/desktop/src/renderer/components/AppToastContext.tsx
+++ b/apps/desktop/src/renderer/components/AppToastContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { ToastContentValue, ToastQueue } from '@heroui/react';
+
+const AppToastContext = createContext<ToastQueue<ToastContentValue> | null>(
+  null,
+);
+
+export function AppToastProvider({
+  children,
+  queue,
+}: {
+  children: ReactNode;
+  queue: ToastQueue<ToastContentValue>;
+}) {
+  return (
+    <AppToastContext.Provider value={queue}>
+      {children}
+    </AppToastContext.Provider>
+  );
+}
+
+export function useAppToastQueue(): ToastQueue<ToastContentValue> {
+  const queue = useContext(AppToastContext);
+  if (!queue) {
+    throw new Error('useAppToastQueue must be used within AppToastProvider');
+  }
+  return queue;
+}

--- a/apps/desktop/src/renderer/components/FilterChromeActions.tsx
+++ b/apps/desktop/src/renderer/components/FilterChromeActions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@gravity-ui/icons';
 import { Button, Tooltip } from '@heroui/react';
 import { JuejinLoginConsentModal } from '@/components/JuejinLoginConsentModal';
+import { useAppToastQueue } from '@/components/AppToastContext';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { fetchConfig, isCliBackend, triggerSync } from '@/lib/api';
 import { openJuejinLogin } from '@/lib/juejin-client-link';
@@ -53,6 +54,7 @@ function JuejinMark({ className }: { className?: string }) {
 /** Filter-bar chrome: link / share / refresh / settings + theme toggle. */
 export function FilterChromeActions() {
   const cliBackend = isCliBackend();
+  const toastQueue = useAppToastQueue();
   const [busy, setBusy] = useState(false);
   const [linked, setLinked] = useState<boolean | null>(null);
   const [consentOpen, setConsentOpen] = useState(false);
@@ -96,7 +98,15 @@ export function FilterChromeActions() {
     setBusy(true);
     try {
       if (cliBackend) {
-        await triggerSync();
+        const result = await triggerSync();
+        if (!result.ok) {
+          toastQueue.add({
+            title: '同步失败，请稍后重试',
+            variant: 'danger',
+          });
+          return;
+        }
+        toastQueue.add({ title: '同步成功', variant: 'success' });
         // Electron IPC already pushes DATA_SYNCED; a second dispatch double-reloads charts.
         if (typeof window.tud?.onDataSynced !== 'function') {
           dispatchDataSynced();
@@ -104,6 +114,11 @@ export function FilterChromeActions() {
       } else {
         dispatchDataSynced();
       }
+    } catch {
+      toastQueue.add({
+        title: '同步失败，请稍后重试',
+        variant: 'danger',
+      });
     } finally {
       setBusy(false);
     }

--- a/packages/dashboard/src/components/AppShell.tsx
+++ b/packages/dashboard/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import { Outlet, useLocation, useNavigate } from '@tanstack/react-router';
 //   writeSidebarCollapsed,
 // } from './AppSidebar';
 import { AboutModal } from './AboutModal';
+import { AppToastProvider } from './AppToastContext';
 import { BackendConfigModal } from './BackendConfigModal';
 // import { MobileActionBubble } from './MobileActionBubble';
 import { ServerLoginGate } from './ServerLoginGate';
@@ -160,13 +161,14 @@ useEffect(() => {
   // };
 
   return (
-    <JuejinAuthProvider
-      authStatus={authStatus}
-      userId={userId}
-      userName={userName}
-      avatarLarge={avatarLarge}
-    >
-      <ShareSnapshotProvider>
+    <AppToastProvider queue={toastQueue}>
+      <JuejinAuthProvider
+        authStatus={authStatus}
+        userId={userId}
+        userName={userName}
+        avatarLarge={avatarLarge}
+      >
+        <ShareSnapshotProvider>
         <InstallGuideUiProvider value={installGuideUiValue}>
           <div className="flex h-svh min-w-0 max-w-full flex-col overflow-hidden bg-background text-foreground">
             <ToastProvider placement="top end" queue={toastQueue} />
@@ -248,7 +250,8 @@ useEffect(() => {
             </div>
           </div>
         </InstallGuideUiProvider>
-      </ShareSnapshotProvider>
-    </JuejinAuthProvider>
+        </ShareSnapshotProvider>
+      </JuejinAuthProvider>
+    </AppToastProvider>
   );
 }

--- a/packages/dashboard/src/components/AppToastContext.tsx
+++ b/packages/dashboard/src/components/AppToastContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import type { ToastContentValue, ToastQueue } from '@heroui/react';
+
+const AppToastContext = createContext<ToastQueue<ToastContentValue> | null>(
+  null,
+);
+
+export function AppToastProvider({
+  children,
+  queue,
+}: {
+  children: ReactNode;
+  queue: ToastQueue<ToastContentValue>;
+}) {
+  return (
+    <AppToastContext.Provider value={queue}>
+      {children}
+    </AppToastContext.Provider>
+  );
+}
+
+export function useAppToastQueue(): ToastQueue<ToastContentValue> {
+  const queue = useContext(AppToastContext);
+  if (!queue) {
+    throw new Error('useAppToastQueue must be used within AppToastProvider');
+  }
+  return queue;
+}

--- a/packages/dashboard/src/components/FilterChromeActions.tsx
+++ b/packages/dashboard/src/components/FilterChromeActions.tsx
@@ -9,6 +9,7 @@ import {
 import { Button, Tooltip } from '@heroui/react';
 import { useNavigate } from '@tanstack/react-router';
 import { JuejinLoginConsentModal } from '@/components/JuejinLoginConsentModal';
+import { useAppToastQueue } from '@/components/AppToastContext';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { useInstallGuideUi } from '@/hooks/InstallGuideUiContext';
 import { fetchConfig, isCliBackend, triggerSync } from '@/lib/api';
@@ -70,6 +71,7 @@ function JuejinMark({ className }: { className?: string }) {
  */
 export function FilterChromeActions() {
   const navigate = useNavigate();
+  const toastQueue = useAppToastQueue();
   const cliBackend = isCliBackend();
   const installGuideUi = useInstallGuideUi();
   const [busy, setBusy] = useState(false);
@@ -125,7 +127,15 @@ export function FilterChromeActions() {
     setBusy(true);
     try {
       if (cliBackend) {
-        await triggerSync();
+        const result = await triggerSync();
+        if (!result.ok) {
+          toastQueue.add({
+            title: '同步失败，请稍后重试',
+            variant: 'danger',
+          });
+          return;
+        }
+        toastQueue.add({ title: '同步成功', variant: 'success' });
         // Electron IPC already pushes DATA_SYNCED; a second dispatch double-reloads charts.
         if (
           typeof (window as { tud?: { onDataSynced?: unknown } }).tud
@@ -136,6 +146,11 @@ export function FilterChromeActions() {
       } else {
         dispatchDataSynced();
       }
+    } catch {
+      toastQueue.add({
+        title: '同步失败，请稍后重试',
+        variant: 'danger',
+      });
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
## Summary
- show HeroUI success toast after a manual sync completes
- show a concise failure toast for failed responses and request errors
- apply the same change to the CLI dashboard and Electron renderer

## Verification
- pnpm --filter @juejin-opensource/jusage-dashboard build
- pnpm --filter @juejin-opensource/jusage-dashboard test
- pnpm --filter @juejin-opensource/jusage-desktop typecheck *(blocked by existing app.dock possibly undefined errors in apps/desktop/src/main/index.ts)*