### PR TITLE
feat(desktop): add context menu to the desktop pet

### DIFF
--- a/.changeset/desktop-pet-context-menu.md
+++ b/.changeset/desktop-pet-context-menu.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+桌面宠物支持右键菜单：显示主窗口、同步数据、打开设置、退出宠物。

--- a/apps/desktop/src/main/DesktopPet.ts
+++ b/apps/desktop/src/main/DesktopPet.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, screen } from 'electron';
+import { app, BrowserWindow, ipcMain, Menu, screen } from 'electron';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import {
@@ -24,6 +24,15 @@ const PET_SET_MOUSE_IGNORE_CHANNEL = 'desktop-pet:set-ignore-mouse-events';
 const PET_ANIMATION_CHANNEL = 'desktop-pet:animation';
 const PET_PREFERENCES_CHANNEL = 'desktop-pet:preferences';
 const PET_MARGIN = 24;
+
+export interface DesktopPetHostActions {
+  showMainWindow: () => void;
+  openSettings: () => void;
+  triggerSync: () => void;
+}
+
+let hostActions: DesktopPetHostActions | null = null;
+let contextMenuOpen = false;
 
 type PetAnimation = 'idle' | 'running-left' | 'running-right';
 
@@ -103,7 +112,61 @@ function sendAnimation(animation: PetAnimation): void {
 }
 
 function sendPreferences(pref: DesktopPetPref): void {
-  if (isPetWindow(petWindow)) petWindow.webContents.send(PET_PREFERENCES_CHANNEL, pref);
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(PET_PREFERENCES_CHANNEL, pref);
+    }
+  }
+}
+
+async function setPetEnabled(enabled: boolean): Promise<boolean> {
+  const current = await loadDesktopPetPref();
+  const saved = await saveDesktopPetPref({
+    ...current,
+    enabled,
+    position: latestPosition ?? current.position,
+  });
+  sendPreferences(saved);
+  await syncDesktopPet();
+  return enabled;
+}
+
+/** Same first items as the tray; last item hides the pet instead of quitting. */
+function buildPetMenu(): Menu {
+  return Menu.buildFromTemplate([
+    {
+      label: '显示主窗口',
+      click: () => hostActions?.showMainWindow(),
+    },
+    {
+      label: '同步数据',
+      click: () => hostActions?.triggerSync(),
+    },
+    {
+      label: '设置',
+      click: () => hostActions?.openSettings(),
+    },
+    { type: 'separator' },
+    {
+      label: '退出宠物',
+      click: () => {
+        void setPetEnabled(false);
+      },
+    },
+  ]);
+}
+
+function popupPetContextMenu(): void {
+  if (!isPetWindow(petWindow) || contextMenuOpen || dragOrigin) return;
+  contextMenuOpen = true;
+  stopAutoMove();
+  buildPetMenu().popup({
+    window: petWindow,
+    callback: () => {
+      contextMenuOpen = false;
+      void scheduleAutoMove();
+    },
+  });
 }
 
 function scheduleIdle(): void {
@@ -251,11 +314,16 @@ function tickAutoMove(): void {
   }
 }
 
