### PR TITLE
docs: document Electron mirror env for pnpm install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,11 @@
 
 需要 Node.js >= 20。克隆后先在仓库根执行 `pnpm install`。
 
-### `pnpm install` 卡在 electron postinstall
+## `pnpm install` 卡在 electron postinstall
 
-本仓库使用 **pnpm 11**。Electron 二进制默认从 GitHub Releases 拉取；国内网络常会超时，表现成一直停在：
+Electron 二进制默认从 GitHub Releases 拉取；国内网络可能会超时
 
-```text
-node_modules/.../electron: Running postinstall script...
-```
-
-`apps/desktop/.npmrc` 里的 `electron_mirror` **不会生效**：pnpm 11 的 `.npmrc` 只处理 registry / auth，依赖的 `postinstall` 也不再注入 `npm_config_electron_mirror`。请在安装前设置环境变量（末尾 `/` 不要省）：
+请在安装前设置环境变量：
 
 ```bash
 # Git Bash / macOS / Linux
@@ -26,12 +22,6 @@ pnpm install
 $env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
 $env:ELECTRON_BUILDER_BINARIES_MIRROR="https://npmmirror.com/mirrors/electron-builder-binaries/"
 pnpm install
-```
-
-可写入用户环境变量，新开终端后长期生效。只做 CLI / Web、不启动 Desktop 时可跳过下载：
-
-```bash
-ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm install
 ```
 
 从 `main` 拉分支，PR 回 `main`。
@@ -107,15 +97,6 @@ pnpm dev:desktop
 # 构建依赖后启动 Electron
 pnpm start:desktop    
 ```
-
-`pnpm install` 若长时间卡在 `electron: Running postinstall script...`，多半是 GitHub 下载 Electron 二进制超时。pnpm 11 下 `apps/desktop/.npmrc` 的 `electron_mirror` 不会传给 postinstall，需先设环境变量再安装：
-
-```bash
-export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
-pnpm install
-```
-
-PowerShell 用 `$env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"`。只做 CLI / Web 时可 `ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm install` 跳过。
 
 ### CLI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 需要 Node.js >= 20。克隆后先在仓库根执行 `pnpm install`。
 
-## `pnpm install` 卡在 electron postinstall
+如 `pnpm install` 卡在 electron postinstall
 
 Electron 二进制默认从 GitHub Releases 拉取；国内网络可能会超时
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,15 @@ pnpm dev:desktop
 pnpm start:desktop    
 ```
 
+`pnpm install` 若长时间卡在 `electron: Running postinstall script...`，多半是 GitHub 下载 Electron 二进制超时。pnpm 11 下 `apps/desktop/.npmrc` 的 `electron_mirror` 不会传给 postinstall，需先设环境变量再安装：
+
+```bash
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+pnpm install
+```
+
+PowerShell 用 `$env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"`。只做 CLI / Web 时可 `ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm install` 跳过。
+
 ### CLI
 
 路径：`packages/cli`（面板来自 `packages/dashboard`）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,36 @@
 
 需要 Node.js >= 20。克隆后先在仓库根执行 `pnpm install`。
 
+### `pnpm install` 卡在 electron postinstall
+
+本仓库使用 **pnpm 11**。Electron 二进制默认从 GitHub Releases 拉取；国内网络常会超时，表现成一直停在：
+
+```text
+node_modules/.../electron: Running postinstall script...
+```
+
+`apps/desktop/.npmrc` 里的 `electron_mirror` **不会生效**：pnpm 11 的 `.npmrc` 只处理 registry / auth，依赖的 `postinstall` 也不再注入 `npm_config_electron_mirror`。请在安装前设置环境变量（末尾 `/` 不要省）：
+
+```bash
+# Git Bash / macOS / Linux
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+export ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/
+pnpm install
+```
+
+```powershell
+# PowerShell
+$env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
+$env:ELECTRON_BUILDER_BINARIES_MIRROR="https://npmmirror.com/mirrors/electron-builder-binaries/"
+pnpm install
+```
+
+可写入用户环境变量，新开终端后长期生效。只做 CLI / Web、不启动 Desktop 时可跳过下载：
+
+```bash
+ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm install
+```
+
 从 `main` 拉分支，PR 回 `main`。
 
 ## 提 Issue


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 📝 文档改进

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [x] Web

（仅贡献文档，不影响运行时代码。）

### 🔗 关联 Issue

国内网络下 `pnpm install` 卡在 electron postinstall（从 GitHub Releases 拉 Electron 二进制超时）。

### 💡 改动说明

1. **原来有什么问题：** 克隆仓库后在根目录执行 `pnpm install` 时，Electron 默认从 GitHub Releases 下载二进制，国内网络容易卡在 postinstall。
2. **这版怎么改：** 在 `CONTRIBUTING.md` 安装说明处补充 npmmirror 镜像环境变量，分别给出 bash（macOS / Linux / Git Bash）和 PowerShell 示例，并说明需在安装前设置。
3. 无 UI 改动。

### 📝 Changelog

无需 changeset。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [ ] `pnpm build` 通过


Made with [Cursor](https://cursor.com)