### PR TITLE
docs: add Electron mirror install notes to README and AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,30 @@
 
 PR / 分支命名 / Web 对照线上：[CONTRIBUTING.md](CONTRIBUTING.md)。Desktop 主进程、IPC、heartbeat、mock：[apps/desktop/README.md](apps/desktop/README.md)。
 
+## 开发指南
+
+需要 Node.js >= 20。克隆后先在仓库根执行 `pnpm install`。
+
+如 `pnpm install` 卡在 electron postinstall
+
+Electron 二进制默认从 GitHub Releases 拉取；国内网络可能会超时
+
+请在安装前设置环境变量：
+
+```bash
+# Git Bash / macOS / Linux
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+export ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/
+pnpm install
+```
+
+```powershell
+# PowerShell
+$env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
+$env:ELECTRON_BUILDER_BINARIES_MIRROR="https://npmmirror.com/mirrors/electron-builder-binaries/"
+pnpm install
+```
+
 ## 契约
 
 `packages/core/src/server/local-api.ts` 的 `/functions/tud-*` 是 CLI / Desktop / web 共用契约。Dashboard `src/lib/api.ts` 用 `VITE_API_TARGET`（`cli` / `server`）切本地路径与公开 API 根。Desktop renderer 经 IPC 走同一契约，不占 `:8452`。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 源码仓库：[juejin-cn/juejin-usage](https://github.com/juejin-cn/juejin-usage)。
 
+## 安装依赖的注意事项
 需要 Node.js >= 20。克隆后先在仓库根执行 `pnpm install`。
 
 如 `pnpm install` 卡在 electron postinstall

--- a/README.md
+++ b/README.md
@@ -100,6 +100,30 @@ jusage service start
 
 具体内容前往点击查看用户隐私协议: 《[稀土掘金用户隐私协议](#)》
 
+## 🛠️ 开发注意事项
+
+需要 Node.js >= 20。克隆后先在仓库根执行 `pnpm install`。
+
+如 `pnpm install` 卡在 electron postinstall
+
+Electron 二进制默认从 GitHub Releases 拉取；国内网络可能会超时
+
+请在安装前设置环境变量：
+
+```bash
+# Git Bash / macOS / Linux
+export ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/
+export ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/
+pnpm install
+```
+
+```powershell
+# PowerShell
+$env:ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/"
+$env:ELECTRON_BUILDER_BINARIES_MIRROR="https://npmmirror.com/mirrors/electron-builder-binaries/"
+pnpm install
+```
+
 ## 🤝 贡献指南
 
 - 联系Captain:229199157


### PR DESCRIPTION
### 🏷️ 变动类型

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [x] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [ ] Desktop
- [ ] CLI
- [ ] Web

纯文档改动，不涉及任何端的功能代码。

### 🔗 关联 Issue

无对应 Issue。承接已合并的 #51（`chore/electron-mirror-docs`），当时只把 Electron 镜像安装说明写进了 CONTRIBUTING.md；本次把同一份说明同步到 README 与 AGENTS.md，让开发者在仓库根和 Dashboard/Desktop 入口都能看到。

### 💡 改动说明

1. **原来有什么问题**：国内网络下 `pnpm install` 会卡在 electron postinstall——Electron 二进制默认从 GitHub Releases 拉取，容易超时。此前该说明只存在于 CONTRIBUTING.md，README 与 AGENTS.md 未覆盖。
2. **这版怎么改的**：
   - README 新增「🛠️ 开发注意事项」章节：Node.js >= 20 要求 + Git Bash / PowerShell 两种环境的镜像环境变量示例；
   - AGENTS.md 新增「开发指南」章节，内容与 CONTRIBUTING.md 保持一致；
   - CONTRIBUTING.md 为既有内容补充「安装依赖的注意事项」小节标题，与其他文件结构对齐。
3. 纯文档，无 UI / 交互改动。

### 📝 Changelog

无需 changeset（纯文档改动）。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）—— `chore/electron-mirror-docs`
- [ ] 已在受影响的端本地自测通过（纯文档，不涉及代码，跳过）
- [ ] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改（不涉及）
- [ ] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [ ] `pnpm build` 通过（纯文档，不涉及构建，跳过）