+function canAutoMove(window: BrowserWindow | null): window is BrowserWindow {
+  return isPetWindow(window) && !dragOrigin && !autoMoveRun && !contextMenuOpen;
+}
+
 async function startAutoMove(): Promise<void> {
   autoMoveTimer = null;
-  if (!isPetWindow(petWindow) || dragOrigin || autoMoveRun) return;
+  if (!canAutoMove(petWindow)) return;
   const pref = await loadDesktopPetPref();
-  if (!pref.enabled || !pref.autoMoveEnabled || !isPetWindow(petWindow) || dragOrigin) return;
+  if (!pref.enabled || !pref.autoMoveEnabled) return;
+  if (!canAutoMove(petWindow)) return;
   const [x, y] = petWindow.getPosition();
   const target = randomAutoMoveTarget(pref.scale, { x, y });
   if (!target) {
@@ -280,9 +348,10 @@ async function startAutoMove(): Promise<void> {
 
 async function scheduleAutoMove(delayMs?: number): Promise<void> {
   clearAutoMoveTimer();
-  if (!isPetWindow(petWindow) || dragOrigin || autoMoveRun) return;
+  if (!canAutoMove(petWindow)) return;
   const pref = await loadDesktopPetPref();
-  if (!pref.enabled || !pref.autoMoveEnabled || !isPetWindow(petWindow) || dragOrigin || autoMoveRun) return;
+  if (!pref.enabled || !pref.autoMoveEnabled) return;
+  if (!canAutoMove(petWindow)) return;
   autoMoveTimer = setTimeout(() => { void startAutoMove(); }, delayMs ?? pref.autoMoveIntervalMinutes * 60_000);
 }
 
@@ -409,6 +478,10 @@ async function ensurePetWindow(): Promise<BrowserWindow> {
   if (process.platform === 'darwin') window.setWindowButtonVisibility(false);
   suppressPetWindowTitle(window);
   window.setAlwaysOnTop(true, 'floating');
+  window.webContents.on('context-menu', (event) => {
+    event.preventDefault();
+    popupPetContextMenu();
+  });
   window.on('move', onPetMoved);
   window.on('closed', () => {
     stopAutoMove();
@@ -468,17 +541,15 @@ async function doSyncDesktopPet(): Promise<void> {
   await scheduleAutoMove();
 }
 
-export function registerDesktopPetIpc(): void {
+export function registerDesktopPetIpc(actions: DesktopPetHostActions): void {
+  hostActions = actions;
   ipcMain.removeHandler(PET_GET_CHANNEL);
   ipcMain.handle(PET_GET_CHANNEL, async () => loadDesktopPetPref());
 
   ipcMain.removeHandler(PET_SET_ENABLED_CHANNEL);
   ipcMain.handle(PET_SET_ENABLED_CHANNEL, async (_event, enabled: unknown) => {
     if (typeof enabled !== 'boolean') throw new Error('desktop pet enabled must be a boolean');
-    const current = await loadDesktopPetPref();
-    await saveDesktopPetPref({ ...current, enabled, position: latestPosition ?? current.position });
-    await syncDesktopPet();
-    return enabled;
+    return setPetEnabled(enabled);
   });
 
   ipcMain.removeHandler(PET_SET_SELECTED_CHANNEL);
@@ -561,6 +632,8 @@ export function registerDesktopPetIpc(): void {
 
 export function unregisterDesktopPetIpc(): void {
   stopAutoMove();
+  hostActions = null;
+  contextMenuOpen = false;
   ipcMain.removeHandler(PET_GET_CHANNEL);
   ipcMain.removeHandler(PET_SET_ENABLED_CHANNEL);
   ipcMain.removeHandler(PET_SET_SELECTED_CHANNEL);
@@ -578,6 +651,7 @@ export function disposeDesktopPet(): void {
   if (positionSaveTimer) clearTimeout(positionSaveTimer);
   positionSaveTimer = null;
   dragOrigin = null;
+  contextMenuOpen = false;
   if (isPetWindow(petWindow)) petWindow.destroy();
   petWindow = null;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -207,6 +207,19 @@ function showMainWindow(): void {
   void showMainWindowAsync();
 }
 
+/** Same as in-app / tray「同步数据」→ POST tud-trigger-sync. */
+function triggerSync(): void {
+  void localApiRequest('/functions/tud-trigger-sync', {
+    method: 'POST',
+    body: '{}',
+  }).catch((err) => {
+    console.error(
+      '[tud-desktop] sync failed:',
+      err instanceof Error ? err.message : err,
+    );
+  });
+}
+
 /** After a tray rebuild the page may still be loading, and SettingsPanel
  *  only subscribes in useEffect — wait for both before sending IPC. */
 function sendToMainWindowWhenReady(
@@ -359,7 +372,13 @@ void acquireDesktopInstanceLock().then((gotLock) => {
     registerThemeIpc();
     registerShareCardIpc();
     registerAutostartIpc();
-    registerDesktopPetIpc();
+    registerDesktopPetIpc({
+      showMainWindow,
+      openSettings: () => {
+        void openSettings({ tab: 'pet' });
+      },
+      triggerSync,
+    });
     disposeLocalApiIpc = registerLocalApiIpc();
     await initializeAutoUpdate({
       beforeInstall: async () => {
@@ -418,17 +437,7 @@ void acquireDesktopInstanceLock().then((gotLock) => {
     createTrayPopover({
       showMainWindow,
       openSettings: () => openSettings(),
-      triggerSync: () => {
-        void localApiRequest('/functions/tud-trigger-sync', {
-          method: 'POST',
-          body: '{}',
-        }).catch((err) => {
-          console.error(
-            '[tud-desktop] tray sync failed:',
-            err instanceof Error ? err.message : err,
-          );
-        });
-      },
+      triggerSync,
     });
 
     if (pendingDeepLinkUrl) {

--- a/apps/desktop/src/renderer/components/DesktopPetView.tsx
+++ b/apps/desktop/src/renderer/components/DesktopPetView.tsx
@@ -173,7 +173,8 @@ export function DesktopPetView() {
    * a click apart from a drag, and never sends per-move coordinates.
    */
   const onPointerDown = (event: PointerEvent<HTMLButtonElement>) => {
-    if (event.button !== 0) return;
+    // Right-click / macOS ctrl-click open the native menu; do not start a drag.
+    if (event.button !== 0 || event.ctrlKey) return;
     event.preventDefault();
     setMouseIgnored(false);
     event.currentTarget.setPointerCapture(event.pointerId);
@@ -215,9 +216,13 @@ export function DesktopPetView() {
 
   useEffect(() => {
     const cancelDrag = () => finishDrag(undefined, true);
+    // Do not preventDefault: main shows the native menu from webContents `context-menu`.
+    const onContextMenu = () => setIsTokenTooltipOpen(false);
     window.addEventListener('blur', cancelDrag);
+    window.addEventListener('contextmenu', onContextMenu);
     return () => {
       window.removeEventListener('blur', cancelDrag);
+      window.removeEventListener('contextmenu', onContextMenu);
       cancelDrag();
     };
   }, []);
@@ -254,7 +259,7 @@ export function DesktopPetView() {
           } as CSSProperties}
         >
           <button
-            aria-label={`${pet.displayName} 桌面宠物，点击查看总 Token，拖动可移动`}
+            aria-label={`${pet.displayName} 桌面宠物，点击查看总 Token，拖动可移动，右键打开菜单`}
             className="desktop-pet-sprite"
             onMouseMove={updateMousePassThrough}
             onPointerDown={onPointerDown}

--- a/apps/desktop/src/renderer/components/SettingsPanel.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.tsx
@@ -182,17 +182,30 @@ function DesktopPetSettings() {
 
   useEffect(() => {
     let cancelled = false;
+    const applyPref = (
+      pref: {
+        enabled: boolean;
+        selectedPetId: string;
+        scale: number;
+        frameIntervalMs: number;
+        autoMoveEnabled: boolean;
+        autoMoveIntervalMinutes: number;
+      },
+      skipMotion = false,
+    ) => {
+      setEnabled(pref.enabled);
+      setSelectedPetId(pref.selectedPetId);
+      if (skipMotion) return;
+      setScale(Math.round(pref.scale * 100));
+      setFrameIntervalMs(pref.frameIntervalMs);
+      setAutoMoveEnabled(pref.autoMoveEnabled);
+      setAutoMoveIntervalMinutes(pref.autoMoveIntervalMinutes);
+    };
+
     void window.tud
       .getDesktopPet()
       .then((pref) => {
-        if (!cancelled) {
-          setEnabled(pref.enabled);
-          setSelectedPetId(pref.selectedPetId);
-          setScale(Math.round(pref.scale * 100));
-          setFrameIntervalMs(pref.frameIntervalMs);
-          setAutoMoveEnabled(pref.autoMoveEnabled);
-          setAutoMoveIntervalMinutes(pref.autoMoveIntervalMinutes);
-        }
+        if (!cancelled) applyPref(pref);
       })
       .catch((reason) => {
         if (!cancelled) {
@@ -204,8 +217,13 @@ function DesktopPetSettings() {
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
+
+    const unsubscribe = window.tud.onDesktopPetPreferences((pref) => {
+      applyPref(pref, saveTimer.current !== null);
+    });
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, []);
 
@@ -292,7 +310,7 @@ function DesktopPetSettings() {
       {error && <StatusBanner tone="error" title={error} />}
       <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         <p className="mb-3 text-sm text-muted">
-          显示悬浮宠物；拖动它可在桌面上移动。
+          显示悬浮宠物。拖动可移动位置，右键可打开菜单。
         </p>
         <Checkbox
           id="desktop-pet-enabled"


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

自己在用桌面宠物时想通过右键快速打开主窗口、设置或关掉宠物，托盘菜单已有同类入口，宠物窗口没有。

### 💡 改动说明

桌面宠物之前只能左键看 Token、拖动位置，没有右键菜单。关掉宠物或打开设置必须先找到托盘或主窗口。

这版给宠物窗口加了和托盘同结构的原生右键菜单：

- 显示主窗口
- 同步数据（与托盘、主界面同一条 `tud-trigger-sync`）
- 设置（打开设置并切到「桌面宠物」）
- 退出宠物（隐藏宠物，不退出应用）

菜单由主进程在宠物窗口的 `context-menu` 上弹出，和托盘一致，没有额外 IPC。右键 / macOS ctrl-click 不会开始拖动；菜单打开时暂停自动跑动。从菜单退出宠物后，若设置页已打开会同步开关状态。

未改 `packages/dashboard`：桌面宠物只存在于 Desktop。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 桌面宠物支持右键菜单：显示主窗口、同步数据、打开设置、退出宠物。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过