### PR TITLE
feat(desktop): sync Juejin profile name and avatar

### DIFF
--- a/.changeset/juejin-profile-sync.md
+++ b/.changeset/juejin-profile-sync.md
@@ -1,0 +1,7 @@
+---
+"@juejin-opensource/jusage-core": minor
+"@juejin-opensource/jusage-dashboard": minor
+"@juejin-opensource/jusage-desktop": minor
+---
+
+设置里的关联账号会同步掘金最新头像和昵称。打开云端同步时自动更新本机展示，资料旁也可手动刷新。

--- a/apps/desktop/src/main/local-runtime.ts
+++ b/apps/desktop/src/main/local-runtime.ts
@@ -26,6 +26,7 @@ import {
   setupClaudeHook,
   setupCodexHook,
   startPricingRefresh,
+  syncJuejinProfile,
   syncLogPath,
   touchRuntimeHeartbeat,
   clearRuntimeHeartbeat,
@@ -414,6 +415,18 @@ async function startLocalRuntimeUnlocked(): Promise<{
   };
 
   console.log('[tud-desktop] background syncing local usage…');
+  void syncJuejinProfile(dir, runtime.config)
+    .then((result) => {
+      if (result.changed) {
+        console.log('[tud-desktop] juejin profile synced');
+      }
+    })
+    .catch((err) => {
+      console.warn(
+        '[tud-desktop] juejin profile sync failed:',
+        err instanceof Error ? err.message : err,
+      );
+    });
   if (!isSyncWorkerRunning()) {
     kickBackfillDrain(dir, () => runtime!.config);
   }

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowsRotateRight } from '@gravity-ui/icons';
 import {
   Alert,
   Button,
@@ -17,6 +18,7 @@ import {
   TextField,
   Toast,
   ToastQueue,
+  Tooltip,
 } from '@heroui/react';
 import type { AutoUpdateState } from '../../shared/auto-update';
 import {
@@ -24,6 +26,7 @@ import {
   getApiBearer,
   hasConfiguredApiBearer,
   isCliBackend,
+  refreshJuejinProfile,
   saveConfig,
   setApiBearer,
   type TudConfigView,
@@ -444,6 +447,7 @@ function CliSyncSettings({
   const [enabled, setEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [confirmLogoutOpen, setConfirmLogoutOpen] = useState(false);
   const [consentOpen, setConsentOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -466,6 +470,21 @@ function CliSyncSettings({
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (!config?.juejin.userId) return;
+    let cancelled = false;
+    void refreshJuejinProfile({ force: false })
+      .then((result) => {
+        if (!cancelled && result.changed) setConfig(result.config);
+      })
+      .catch(() => {
+        // Keep the login snapshot when the public card is unreachable.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config?.juejin.userId]);
 
   // Deep-link / tray may open settings after writing config — force reload.
   useEffect(() => {
@@ -562,6 +581,51 @@ function CliSyncSettings({
     });
   };
 
+  const onRefreshProfile = async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const result = await refreshJuejinProfile({ force: true });
+      setConfig(result.config);
+      if (result.reason === 'not_linked') {
+        onNotify({
+          title: '无法同步资料',
+          description: '缺少用户 ID，请重新掘金登录关联',
+          variant: 'danger',
+        });
+        return;
+      }
+      if (result.reason === 'fetch_failed') {
+        onNotify({
+          title: '同步失败',
+          description: '暂时无法读取掘金公开资料，请稍后重试',
+          variant: 'danger',
+        });
+        return;
+      }
+      if (result.changed) {
+        dispatchJuejinLinkChanged();
+        onNotify({
+          title: '已同步账号资料',
+          variant: 'success',
+        });
+        return;
+      }
+      onNotify({
+        title: '资料已是最新',
+        variant: 'success',
+      });
+    } catch (e) {
+      onNotify({
+        title: '同步失败',
+        description: e instanceof Error ? e.message : '请稍后重试',
+        variant: 'danger',
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col gap-4 overflow-hidden">
       {error && <StatusBanner tone="error" title={error} />}
@@ -588,7 +652,7 @@ function CliSyncSettings({
         <div className="flex items-start justify-between gap-4 text-sm">
           <span className="shrink-0 text-muted">关联账号</span>
           {userId ? (
-            <div className="flex min-w-0 items-center gap-2.5">
+            <div className="flex min-w-0 items-center gap-2">
               {avatarLarge ? (
                 <img
                   alt={userName || '用户头像'}
@@ -624,6 +688,26 @@ function CliSyncSettings({
                   {displayUserId ?? '缺少用户 ID（请重新登录关联）'}
                 </p>
               </div>
+              <Tooltip closeDelay={80} delay={100}>
+                <Button
+                  aria-label="同步资料"
+                  className="size-6 min-h-6 min-w-6 shrink-0 p-0 text-muted"
+                  isDisabled={saving || refreshing}
+                  isIconOnly
+                  onPress={() => {
+                    void onRefreshProfile();
+                  }}
+                  size="sm"
+                  variant="ghost"
+                >
+                  <ArrowsRotateRight
+                    className={`size-3.5 ${refreshing ? 'animate-spin' : ''}`}
+                  />
+                </Button>
+                <Tooltip.Content placement="bottom">
+                  <p>同步资料</p>
+                </Tooltip.Content>
+              </Tooltip>
             </div>
           ) : (
             <span className="text-muted">未关联</span>

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -587,32 +587,9 @@ function CliSyncSettings({
     try {
       const result = await refreshJuejinProfile({ force: true });
       setConfig(result.config);
-      if (result.reason === 'not_linked') {
-        onNotify({
-          title: '无法同步资料',
-          description: '缺少用户 ID，请重新掘金登录关联',
-          variant: 'danger',
-        });
-        return;
-      }
-      if (result.reason === 'fetch_failed') {
-        onNotify({
-          title: '同步失败',
-          description: '暂时无法读取掘金公开资料，请稍后重试',
-          variant: 'danger',
-        });
-        return;
-      }
-      if (result.changed) {
-        dispatchJuejinLinkChanged();
-        onNotify({
-          title: '已同步账号资料',
-          variant: 'success',
-        });
-        return;
-      }
+      if (result.changed) dispatchJuejinLinkChanged();
       onNotify({
-        title: '资料已是最新',
+        title: result.changed ? '已同步账号资料' : '资料已是最新',
         variant: 'success',
       });
     } catch (e) {

--- a/apps/desktop/src/renderer/lib/api.ts
+++ b/apps/desktop/src/renderer/lib/api.ts
@@ -484,19 +484,8 @@ export async function saveConfig(update: TudConfigUpdate): Promise<TudConfigView
   });
 }
 
-export type JuejinProfileSyncReason =
-  | 'not_linked'
-  | 'throttled'
-  | 'fetch_failed'
-  | 'unchanged'
-  | 'updated';
-
 export interface JuejinProfileSyncResponse {
   changed: boolean;
-  fetched: boolean;
-  reason: JuejinProfileSyncReason;
-  userName: string | null;
-  avatarLarge: string | null;
   config: TudConfigView;
 }
 

--- a/apps/desktop/src/renderer/lib/api.ts
+++ b/apps/desktop/src/renderer/lib/api.ts
@@ -484,6 +484,34 @@ export async function saveConfig(update: TudConfigUpdate): Promise<TudConfigView
   });
 }
 
+export type JuejinProfileSyncReason =
+  | 'not_linked'
+  | 'throttled'
+  | 'fetch_failed'
+  | 'unchanged'
+  | 'updated';
+
+export interface JuejinProfileSyncResponse {
+  changed: boolean;
+  fetched: boolean;
+  reason: JuejinProfileSyncReason;
+  userName: string | null;
+  avatarLarge: string | null;
+  config: TudConfigView;
+}
+
+/** Pull the public Juejin user card into the local login snapshot. */
+export async function refreshJuejinProfile(
+  opts?: { force?: boolean },
+): Promise<JuejinProfileSyncResponse> {
+  const { others } = apiPrefixes();
+  return request<JuejinProfileSyncResponse>(`${others}refresh-profile`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ force: Boolean(opts?.force) }),
+  });
+}
+
 /** User-facing hint for load/sync failures (IPC local-api vs server). */
 export function apiErrorHint(message: string): string | null {
   const lower = message.toLowerCase();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ import {
   resolvePricingRefreshConfig,
   DEFAULT_PRICING_FIRST_FETCH_TIMEOUT_MS,
   startPricingRefresh,
+  syncJuejinProfile,
   type AggregateCache,
   type SyncResult,
   type TudConfig,
@@ -228,6 +229,15 @@ async function cmdStart(portArg?: number, hostArg?: string, daysAgo?: number): P
   const aggregateCache = await createAggregateCache(dir, bucketStore.getRows());
   runtime = { dir, config: refreshed, bucketStore, aggregateCache };
   runtimeDataDir = dir;
+
+  if (!isObserver) {
+    void syncJuejinProfile(dir, runtime.config).catch((err) => {
+      console.warn(
+        'juejin profile sync failed:',
+        err instanceof Error ? err.message : err,
+      );
+    });
+  }
 
   // Idle rounds back off 1min → 2min → 5min; hook/manual activity re-arms at 1min.
   const pollBackoff = createPollBackoff();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './leaderboard.js';
 export * from './tool-catalog.js';
 export * from './paths.js';
 export * from './config.js';
+export * from './juejin-profile.js';
 export * from './debug-log.js';
 export * from './signals.js';
 export * from './runtime-pid.js';

--- a/packages/core/src/juejin-profile.ts
+++ b/packages/core/src/juejin-profile.ts
@@ -1,0 +1,253 @@
+/**
+ * Refresh the locally cached Juejin display name / avatar from the public
+ * user card. Login association writes a snapshot; cloud upload does not
+ * refresh it, and `tud-session` needs a browser cookie.
+ */
+import { saveConfig } from './config.js';
+import type { TudConfig } from './types.js';
+
+const JUEJIN_USER_GET_URL = 'https://api.juejin.cn/user_api/v1/user/get';
+export const JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 8_000;
+const DISPLAY_NAME_MAX_LEN = 64;
+const AVATAR_URL_MAX_LEN = 2048;
+
+export type JuejinProfileSyncReason =
+  | 'not_linked'
+  | 'throttled'
+  | 'fetch_failed'
+  | 'unchanged'
+  | 'updated';
+
+export interface JuejinProfileSyncResult {
+  changed: boolean;
+  fetched: boolean;
+  reason: JuejinProfileSyncReason;
+  userName: string | null;
+  avatarLarge: string | null;
+}
+
+export interface JuejinPublicProfile {
+  userId: string;
+  /** Display name, or null when empty / too long. */
+  userName: string | null;
+  avatarLarge: string | null;
+}
+
+export interface SyncJuejinProfileOptions {
+  force?: boolean;
+  fetchImpl?: typeof fetch;
+  nowMs?: number;
+}
+
+const lastAttemptByUser = new Map<string, number>();
+const inFlightByDir = new Map<string, Promise<JuejinProfileSyncResult>>();
+
+export function resetJuejinProfileSyncStateForTests(): void {
+  lastAttemptByUser.clear();
+  inFlightByDir.clear();
+}
+
+function stripWrappingQuotes(raw: string): string {
+  const trimmed = raw.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function looksLikePlainJuejinUserId(value: string): boolean {
+  return /^\d{6,20}$/.test(value);
+}
+
+/** Plain Juejin id used to fetch the public user card. */
+export function resolveProfileOriginUserId(
+  config: TudConfig,
+): string | null {
+  const origin = stripWrappingQuotes(config.juejin.originUserId?.trim() || '');
+  if (origin && looksLikePlainJuejinUserId(origin)) return origin;
+  const token = stripWrappingQuotes(config.juejin.token?.trim() || '');
+  if (token && looksLikePlainJuejinUserId(token)) return token;
+  return null;
+}
+
+export function isUsableDisplayName(name: string): boolean {
+  const trimmed = name.trim();
+  return Boolean(trimmed) && trimmed.length <= DISPLAY_NAME_MAX_LEN;
+}
+
+export function isUsableAvatarUrl(url: string): boolean {
+  const trimmed = url.trim();
+  if (!trimmed || trimmed.length > AVATAR_URL_MAX_LEN || /\s/.test(trimmed)) {
+    return false;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === 'https:' && Boolean(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function parseJuejinUserGetPayload(
+  raw: unknown,
+  originUserId: string,
+): JuejinPublicProfile | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const body = raw as Record<string, unknown>;
+  if (body.err_no !== 0 && body.err_no !== undefined) return null;
+  const data = body.data;
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
+  const user = data as Record<string, unknown>;
+
+  const idRaw = user.user_id;
+  const userId =
+    typeof idRaw === 'string' || typeof idRaw === 'number'
+      ? String(idRaw).trim()
+      : originUserId;
+  if (
+    userId &&
+    originUserId &&
+    userId !== originUserId &&
+    looksLikePlainJuejinUserId(userId) &&
+    looksLikePlainJuejinUserId(originUserId)
+  ) {
+    return null;
+  }
+
+  const rawName = typeof user.user_name === 'string' ? user.user_name.trim() : '';
+  const rawAvatar =
+    typeof user.avatar_large === 'string' ? user.avatar_large.trim() : '';
+
+  return {
+    userId: userId || originUserId,
+    userName: rawName && isUsableDisplayName(rawName) ? rawName : null,
+    avatarLarge: rawAvatar && isUsableAvatarUrl(rawAvatar) ? rawAvatar : null,
+  };
+}
+
+export async function fetchJuejinPublicProfile(
+  originUserId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JuejinPublicProfile | null> {
+  const url = new URL(JUEJIN_USER_GET_URL);
+  url.searchParams.set('aid', '2608');
+  url.searchParams.set('user_id', originUserId);
+  url.searchParams.set('not_self', '1');
+
+  try {
+    const res = await fetchImpl(url, {
+      headers: {
+        Accept: 'application/json',
+        Referer: 'https://juejin.cn/',
+        'User-Agent': 'Mozilla/5.0 (compatible; jusage)',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      return null;
+    }
+    return parseJuejinUserGetPayload(body, originUserId);
+  } catch {
+    return null;
+  }
+}
+
+function currentProfile(config: TudConfig): {
+  userName: string | null;
+  avatarLarge: string | null;
+} {
+  return {
+    userName: config.juejin.userName?.trim() || null,
+    avatarLarge: config.juejin.avatarLarge?.trim() || null,
+  };
+}
+
+function emptyResult(
+  config: TudConfig,
+  reason: JuejinProfileSyncReason,
+): JuejinProfileSyncResult {
+  const current = currentProfile(config);
+  return {
+    changed: false,
+    fetched: false,
+    reason,
+    userName: current.userName,
+    avatarLarge: current.avatarLarge,
+  };
+}
+
+async function syncJuejinProfileUnlocked(
+  dataDir: string,
+  config: TudConfig,
+  opts: SyncJuejinProfileOptions,
+): Promise<JuejinProfileSyncResult> {
+  const originUserId = resolveProfileOriginUserId(config);
+  if (!originUserId) return emptyResult(config, 'not_linked');
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const force = Boolean(opts.force);
+  const lastAttemptMs = lastAttemptByUser.get(originUserId) ?? 0;
+  if (
+    !force &&
+    lastAttemptMs > 0 &&
+    nowMs - lastAttemptMs < JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS
+  ) {
+    return emptyResult(config, 'throttled');
+  }
+  lastAttemptByUser.set(originUserId, nowMs);
+
+  const profile = await fetchJuejinPublicProfile(originUserId, opts.fetchImpl);
+  if (!profile) return emptyResult(config, 'fetch_failed');
+
+  const current = currentProfile(config);
+  const nextName = profile.userName ?? current.userName;
+  const nextAvatar = profile.avatarLarge ?? current.avatarLarge;
+  const changed =
+    nextName !== current.userName || nextAvatar !== current.avatarLarge;
+
+  if (!changed) {
+    return {
+      changed: false,
+      fetched: true,
+      reason: 'unchanged',
+      userName: current.userName,
+      avatarLarge: current.avatarLarge,
+    };
+  }
+
+  config.juejin.userName = nextName;
+  config.juejin.avatarLarge = nextAvatar;
+  await saveConfig(dataDir, config);
+
+  return {
+    changed: true,
+    fetched: true,
+    reason: 'updated',
+    userName: nextName,
+    avatarLarge: nextAvatar,
+  };
+}
+
+/** Fetch the public Juejin card and write usable fields into config.json. */
+export async function syncJuejinProfile(
+  dataDir: string,
+  config: TudConfig,
+  opts: SyncJuejinProfileOptions = {},
+): Promise<JuejinProfileSyncResult> {
+  const existing = inFlightByDir.get(dataDir);
+  if (existing) return existing;
+  const pending = syncJuejinProfileUnlocked(dataDir, config, opts).finally(() => {
+    inFlightByDir.delete(dataDir);
+  });
+  inFlightByDir.set(dataDir, pending);
+  return pending;
+}

--- a/packages/core/src/juejin-profile.ts
+++ b/packages/core/src/juejin-profile.ts
@@ -21,15 +21,10 @@ export type JuejinProfileSyncReason =
 
 export interface JuejinProfileSyncResult {
   changed: boolean;
-  fetched: boolean;
   reason: JuejinProfileSyncReason;
-  userName: string | null;
-  avatarLarge: string | null;
 }
 
 export interface JuejinPublicProfile {
-  userId: string;
-  /** Display name, or null when empty / too long. */
   userName: string | null;
   avatarLarge: string | null;
 }
@@ -64,10 +59,7 @@ function looksLikePlainJuejinUserId(value: string): boolean {
   return /^\d{6,20}$/.test(value);
 }
 
-/** Plain Juejin id used to fetch the public user card. */
-export function resolveProfileOriginUserId(
-  config: TudConfig,
-): string | null {
+export function resolveProfileOriginUserId(config: TudConfig): string | null {
   const origin = stripWrappingQuotes(config.juejin.originUserId?.trim() || '');
   if (origin && looksLikePlainJuejinUserId(origin)) return origin;
   const token = stripWrappingQuotes(config.juejin.token?.trim() || '');
@@ -108,23 +100,13 @@ export function parseJuejinUserGetPayload(
   const userId =
     typeof idRaw === 'string' || typeof idRaw === 'number'
       ? String(idRaw).trim()
-      : originUserId;
-  if (
-    userId &&
-    originUserId &&
-    userId !== originUserId &&
-    looksLikePlainJuejinUserId(userId) &&
-    looksLikePlainJuejinUserId(originUserId)
-  ) {
-    return null;
-  }
+      : '';
+  if (userId && userId !== originUserId) return null;
 
   const rawName = typeof user.user_name === 'string' ? user.user_name.trim() : '';
   const rawAvatar =
     typeof user.avatar_large === 'string' ? user.avatar_large.trim() : '';
-
   return {
-    userId: userId || originUserId,
     userName: rawName && isUsableDisplayName(rawName) ? rawName : null,
     avatarLarge: rawAvatar && isUsableAvatarUrl(rawAvatar) ? rawAvatar : null,
   };
@@ -171,70 +153,39 @@ function currentProfile(config: TudConfig): {
   };
 }
 
-function emptyResult(
-  config: TudConfig,
-  reason: JuejinProfileSyncReason,
-): JuejinProfileSyncResult {
-  const current = currentProfile(config);
-  return {
-    changed: false,
-    fetched: false,
-    reason,
-    userName: current.userName,
-    avatarLarge: current.avatarLarge,
-  };
-}
-
 async function syncJuejinProfileUnlocked(
   dataDir: string,
   config: TudConfig,
   opts: SyncJuejinProfileOptions,
 ): Promise<JuejinProfileSyncResult> {
   const originUserId = resolveProfileOriginUserId(config);
-  if (!originUserId) return emptyResult(config, 'not_linked');
+  if (!originUserId) return { changed: false, reason: 'not_linked' };
 
   const nowMs = opts.nowMs ?? Date.now();
-  const force = Boolean(opts.force);
   const lastAttemptMs = lastAttemptByUser.get(originUserId) ?? 0;
   if (
-    !force &&
+    !opts.force &&
     lastAttemptMs > 0 &&
     nowMs - lastAttemptMs < JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS
   ) {
-    return emptyResult(config, 'throttled');
+    return { changed: false, reason: 'throttled' };
   }
   lastAttemptByUser.set(originUserId, nowMs);
 
   const profile = await fetchJuejinPublicProfile(originUserId, opts.fetchImpl);
-  if (!profile) return emptyResult(config, 'fetch_failed');
+  if (!profile) return { changed: false, reason: 'fetch_failed' };
 
   const current = currentProfile(config);
   const nextName = profile.userName ?? current.userName;
   const nextAvatar = profile.avatarLarge ?? current.avatarLarge;
-  const changed =
-    nextName !== current.userName || nextAvatar !== current.avatarLarge;
-
-  if (!changed) {
-    return {
-      changed: false,
-      fetched: true,
-      reason: 'unchanged',
-      userName: current.userName,
-      avatarLarge: current.avatarLarge,
-    };
+  if (nextName === current.userName && nextAvatar === current.avatarLarge) {
+    return { changed: false, reason: 'unchanged' };
   }
 
   config.juejin.userName = nextName;
   config.juejin.avatarLarge = nextAvatar;
   await saveConfig(dataDir, config);
-
-  return {
-    changed: true,
-    fetched: true,
-    reason: 'updated',
-    userName: nextName,
-    avatarLarge: nextAvatar,
-  };
+  return { changed: true, reason: 'updated' };
 }
 
 /** Fetch the public Juejin card and write usable fields into config.json. */

--- a/packages/core/src/juejin-profile.ts
+++ b/packages/core/src/juejin-profile.ts
@@ -1,12 +1,11 @@
 /**
- * Refresh the locally cached Juejin display name / avatar from the public
- * user card. Login association writes a snapshot; cloud upload does not
- * refresh it, and `tud-session` needs a browser cookie.
+ * Refresh the locally cached Juejin display name / avatar via the public
+ * aiusage `tud-session` contract (same envelope as online login).
  */
-import { saveConfig } from './config.js';
+import { resolveLinkedUserId, saveConfig } from './config.js';
 import type { TudConfig } from './types.js';
+import { normalizeApiUrl } from './upload/state.js';
 
-const JUEJIN_USER_GET_URL = 'https://api.juejin.cn/user_api/v1/user/get';
 export const JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS = 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 8_000;
 const DISPLAY_NAME_MAX_LEN = 64;
@@ -24,9 +23,10 @@ export interface JuejinProfileSyncResult {
   reason: JuejinProfileSyncReason;
 }
 
-export interface JuejinPublicProfile {
+export interface JuejinSessionProfile {
   userName: string | null;
   avatarLarge: string | null;
+  originUserId: string | null;
 }
 
 export interface SyncJuejinProfileOptions {
@@ -35,36 +35,12 @@ export interface SyncJuejinProfileOptions {
   nowMs?: number;
 }
 
-const lastAttemptByUser = new Map<string, number>();
+const lastAttemptByToken = new Map<string, number>();
 const inFlightByDir = new Map<string, Promise<JuejinProfileSyncResult>>();
 
 export function resetJuejinProfileSyncStateForTests(): void {
-  lastAttemptByUser.clear();
+  lastAttemptByToken.clear();
   inFlightByDir.clear();
-}
-
-function stripWrappingQuotes(raw: string): string {
-  const trimmed = raw.trim();
-  if (
-    trimmed.length >= 2 &&
-    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-      (trimmed.startsWith("'") && trimmed.endsWith("'")))
-  ) {
-    return trimmed.slice(1, -1).trim();
-  }
-  return trimmed;
-}
-
-function looksLikePlainJuejinUserId(value: string): boolean {
-  return /^\d{6,20}$/.test(value);
-}
-
-export function resolveProfileOriginUserId(config: TudConfig): string | null {
-  const origin = stripWrappingQuotes(config.juejin.originUserId?.trim() || '');
-  if (origin && looksLikePlainJuejinUserId(origin)) return origin;
-  const token = stripWrappingQuotes(config.juejin.token?.trim() || '');
-  if (token && looksLikePlainJuejinUserId(token)) return token;
-  return null;
 }
 
 export function isUsableDisplayName(name: string): boolean {
@@ -85,48 +61,37 @@ export function isUsableAvatarUrl(url: string): boolean {
   }
 }
 
-export function parseJuejinUserGetPayload(
-  raw: unknown,
-  originUserId: string,
-): JuejinPublicProfile | null {
+export function parseTudSessionPayload(raw: unknown): JuejinSessionProfile | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
   const body = raw as Record<string, unknown>;
-  if (body.err_no !== 0 && body.err_no !== undefined) return null;
+  if (body.success === false) return null;
   const data = body.data;
   if (!data || typeof data !== 'object' || Array.isArray(data)) return null;
-  const user = data as Record<string, unknown>;
+  const session = data as Record<string, unknown>;
 
-  const idRaw = user.user_id;
-  const userId =
-    typeof idRaw === 'string' || typeof idRaw === 'number'
-      ? String(idRaw).trim()
-      : '';
-  if (userId && userId !== originUserId) return null;
-
-  const rawName = typeof user.user_name === 'string' ? user.user_name.trim() : '';
+  const rawName = typeof session.userName === 'string' ? session.userName.trim() : '';
   const rawAvatar =
-    typeof user.avatar_large === 'string' ? user.avatar_large.trim() : '';
+    typeof session.avatarLarge === 'string' ? session.avatarLarge.trim() : '';
+  const origin =
+    typeof session.originUserId === 'string' ? session.originUserId.trim() : '';
   return {
     userName: rawName && isUsableDisplayName(rawName) ? rawName : null,
     avatarLarge: rawAvatar && isUsableAvatarUrl(rawAvatar) ? rawAvatar : null,
+    originUserId: origin || null,
   };
 }
 
-export async function fetchJuejinPublicProfile(
-  originUserId: string,
+export async function fetchJuejinSessionProfile(
+  apiUrl: string,
+  token: string,
   fetchImpl: typeof fetch = fetch,
-): Promise<JuejinPublicProfile | null> {
-  const url = new URL(JUEJIN_USER_GET_URL);
-  url.searchParams.set('aid', '2608');
-  url.searchParams.set('user_id', originUserId);
-  url.searchParams.set('not_self', '1');
-
+): Promise<JuejinSessionProfile | null> {
+  const url = `${normalizeApiUrl(apiUrl)}/functions/tud-session`;
   try {
     const res = await fetchImpl(url, {
       headers: {
         Accept: 'application/json',
-        Referer: 'https://juejin.cn/',
-        'User-Agent': 'Mozilla/5.0 (compatible; jusage)',
+        Authorization: `Bearer ${token}`,
       },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
@@ -137,7 +102,7 @@ export async function fetchJuejinPublicProfile(
     } catch {
       return null;
     }
-    return parseJuejinUserGetPayload(body, originUserId);
+    return parseTudSessionPayload(body);
   } catch {
     return null;
   }
@@ -146,10 +111,12 @@ export async function fetchJuejinPublicProfile(
 function currentProfile(config: TudConfig): {
   userName: string | null;
   avatarLarge: string | null;
+  originUserId: string | null;
 } {
   return {
     userName: config.juejin.userName?.trim() || null,
     avatarLarge: config.juejin.avatarLarge?.trim() || null,
+    originUserId: config.juejin.originUserId?.trim() || null,
   };
 }
 
@@ -158,11 +125,12 @@ async function syncJuejinProfileUnlocked(
   config: TudConfig,
   opts: SyncJuejinProfileOptions,
 ): Promise<JuejinProfileSyncResult> {
-  const originUserId = resolveProfileOriginUserId(config);
-  if (!originUserId) return { changed: false, reason: 'not_linked' };
+  const token = resolveLinkedUserId(config.deviceId, config.juejin.token);
+  const apiUrl = normalizeApiUrl(config.juejin.apiUrl ?? '');
+  if (!token || !apiUrl) return { changed: false, reason: 'not_linked' };
 
   const nowMs = opts.nowMs ?? Date.now();
-  const lastAttemptMs = lastAttemptByUser.get(originUserId) ?? 0;
+  const lastAttemptMs = lastAttemptByToken.get(token) ?? 0;
   if (
     !opts.force &&
     lastAttemptMs > 0 &&
@@ -170,25 +138,31 @@ async function syncJuejinProfileUnlocked(
   ) {
     return { changed: false, reason: 'throttled' };
   }
-  lastAttemptByUser.set(originUserId, nowMs);
+  lastAttemptByToken.set(token, nowMs);
 
-  const profile = await fetchJuejinPublicProfile(originUserId, opts.fetchImpl);
+  const profile = await fetchJuejinSessionProfile(apiUrl, token, opts.fetchImpl);
   if (!profile) return { changed: false, reason: 'fetch_failed' };
 
   const current = currentProfile(config);
   const nextName = profile.userName ?? current.userName;
   const nextAvatar = profile.avatarLarge ?? current.avatarLarge;
-  if (nextName === current.userName && nextAvatar === current.avatarLarge) {
+  const nextOrigin = profile.originUserId ?? current.originUserId;
+  if (
+    nextName === current.userName &&
+    nextAvatar === current.avatarLarge &&
+    nextOrigin === current.originUserId
+  ) {
     return { changed: false, reason: 'unchanged' };
   }
 
   config.juejin.userName = nextName;
   config.juejin.avatarLarge = nextAvatar;
+  config.juejin.originUserId = nextOrigin;
   await saveConfig(dataDir, config);
   return { changed: true, reason: 'updated' };
 }
 
-/** Fetch the public Juejin card and write usable fields into config.json. */
+/** Pull tud-session profile fields into config.json. */
 export async function syncJuejinProfile(
   dataDir: string,
   config: TudConfig,

--- a/packages/core/src/server/local-api.ts
+++ b/packages/core/src/server/local-api.ts
@@ -570,15 +570,16 @@ export function createLocalApiApp(deps: LocalApiDeps): Hono {
     }
     const config = deps.getConfig();
     const result = await syncJuejinProfile(deps.dataDir, config, { force });
+    if (result.reason === 'fetch_failed') {
+      return c.json(
+        { success: false, message: 'PROFILE_FETCH_FAILED', data: null },
+        502,
+      );
+    }
     if (result.changed) {
       deps.onConfigChange?.(config);
     }
-    return c.json(
-      ok({
-        ...result,
-        config: toConfigView(config),
-      }),
-    );
+    return c.json(ok({ changed: result.changed, config: toConfigView(config) }));
   });
 
   app.post('/functions/tud-trigger-sync', async (c) => {

--- a/packages/core/src/server/local-api.ts
+++ b/packages/core/src/server/local-api.ts
@@ -9,6 +9,7 @@ import {
   aggregateModelBreakdown,
 } from '../aggregate.js';
 import { resolveLinkedUserId, resolveLocalCollectSince, saveConfig } from '../config.js';
+import { syncJuejinProfile } from '../juejin-profile.js';
 import { LEADERBOARD_DEFAULT_LIMIT } from '../leaderboard.js';
 import type {
   LeaderboardBoard,
@@ -557,6 +558,27 @@ export function createLocalApiApp(deps: LocalApiDeps): Hono {
     }
 
     return c.json(ok(toConfigView(config)));
+  });
+
+  app.post('/functions/tud-refresh-profile', async (c) => {
+    let force = false;
+    try {
+      const body = await c.req.json<{ force?: boolean }>();
+      force = Boolean(body?.force);
+    } catch {
+      // empty body → auto (throttled) refresh
+    }
+    const config = deps.getConfig();
+    const result = await syncJuejinProfile(deps.dataDir, config, { force });
+    if (result.changed) {
+      deps.onConfigChange?.(config);
+    }
+    return c.json(
+      ok({
+        ...result,
+        config: toConfigView(config),
+      }),
+    );
   });
 
   app.post('/functions/tud-trigger-sync', async (c) => {

--- a/packages/core/test/juejin-profile.test.ts
+++ b/packages/core/test/juejin-profile.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { bakedPricingConfig } from '../src/config.js';
+import { configPath } from '../src/paths.js';
+import {
+  JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS,
+  isUsableAvatarUrl,
+  isUsableDisplayName,
+  parseJuejinUserGetPayload,
+  resetJuejinProfileSyncStateForTests,
+  resolveProfileOriginUserId,
+  syncJuejinProfile,
+} from '../src/juejin-profile.js';
+import type { TudConfig } from '../src/types.js';
+
+function config(partial?: Partial<TudConfig['juejin']>): TudConfig {
+  return {
+    deviceId: '550e8400-e29b-41d4-a716-446655440000',
+    statsSince: '2026-01-01T00:00:00.000Z',
+    hostname: 'test',
+    dataDir: '/tmp',
+    juejin: {
+      enabled: true,
+      apiUrl: 'https://api.juejin.cn/aiusage_api',
+      authMode: 'tbd',
+      token: 'jau.opaque',
+      originUserId: '916310739397084',
+      userName: '压抑了',
+      avatarLarge:
+        'https://p3-passport.byteacctimg.com/img/user-avatar/oldhash~300x300.image',
+      ...partial,
+    },
+    pricing: bakedPricingConfig(),
+  };
+}
+
+function payload(overrides?: Record<string, unknown>) {
+  return {
+    err_no: 0,
+    err_msg: 'success',
+    data: {
+      user_id: '916310739397084',
+      user_name: '新昵称',
+      avatar_large:
+        'https://p3-passport.byteacctimg.com/img/user-avatar/newhash~300x300.image',
+      ...overrides,
+    },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+test('isUsableDisplayName accepts unusual but real nicknames', () => {
+  assert.equal(isUsableDisplayName('压抑了'), true);
+  assert.equal(isUsableDisplayName('松尾'), true);
+  assert.equal(isUsableDisplayName('未知用户undefined'), true);
+  assert.equal(isUsableDisplayName(''), false);
+  assert.equal(isUsableDisplayName('   '), false);
+});
+
+test('isUsableAvatarUrl accepts https CDN urls', () => {
+  assert.equal(
+    isUsableAvatarUrl(
+      'https://p3-passport.byteacctimg.com/img/user-avatar/abc~300x300.image',
+    ),
+    true,
+  );
+  assert.equal(isUsableAvatarUrl('http://insecure.example/a.png'), false);
+  assert.equal(isUsableAvatarUrl('not a url'), false);
+  assert.equal(isUsableAvatarUrl('https://evil.example/a.png with space'), false);
+});
+
+test('parseJuejinUserGetPayload keeps unusual nicknames', () => {
+  const parsed = parseJuejinUserGetPayload(
+    payload({ user_name: '未知用户undefined' }),
+    '916310739397084',
+  );
+  assert.ok(parsed);
+  assert.equal(parsed?.userName, '未知用户undefined');
+  assert.match(parsed?.avatarLarge ?? '', /newhash/);
+});
+
+test('parseJuejinUserGetPayload rejects a different user id', () => {
+  const parsed = parseJuejinUserGetPayload(
+    payload({ user_id: '1234567890' }),
+    '916310739397084',
+  );
+  assert.equal(parsed, null);
+});
+
+test('resolveProfileOriginUserId strips quoted ids', () => {
+  const value = config({ originUserId: '"916310739397084"' });
+  assert.equal(resolveProfileOriginUserId(value), '916310739397084');
+  assert.equal(
+    resolveProfileOriginUserId(config({ originUserId: null, token: 'jau.x' })),
+    null,
+  );
+});
+
+test('syncJuejinProfile writes the remote name even when it looks unusual', async () => {
+  resetJuejinProfileSyncStateForTests();
+  const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
+  const value = config();
+  value.dataDir = dir;
+  try {
+    const result = await syncJuejinProfile(dir, value, {
+      force: true,
+      nowMs: 1,
+      fetchImpl: async () =>
+        jsonResponse(payload({ user_name: '未知用户undefined' })),
+    });
+    assert.equal(result.reason, 'updated');
+    assert.equal(result.changed, true);
+    assert.equal(result.userName, '未知用户undefined');
+    assert.match(result.avatarLarge ?? '', /newhash/);
+    const saved = JSON.parse(await readFile(configPath(dir), 'utf8')) as TudConfig;
+    assert.equal(saved.juejin.userName, '未知用户undefined');
+    assert.match(saved.juejin.avatarLarge ?? '', /newhash/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('syncJuejinProfile keeps the login snapshot when remote name is empty', async () => {
+  resetJuejinProfileSyncStateForTests();
+  const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
+  const value = config();
+  try {
+    const result = await syncJuejinProfile(dir, value, {
+      force: true,
+      nowMs: 1,
+      fetchImpl: async () => jsonResponse(payload({ user_name: '' })),
+    });
+    assert.equal(result.changed, true);
+    assert.equal(result.userName, '压抑了');
+    assert.match(result.avatarLarge ?? '', /newhash/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('syncJuejinProfile writes a usable remote name', async () => {
+  resetJuejinProfileSyncStateForTests();
+  const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
+  const value = config();
+  try {
+    const result = await syncJuejinProfile(dir, value, {
+      force: true,
+      nowMs: 1,
+      fetchImpl: async () => jsonResponse(payload()),
+    });
+    assert.equal(result.reason, 'updated');
+    assert.equal(result.userName, '新昵称');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('syncJuejinProfile auto path is throttled until the interval elapses', async () => {
+  resetJuejinProfileSyncStateForTests();
+  const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
+  const value = config();
+  let calls = 0;
+  const fetchImpl: typeof fetch = async () => {
+    calls += 1;
+    return jsonResponse(payload());
+  };
+  try {
+    const first = await syncJuejinProfile(dir, value, {
+      nowMs: 10,
+      fetchImpl,
+    });
+    assert.equal(first.reason, 'updated');
+    const second = await syncJuejinProfile(dir, value, {
+      nowMs: 11,
+      fetchImpl,
+    });
+    assert.equal(second.reason, 'throttled');
+    assert.equal(calls, 1);
+    const forced = await syncJuejinProfile(dir, value, {
+      force: true,
+      nowMs: 11,
+      fetchImpl,
+    });
+    assert.equal(forced.reason, 'unchanged');
+    assert.equal(calls, 2);
+    const later = await syncJuejinProfile(dir, value, {
+      nowMs: 11 + JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS,
+      fetchImpl,
+    });
+    assert.equal(later.reason, 'unchanged');
+    assert.equal(calls, 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('syncJuejinProfile is a no-op without a linked origin user id', async () => {
+  resetJuejinProfileSyncStateForTests();
+  const value = config({ originUserId: null, token: 'jau.opaque' });
+  const result = await syncJuejinProfile('/tmp', value, {
+    force: true,
+    fetchImpl: async () => {
+      throw new Error('should not fetch');
+    },
+  });
+  assert.equal(result.reason, 'not_linked');
+  assert.equal(result.fetched, false);
+});

--- a/packages/core/test/juejin-profile.test.ts
+++ b/packages/core/test/juejin-profile.test.ts
@@ -10,9 +10,8 @@ import {
   JUEJIN_PROFILE_AUTO_MIN_INTERVAL_MS,
   isUsableAvatarUrl,
   isUsableDisplayName,
-  parseJuejinUserGetPayload,
+  parseTudSessionPayload,
   resetJuejinProfileSyncStateForTests,
-  resolveProfileOriginUserId,
   syncJuejinProfile,
 } from '../src/juejin-profile.js';
 import type { TudConfig } from '../src/types.js';
@@ -40,12 +39,13 @@ function config(partial?: Partial<TudConfig['juejin']>): TudConfig {
 
 function payload(overrides?: Record<string, unknown>) {
   return {
-    err_no: 0,
-    err_msg: 'success',
+    success: true,
+    message: 'ok',
     data: {
-      user_id: '916310739397084',
-      user_name: '新昵称',
-      avatar_large:
+      encryptedUserId: 'jau.opaque',
+      originUserId: '916310739397084',
+      userName: '新昵称',
+      avatarLarge:
         'https://p3-passport.byteacctimg.com/img/user-avatar/newhash~300x300.image',
       ...overrides,
     },
@@ -61,10 +61,8 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 test('isUsableDisplayName accepts unusual but real nicknames', () => {
   assert.equal(isUsableDisplayName('压抑了'), true);
-  assert.equal(isUsableDisplayName('松尾'), true);
   assert.equal(isUsableDisplayName('未知用户undefined'), true);
   assert.equal(isUsableDisplayName(''), false);
-  assert.equal(isUsableDisplayName('   '), false);
 });
 
 test('isUsableAvatarUrl accepts https CDN urls', () => {
@@ -76,37 +74,25 @@ test('isUsableAvatarUrl accepts https CDN urls', () => {
   );
   assert.equal(isUsableAvatarUrl('http://insecure.example/a.png'), false);
   assert.equal(isUsableAvatarUrl('not a url'), false);
-  assert.equal(isUsableAvatarUrl('https://evil.example/a.png with space'), false);
 });
 
-test('parseJuejinUserGetPayload keeps unusual nicknames', () => {
-  const parsed = parseJuejinUserGetPayload(
-    payload({ user_name: '未知用户undefined' }),
-    '916310739397084',
+test('parseTudSessionPayload keeps unusual nicknames', () => {
+  const parsed = parseTudSessionPayload(
+    payload({ userName: '未知用户undefined' }),
   );
   assert.ok(parsed);
   assert.equal(parsed?.userName, '未知用户undefined');
   assert.match(parsed?.avatarLarge ?? '', /newhash/);
 });
 
-test('parseJuejinUserGetPayload rejects a different user id', () => {
-  const parsed = parseJuejinUserGetPayload(
-    payload({ user_id: '1234567890' }),
-    '916310739397084',
-  );
-  assert.equal(parsed, null);
-});
-
-test('resolveProfileOriginUserId strips quoted ids', () => {
-  const value = config({ originUserId: '"916310739397084"' });
-  assert.equal(resolveProfileOriginUserId(value), '916310739397084');
+test('parseTudSessionPayload rejects failed envelopes', () => {
   assert.equal(
-    resolveProfileOriginUserId(config({ originUserId: null, token: 'jau.x' })),
+    parseTudSessionPayload({ success: false, message: 'UNAUTHENTICATED', data: null }),
     null,
   );
 });
 
-test('syncJuejinProfile writes the remote name even when it looks unusual', async () => {
+test('syncJuejinProfile writes tud-session name and avatar', async () => {
   resetJuejinProfileSyncStateForTests();
   const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
   const value = config();
@@ -115,11 +101,16 @@ test('syncJuejinProfile writes the remote name even when it looks unusual', asyn
     const result = await syncJuejinProfile(dir, value, {
       force: true,
       nowMs: 1,
-      fetchImpl: async () =>
-        jsonResponse(payload({ user_name: '未知用户undefined' })),
+      fetchImpl: async (input, init) => {
+        assert.equal(String(input), 'https://api.juejin.cn/aiusage_api/functions/tud-session');
+        assert.equal(
+          new Headers(init?.headers).get('Authorization'),
+          'Bearer jau.opaque',
+        );
+        return jsonResponse(payload({ userName: '未知用户undefined' }));
+      },
     });
     assert.equal(result.reason, 'updated');
-    assert.equal(result.changed, true);
     assert.equal(value.juejin.userName, '未知用户undefined');
     const saved = JSON.parse(await readFile(configPath(dir), 'utf8')) as TudConfig;
     assert.equal(saved.juejin.userName, '未知用户undefined');
@@ -129,7 +120,7 @@ test('syncJuejinProfile writes the remote name even when it looks unusual', asyn
   }
 });
 
-test('syncJuejinProfile keeps the login snapshot when remote name is empty', async () => {
+test('syncJuejinProfile keeps the login snapshot when session name is empty', async () => {
   resetJuejinProfileSyncStateForTests();
   const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
   const value = config();
@@ -137,7 +128,7 @@ test('syncJuejinProfile keeps the login snapshot when remote name is empty', asy
     const result = await syncJuejinProfile(dir, value, {
       force: true,
       nowMs: 1,
-      fetchImpl: async () => jsonResponse(payload({ user_name: '' })),
+      fetchImpl: async () => jsonResponse(payload({ userName: '' })),
     });
     assert.equal(result.changed, true);
     assert.equal(value.juejin.userName, '压抑了');
@@ -186,9 +177,9 @@ test('syncJuejinProfile auto path is throttled until the interval elapses', asyn
   }
 });
 
-test('syncJuejinProfile is a no-op without a linked origin user id', async () => {
+test('syncJuejinProfile is a no-op when the upload token is still the deviceId', async () => {
   resetJuejinProfileSyncStateForTests();
-  const value = config({ originUserId: null, token: 'jau.opaque' });
+  const value = config({ token: '550e8400-e29b-41d4-a716-446655440000' });
   const result = await syncJuejinProfile('/tmp', value, {
     force: true,
     fetchImpl: async () => {

--- a/packages/core/test/juejin-profile.test.ts
+++ b/packages/core/test/juejin-profile.test.ts
@@ -120,8 +120,7 @@ test('syncJuejinProfile writes the remote name even when it looks unusual', asyn
     });
     assert.equal(result.reason, 'updated');
     assert.equal(result.changed, true);
-    assert.equal(result.userName, '未知用户undefined');
-    assert.match(result.avatarLarge ?? '', /newhash/);
+    assert.equal(value.juejin.userName, '未知用户undefined');
     const saved = JSON.parse(await readFile(configPath(dir), 'utf8')) as TudConfig;
     assert.equal(saved.juejin.userName, '未知用户undefined');
     assert.match(saved.juejin.avatarLarge ?? '', /newhash/);
@@ -141,25 +140,8 @@ test('syncJuejinProfile keeps the login snapshot when remote name is empty', asy
       fetchImpl: async () => jsonResponse(payload({ user_name: '' })),
     });
     assert.equal(result.changed, true);
-    assert.equal(result.userName, '压抑了');
-    assert.match(result.avatarLarge ?? '', /newhash/);
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-});
-
-test('syncJuejinProfile writes a usable remote name', async () => {
-  resetJuejinProfileSyncStateForTests();
-  const dir = await mkdtemp(join(tmpdir(), 'tud-profile-'));
-  const value = config();
-  try {
-    const result = await syncJuejinProfile(dir, value, {
-      force: true,
-      nowMs: 1,
-      fetchImpl: async () => jsonResponse(payload()),
-    });
-    assert.equal(result.reason, 'updated');
-    assert.equal(result.userName, '新昵称');
+    assert.equal(value.juejin.userName, '压抑了');
+    assert.match(value.juejin.avatarLarge ?? '', /newhash/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -214,5 +196,5 @@ test('syncJuejinProfile is a no-op without a linked origin user id', async () =>
     },
   });
   assert.equal(result.reason, 'not_linked');
-  assert.equal(result.fetched, false);
+  assert.equal(result.changed, false);
 });

--- a/packages/core/test/local-api-profile.test.ts
+++ b/packages/core/test/local-api-profile.test.ts
@@ -64,14 +64,12 @@ test('tud-refresh-profile writes remote name and avatar into config', async () =
       success: boolean;
       data: {
         changed: boolean;
-        reason: string;
         config: TudConfigView;
       };
     };
     assert.equal(response.status, 200);
     assert.equal(body.success, true);
     assert.equal(body.data.changed, true);
-    assert.equal(body.data.reason, 'updated');
     assert.equal(body.data.config.juejin.userName, '未知用户undefined');
     assert.match(body.data.config.juejin.avatarLarge ?? '', /newhash/);
   } finally {

--- a/packages/core/test/local-api-profile.test.ts
+++ b/packages/core/test/local-api-profile.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { resetJuejinProfileSyncStateForTests } from '../src/juejin-profile.js';
+import { createLocalApiApp } from '../src/server/local-api.js';
+import { BucketStore, type LocalApiDeps } from '../src/server/state.js';
+import type { TudConfig, TudConfigView } from '../src/types.js';
+
+function config(dir: string): TudConfig {
+  return {
+    deviceId: 'device-test',
+    statsSince: '2026-01-01T00:00:00.000Z',
+    hostname: 'test',
+    dataDir: dir,
+    juejin: {
+      enabled: true,
+      apiUrl: 'https://usage.example.com',
+      authMode: 'bearer',
+      token: 'jau.opaque',
+      originUserId: '200000000000001',
+      userName: '压抑了',
+      avatarLarge:
+        'https://p3-passport.byteacctimg.com/img/user-avatar/oldhash~300x300.image',
+    },
+  };
+}
+
+test('tud-refresh-profile writes remote name and avatar into config', async () => {
+  resetJuejinProfileSyncStateForTests();
+  const dir = await mkdtemp(join(tmpdir(), 'tud-api-profile-'));
+  const value = config(dir);
+  const deps: LocalApiDeps = {
+    dataDir: dir,
+    getConfig: () => value,
+    bucketStore: new BucketStore(),
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        err_no: 0,
+        data: {
+          user_id: '200000000000001',
+          user_name: '未知用户undefined',
+          avatar_large:
+            'https://p3-passport.byteacctimg.com/img/user-avatar/newhash~300x300.image',
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )) as typeof fetch;
+  try {
+    const response = await createLocalApiApp(deps).request(
+      '/functions/tud-refresh-profile',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force: true }),
+      },
+    );
+    const body = (await response.json()) as {
+      success: boolean;
+      data: {
+        changed: boolean;
+        reason: string;
+        config: TudConfigView;
+      };
+    };
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(body.data.changed, true);
+    assert.equal(body.data.reason, 'updated');
+    assert.equal(body.data.config.juejin.userName, '未知用户undefined');
+    assert.match(body.data.config.juejin.avatarLarge ?? '', /newhash/);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/core/test/local-api-profile.test.ts
+++ b/packages/core/test/local-api-profile.test.ts
@@ -28,7 +28,7 @@ function config(dir: string): TudConfig {
   };
 }
 
-test('tud-refresh-profile writes remote name and avatar into config', async () => {
+test('tud-refresh-profile writes tud-session name and avatar into config', async () => {
   resetJuejinProfileSyncStateForTests();
   const dir = await mkdtemp(join(tmpdir(), 'tud-api-profile-'));
   const value = config(dir);
@@ -38,19 +38,26 @@ test('tud-refresh-profile writes remote name and avatar into config', async () =
     bucketStore: new BucketStore(),
   };
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response(
+  let requestedUrl = '';
+  let authorization = '';
+  globalThis.fetch = (async (input, init) => {
+    requestedUrl = String(input);
+    authorization = new Headers(init?.headers).get('Authorization') ?? '';
+    return new Response(
       JSON.stringify({
-        err_no: 0,
+        success: true,
+        message: 'ok',
         data: {
-          user_id: '200000000000001',
-          user_name: '未知用户undefined',
-          avatar_large:
+          encryptedUserId: 'jau.opaque',
+          originUserId: '200000000000001',
+          userName: '未知用户undefined',
+          avatarLarge:
             'https://p3-passport.byteacctimg.com/img/user-avatar/newhash~300x300.image',
         },
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } },
-    )) as typeof fetch;
+    );
+  }) as typeof fetch;
   try {
     const response = await createLocalApiApp(deps).request(
       '/functions/tud-refresh-profile',
@@ -69,6 +76,8 @@ test('tud-refresh-profile writes remote name and avatar into config', async () =
     };
     assert.equal(response.status, 200);
     assert.equal(body.success, true);
+    assert.equal(requestedUrl, 'https://usage.example.com/functions/tud-session');
+    assert.equal(authorization, 'Bearer jau.opaque');
     assert.equal(body.data.changed, true);
     assert.equal(body.data.config.juejin.userName, '未知用户undefined');
     assert.match(body.data.config.juejin.avatarLarge ?? '', /newhash/);

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -261,32 +261,9 @@ function CliSyncSettings({
     try {
       const result = await refreshJuejinProfile({ force: true });
       setConfig(result.config);
-      if (result.reason === 'not_linked') {
-        onNotify({
-          title: '无法同步资料',
-          description: '缺少用户 ID，请重新掘金登录关联',
-          variant: 'danger',
-        });
-        return;
-      }
-      if (result.reason === 'fetch_failed') {
-        onNotify({
-          title: '同步失败',
-          description: '暂时无法读取掘金公开资料，请稍后重试',
-          variant: 'danger',
-        });
-        return;
-      }
-      if (result.changed) {
-        dispatchJuejinLinkChanged();
-        onNotify({
-          title: '已同步账号资料',
-          variant: 'success',
-        });
-        return;
-      }
+      if (result.changed) dispatchJuejinLinkChanged();
       onNotify({
-        title: '资料已是最新',
+        title: result.changed ? '已同步账号资料' : '资料已是最新',
         variant: 'success',
       });
     } catch (e) {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { ArrowsRotateRight } from '@gravity-ui/icons';
 import {
   Button,
   Checkbox,
@@ -11,12 +12,14 @@ import {
   TextField,
   Toast,
   ToastQueue,
+  Tooltip,
 } from '@heroui/react';
 import {
   fetchConfig,
   getApiBearer,
   hasConfiguredApiBearer,
   isCliBackend,
+  refreshJuejinProfile,
   saveConfig,
   setApiBearer,
   type TudConfigView,
@@ -142,6 +145,7 @@ function CliSyncSettings({
   const [enabled, setEnabled] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [confirmLogoutOpen, setConfirmLogoutOpen] = useState(false);
   const [consentOpen, setConsentOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -164,6 +168,21 @@ function CliSyncSettings({
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (!config?.juejin.userId) return;
+    let cancelled = false;
+    void refreshJuejinProfile({ force: false })
+      .then((result) => {
+        if (!cancelled && result.changed) setConfig(result.config);
+      })
+      .catch(() => {
+        // Keep the login snapshot when the public card is unreachable.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [config?.juejin.userId]);
 
   const onEnabledChange = async (next: boolean) => {
     const prev = enabled;
@@ -236,6 +255,51 @@ function CliSyncSettings({
     });
   };
 
+  const onRefreshProfile = async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const result = await refreshJuejinProfile({ force: true });
+      setConfig(result.config);
+      if (result.reason === 'not_linked') {
+        onNotify({
+          title: '无法同步资料',
+          description: '缺少用户 ID，请重新掘金登录关联',
+          variant: 'danger',
+        });
+        return;
+      }
+      if (result.reason === 'fetch_failed') {
+        onNotify({
+          title: '同步失败',
+          description: '暂时无法读取掘金公开资料，请稍后重试',
+          variant: 'danger',
+        });
+        return;
+      }
+      if (result.changed) {
+        dispatchJuejinLinkChanged();
+        onNotify({
+          title: '已同步账号资料',
+          variant: 'success',
+        });
+        return;
+      }
+      onNotify({
+        title: '资料已是最新',
+        variant: 'success',
+      });
+    } catch (e) {
+      onNotify({
+        title: '同步失败',
+        description: e instanceof Error ? e.message : '请稍后重试',
+        variant: 'danger',
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   return (
     <div className="flex h-full flex-col gap-3 overflow-hidden">
       {error && <StatusBanner tone="error" title={error} />}
@@ -270,7 +334,7 @@ function CliSyncSettings({
             <p className="mt-1 text-xs text-muted">用于识别云端用量归属</p>
           </div>
           {userId ? (
-            <div className="flex min-w-0 items-center gap-2.5">
+            <div className="flex min-w-0 items-center gap-2">
               {avatarLarge ? (
                 <img
                   alt={userName || '用户头像'}
@@ -306,6 +370,26 @@ function CliSyncSettings({
                   {displayUserId ?? '缺少用户 ID（请重新登录关联）'}
                 </p>
               </div>
+              <Tooltip closeDelay={80} delay={100}>
+                <Button
+                  aria-label="同步资料"
+                  className="size-6 min-h-6 min-w-6 shrink-0 p-0 text-muted"
+                  isDisabled={saving || refreshing}
+                  isIconOnly
+                  onPress={() => {
+                    void onRefreshProfile();
+                  }}
+                  size="sm"
+                  variant="ghost"
+                >
+                  <ArrowsRotateRight
+                    className={`size-3.5 ${refreshing ? 'animate-spin' : ''}`}
+                  />
+                </Button>
+                <Tooltip.Content placement="bottom">
+                  <p>同步资料</p>
+                </Tooltip.Content>
+              </Tooltip>
             </div>
           ) : (
             <span className="text-muted">未关联</span>

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -642,19 +642,8 @@ export async function saveConfig(update: TudConfigUpdate): Promise<TudConfigView
   });
 }
 
-export type JuejinProfileSyncReason =
-  | 'not_linked'
-  | 'throttled'
-  | 'fetch_failed'
-  | 'unchanged'
-  | 'updated';
-
 export interface JuejinProfileSyncResponse {
   changed: boolean;
-  fetched: boolean;
-  reason: JuejinProfileSyncReason;
-  userName: string | null;
-  avatarLarge: string | null;
   config: TudConfigView;
 }
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -642,6 +642,34 @@ export async function saveConfig(update: TudConfigUpdate): Promise<TudConfigView
   });
 }
 
+export type JuejinProfileSyncReason =
+  | 'not_linked'
+  | 'throttled'
+  | 'fetch_failed'
+  | 'unchanged'
+  | 'updated';
+
+export interface JuejinProfileSyncResponse {
+  changed: boolean;
+  fetched: boolean;
+  reason: JuejinProfileSyncReason;
+  userName: string | null;
+  avatarLarge: string | null;
+  config: TudConfigView;
+}
+
+/** Pull the public Juejin user card into the local login snapshot. */
+export async function refreshJuejinProfile(
+  opts?: { force?: boolean },
+): Promise<JuejinProfileSyncResponse> {
+  const { others } = apiPrefixes();
+  return request<JuejinProfileSyncResponse>(`${others}refresh-profile`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ force: Boolean(opts?.force) }),
+  });
+}
+
 /** User-facing hint for load/sync failures (CLI vs server dev). */
 export function apiErrorHint(message: string): string | null {
   const lower = message.toLowerCase();


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

跨端：core 增加资料刷新；Desktop renderer 与 Dashboard 设置页（CLI 面板）同步改了关联账号旁的刷新图标。线上 Web 仍走 cookie 的 `tud-session`，不走这条本地接口。

### 🔗 关联 Issue

自己踩到的：掘金改了头像/昵称后，Desktop 设置里的关联账号一直显示登录时的快照。

### 💡 改动说明

1. **原来的问题**：昵称和头像只在掘金登录关联时写入 `~/.ai-usage/config.json`。云端同步只上报用量，之后改资料不会刷新本机展示。
2. **这版怎么改**：core 用 `originUserId` 拉掘金公开用户卡片，写回本地配置。Desktop / CLI 启动时静默刷新一次（1 小时内不重复打）；打开设置「云端同步」也会自动刷新；资料旁有一个小同步图标可手动强制刷新。空昵称不会覆盖登录快照。
3. **UI**：去掉底部大按钮，只在头像/昵称右侧放灰色同步图标。Dashboard 与 Desktop 设置页都改了。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | minor | 设置里的关联账号会同步掘金最新头像和昵称。打开云端同步时自动更新本机展示，资料旁也可手动刷新。 |
| `@juejin-opensource/jusage-dashboard` | minor | 同上 |
| `@juejin-opensource/jusage-desktop` | minor | 同上 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码都改了
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过
