### PR TITLE
feat(desktop): align pet usage bubble with dashboard range

### DIFF
--- a/.changeset/desktop-pet-usage-range.md
+++ b/.changeset/desktop-pet-usage-range.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+桌面宠物点击后的 Token / 费用与主面板当前时间范围一致，并标明是今天还是近 7 / 30 / 90 天。

--- a/apps/desktop/src/main/autostart.ts
+++ b/apps/desktop/src/main/autostart.ts
@@ -5,10 +5,18 @@
  * setLoginItemSettings only runs when packaged so `electron-vite dev`
  * does not register the Electron binary itself.
  */
-import { app, ipcMain } from 'electron';
+import { BrowserWindow, app, ipcMain } from 'electron';
 import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import {
+  DASHBOARD_RANGE_CHANGED_CHANNEL,
+  DASHBOARD_RANGE_GET_CHANNEL,
+  DASHBOARD_RANGE_SET_CHANNEL,
+  DEFAULT_DASHBOARD_RANGE,
+  isDashboardRange,
+  type DashboardRange,
+} from '../shared/dashboard-range';
 
 const AUTOSTART_GET_CHANNEL = 'autostart:get';
 const AUTOSTART_SET_CHANNEL = 'autostart:set';
@@ -40,6 +48,11 @@ interface DesktopPrefs {
   /** 开机自启时是否静默启动（仅托盘，不显示主窗口）。默认开启。 */
   launchHidden: boolean;
   desktopPet?: DesktopPetPref;
+  /**
+   * Last dashboard time range. Stored here so the pet window can follow it;
+   * pet.html does not share the dashboard renderer's localStorage origin.
+   */
+  dashboardRange?: DashboardRange;
 }
 
 export interface AutostartPref {
@@ -68,6 +81,9 @@ async function readPrefsFile(): Promise<DesktopPrefs | null> {
       launchHidden: typeof parsed.launchHidden === 'boolean'
         ? parsed.launchHidden
         : true,
+      dashboardRange: isDashboardRange(parsed.dashboardRange)
+        ? parsed.dashboardRange
+        : undefined,
       desktopPet: desktopPet && typeof desktopPet.enabled === 'boolean'
         ? {
             enabled: desktopPet.enabled,
@@ -97,6 +113,28 @@ async function readPrefsFile(): Promise<DesktopPrefs | null> {
 
 async function writePrefs(prefs: DesktopPrefs): Promise<void> {
   await writeFile(prefsPath(), `${JSON.stringify(prefs, null, 2)}\n`, 'utf8');
+}
+
+async function patchPrefs(patch: Partial<DesktopPrefs>): Promise<DesktopPrefs> {
+  const existing = await readPrefsFile();
+  const next: DesktopPrefs = {
+    openAtLogin: patch.openAtLogin ?? existing?.openAtLogin ?? true,
+    launchHidden: patch.launchHidden ?? existing?.launchHidden ?? true,
+    desktopPet: patch.desktopPet !== undefined ? patch.desktopPet : existing?.desktopPet,
+    dashboardRange: patch.dashboardRange !== undefined
+      ? patch.dashboardRange
+      : existing?.dashboardRange,
+  };
+  await writePrefs(next);
+  return next;
+}
+
+function broadcastDashboardRange(range: DashboardRange): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send(DASHBOARD_RANGE_CHANGED_CHANNEL, range);
+    }
+  }
 }
 
 /** Frozen at init: was *this* process started as a silent login launch? */
@@ -133,10 +171,9 @@ export async function applyAutostart(
 ): Promise<boolean> {
   const existing = await readPrefsFile();
   const hidden = launchHidden ?? existing?.launchHidden ?? true;
-  await writePrefs({
+  await patchPrefs({
     openAtLogin: enabled,
     launchHidden: hidden,
-    desktopPet: existing?.desktopPet,
   });
   setOsLoginItem(enabled, hidden);
   return enabled;
@@ -152,10 +189,9 @@ export async function loadLaunchHidden(): Promise<boolean> {
 export async function setLaunchHidden(hidden: boolean): Promise<boolean> {
   const existing = await readPrefsFile();
   const openAtLogin = existing?.openAtLogin ?? true;
-  await writePrefs({
+  await patchPrefs({
     openAtLogin,
     launchHidden: hidden,
-    desktopPet: existing?.desktopPet,
   });
   setOsLoginItem(openAtLogin, hidden);
   return hidden;
@@ -174,13 +210,21 @@ export async function loadDesktopPetPref(): Promise<DesktopPetPref> {
 }
 
 export async function saveDesktopPetPref(pref: DesktopPetPref): Promise<DesktopPetPref> {
-  const existing = await readPrefsFile();
-  await writePrefs({
-    openAtLogin: existing?.openAtLogin ?? true,
-    launchHidden: existing?.launchHidden ?? true,
-    desktopPet: pref,
-  });
+  await patchPrefs({ desktopPet: pref });
   return pref;
+}
+
+export async function loadDashboardRange(): Promise<DashboardRange> {
+  const existing = await readPrefsFile();
+  return existing?.dashboardRange ?? DEFAULT_DASHBOARD_RANGE;
+}
+
+export async function saveDashboardRange(range: DashboardRange): Promise<DashboardRange> {
+  const current = await loadDashboardRange();
+  if (current === range) return range;
+  await patchPrefs({ dashboardRange: range });
+  broadcastDashboardRange(range);
+  return range;
 }
 
 function isDesktopPetScale(value: unknown): value is number {
@@ -251,6 +295,15 @@ export function registerAutostartIpc(): void {
     }
     return setLaunchHidden(hidden);
   });
+
+  ipcMain.removeHandler(DASHBOARD_RANGE_GET_CHANNEL);
+  ipcMain.handle(DASHBOARD_RANGE_GET_CHANNEL, () => loadDashboardRange());
+
+  ipcMain.removeHandler(DASHBOARD_RANGE_SET_CHANNEL);
+  ipcMain.handle(DASHBOARD_RANGE_SET_CHANNEL, async (_event, range: unknown) => {
+    if (!isDashboardRange(range)) throw new Error('unknown dashboard range');
+    return saveDashboardRange(range);
+  });
 }
 
 export function unregisterAutostartIpc(): void {
@@ -258,4 +311,6 @@ export function unregisterAutostartIpc(): void {
   ipcMain.removeHandler(AUTOSTART_SET_CHANNEL);
   ipcMain.removeHandler(AUTOSTART_GET_HIDDEN_CHANNEL);
   ipcMain.removeHandler(AUTOSTART_SET_HIDDEN_CHANNEL);
+  ipcMain.removeHandler(DASHBOARD_RANGE_GET_CHANNEL);
+  ipcMain.removeHandler(DASHBOARD_RANGE_SET_CHANNEL);
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -14,6 +14,13 @@ import {
   AUTO_UPDATE_STATE_CHANGED_CHANNEL,
   type AutoUpdateState,
 } from '../shared/auto-update';
+import {
+  DASHBOARD_RANGE_CHANGED_CHANNEL,
+  DASHBOARD_RANGE_GET_CHANNEL,
+  DASHBOARD_RANGE_SET_CHANNEL,
+  isDashboardRange,
+  type DashboardRange,
+} from '../shared/dashboard-range';
 
 const API_REQUEST_CHANNEL = 'tud:api-request';
 const DATA_SYNCED_CHANNEL = 'tud:data-synced';
@@ -83,6 +90,20 @@ const tudApi = {
    */
   resizeTrayPopover: (height: number) =>
     ipcRenderer.send(TRAY_POPOVER_RESIZE_CHANNEL, height),
+
+  getDashboardRange: (): Promise<DashboardRange> =>
+    ipcRenderer.invoke(DASHBOARD_RANGE_GET_CHANNEL),
+
+  setDashboardRange: (range: DashboardRange): Promise<DashboardRange> =>
+    ipcRenderer.invoke(DASHBOARD_RANGE_SET_CHANNEL, range),
+
+  onDashboardRange: (callback: (range: DashboardRange) => void) => {
+    const listener = (_event: unknown, range: unknown) => {
+      if (isDashboardRange(range)) callback(range);
+    };
+    ipcRenderer.on(DASHBOARD_RANGE_CHANGED_CHANNEL, listener);
+    return () => ipcRenderer.removeListener(DASHBOARD_RANGE_CHANGED_CHANNEL, listener);
+  },
 
   getTheme: (): Promise<'light' | 'dark'> =>
     ipcRenderer.invoke(THEME_GET_CHANNEL),

--- a/apps/desktop/src/renderer/components/DashboardFilter.tsx
+++ b/apps/desktop/src/renderer/components/DashboardFilter.tsx
@@ -12,15 +12,12 @@ import { FilterChromeActions } from '@/components/FilterChromeActions';
 import { ProviderIcon } from '@/components/ProviderIcon';
 import type { DashboardToolUsageRow } from '@/lib/dashboard-mock-data';
 import { sourceLabel } from '@/lib/tokens';
+import { type DashboardRange } from '../../shared/dashboard-range';
 
-export type DashboardRange = 'today' | 'last-7-days' | 'last-30-days' | 'last-90-days';
-
-export const DASHBOARD_RANGE_DAYS: Record<DashboardRange, number> = {
-  today: 1,
-  'last-7-days': 7,
-  'last-30-days': 30,
-  'last-90-days': 90,
-};
+export {
+  DASHBOARD_RANGE_DAYS,
+  type DashboardRange,
+} from '../../shared/dashboard-range';
 
 const RANGE_OPTIONS: readonly { id: DashboardRange; label: string }[] = [
   { id: 'today', label: '今天' },

--- a/apps/desktop/src/renderer/components/DesktopPetView.tsx
+++ b/apps/desktop/src/renderer/components/DesktopPetView.tsx
@@ -8,9 +8,15 @@ import {
   type PointerEvent,
 } from 'react';
 import { useAnimatedNumber } from '@/hooks/useAnimatedNumber';
-import { fetchSummary } from '@/lib/api';
+import { fetchDaily } from '@/lib/api';
 import { formatTokens, formatTokensExact, formatUsd } from '@/lib/format';
 import { getDesktopPet, loadPetSpritesheet } from '@/pets';
+import {
+  DASHBOARD_RANGE_DAYS,
+  DASHBOARD_RANGE_LABELS,
+  DEFAULT_DASHBOARD_RANGE,
+  type DashboardRange,
+} from '../../shared/dashboard-range';
 import {
   DESKTOP_PET_SOURCE_HEIGHT,
   DESKTOP_PET_SOURCE_WIDTH,
@@ -30,6 +36,20 @@ const ANIMATION_ROWS: Record<Animation, { row: number; frames: number }> = {
   'running-right': { row: 1, frames: 8 },
   'running-left': { row: 2, frames: 8 },
 };
+
+async function fetchRangeTotals(range: DashboardRange): Promise<{
+  totalTokens: number;
+  totalCostUsd: number;
+}> {
+  const daily = await fetchDaily(DASHBOARD_RANGE_DAYS[range]);
+  let totalTokens = 0;
+  let totalCostUsd = 0;
+  for (const row of daily.days ?? []) {
+    totalTokens += row.tokens;
+    totalCostUsd += row.costUsd;
+  }
+  return { totalTokens, totalCostUsd };
+}
 
 /**
  * Click's generated running-left row contains a corrupt frame with neighboring
@@ -55,6 +75,7 @@ export function DesktopPetView() {
   const [scale, setScale] = useState(DISPLAY_SCALE);
   const [frameIntervalMs, setFrameIntervalMs] = useState(180);
   const [isTokenTooltipOpen, setIsTokenTooltipOpen] = useState(false);
+  const [range, setRange] = useState<DashboardRange>(DEFAULT_DASHBOARD_RANGE);
   const [summary, setSummary] = useState<{ totalTokens: number; totalCostUsd: number } | null>(null);
   const [summaryError, setSummaryError] = useState(false);
   const [spritesheetUrl, setSpritesheetUrl] = useState<string | null>(null);
@@ -84,6 +105,11 @@ export function DesktopPetView() {
   }, [effectiveFrameIntervalMs]);
 
   useEffect(() => window.tud.onDesktopPetAnimation(setAnimation), []);
+
+  useEffect(() => {
+    void window.tud.getDashboardRange().then(setRange);
+    return window.tud.onDashboardRange(setRange);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -121,15 +147,23 @@ export function DesktopPetView() {
   useEffect(() => {
     if (!isTokenTooltipOpen) return;
     let cancelled = false;
+    setSummary(null);
     setSummaryError(false);
-    void fetchSummary()
-      .then((next) => {
-        if (cancelled) return;
-        setSummary({ totalTokens: next.totalTokens, totalCostUsd: next.totalCostUsd });
-      })
-      .catch(() => { if (!cancelled) setSummaryError(true); });
-    return () => { cancelled = true; };
-  }, [isTokenTooltipOpen]);
+    const load = () => {
+      void fetchRangeTotals(range)
+        .then((next) => {
+          if (cancelled) return;
+          setSummary(next);
+        })
+        .catch(() => { if (!cancelled) setSummaryError(true); });
+    };
+    load();
+    const unsubscribe = window.tud.onDataSynced(load);
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [isTokenTooltipOpen, range]);
 
   const setMouseIgnored = (shouldIgnore: boolean) => {
     if (shouldIgnore === ignored.current) return;
@@ -291,6 +325,9 @@ export function DesktopPetView() {
         >
           <Popover.Arrow />
           <Popover.Dialog className="grid gap-1 px-3 py-2">
+            <div className="text-center text-[10px] leading-tight text-muted">
+              {DASHBOARD_RANGE_LABELS[range]}
+            </div>
             <PetStatRow
               dotClassName="bg-accent"
               exactLabel={summary ? formatTokensExact(summary.totalTokens) : undefined}

--- a/apps/desktop/src/renderer/global.d.ts
+++ b/apps/desktop/src/renderer/global.d.ts
@@ -27,6 +27,15 @@ declare global {
         url: string,
       ) => Promise<{ ok: boolean; message?: string }>;
       resizeTrayPopover: (height: number) => void;
+      getDashboardRange: () => Promise<
+        import('../shared/dashboard-range').DashboardRange
+      >;
+      setDashboardRange: (
+        range: import('../shared/dashboard-range').DashboardRange,
+      ) => Promise<import('../shared/dashboard-range').DashboardRange>;
+      onDashboardRange: (
+        callback: (range: import('../shared/dashboard-range').DashboardRange) => void,
+      ) => () => void;
       getTheme: () => Promise<'light' | 'dark'>;
       setTheme: (theme: 'light' | 'dark') => void;
       onThemeChanged: (callback: (theme: 'light' | 'dark') => void) => () => void;

--- a/apps/desktop/src/renderer/pages/DashboardPage.tsx
+++ b/apps/desktop/src/renderer/pages/DashboardPage.tsx
@@ -31,13 +31,11 @@ import {
   filterTrendRowsBySources,
 } from '@/lib/usage-filter';
 import { LOCAL_RUNTIME_RECOVERING_HINT } from '@/lib/api';
-
-const SHARE_RANGE_LABELS: Record<DashboardRange, string> = {
-  today: '今天',
-  'last-7-days': '近 7 天',
-  'last-30-days': '近 30 天',
-  'last-90-days': '近 90 天',
-};
+import {
+  DASHBOARD_RANGE_LABELS,
+  DEFAULT_DASHBOARD_RANGE,
+  isDashboardRange,
+} from '../../shared/dashboard-range';
 
 /**
  * Tabs `range` updates immediately; data fetch waits until after paint so
@@ -60,10 +58,12 @@ function useDeferredDashboardRange(range: DashboardRange): DashboardRange {
 export function DashboardPage() {
   const [range, setRange] = useLocalStorage<DashboardRange>(
     'tud.dashboardRange',
-    'last-7-days',
-    (value): value is DashboardRange =>
-      typeof value === 'string' && value in DASHBOARD_RANGE_DAYS,
+    DEFAULT_DASHBOARD_RANGE,
+    isDashboardRange,
   );
+  useEffect(() => {
+    void window.tud.setDashboardRange(range);
+  }, [range]);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
   const { publishSnapshot } = useShareSnapshot();
@@ -79,7 +79,7 @@ export function DashboardPage() {
   const isHourly = dayScoped || rangeDays === 1;
   const shareRangeLabel = selectedDate
     ? formatFilterDayLabel(selectedDate)
-    : SHARE_RANGE_LABELS[range];
+    : DASHBOARD_RANGE_LABELS[range];
   const shareToolLabel = selectedTools.length > 0
     ? selectedTools.map(sourceLabel).join('、')
     : '全部工具';

--- a/apps/desktop/src/shared/dashboard-range.ts
+++ b/apps/desktop/src/shared/dashboard-range.ts
@@ -1,0 +1,26 @@
+export type DashboardRange = 'today' | 'last-7-days' | 'last-30-days' | 'last-90-days';
+
+export const DEFAULT_DASHBOARD_RANGE: DashboardRange = 'last-7-days';
+
+export const DASHBOARD_RANGE_DAYS: Record<DashboardRange, number> = {
+  today: 1,
+  'last-7-days': 7,
+  'last-30-days': 30,
+  'last-90-days': 90,
+};
+
+/** User-facing window label for the pet bubble and share chrome. */
+export const DASHBOARD_RANGE_LABELS: Record<DashboardRange, string> = {
+  today: '今天',
+  'last-7-days': '近 7 天',
+  'last-30-days': '近 30 天',
+  'last-90-days': '近 90 天',
+};
+
+export const DASHBOARD_RANGE_GET_CHANNEL = 'dashboard-range:get';
+export const DASHBOARD_RANGE_SET_CHANNEL = 'dashboard-range:set';
+export const DASHBOARD_RANGE_CHANGED_CHANNEL = 'dashboard-range:changed';
+
+export function isDashboardRange(value: unknown): value is DashboardRange {
+  return typeof value === 'string' && value in DASHBOARD_RANGE_DAYS;
+}


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

自己点桌宠气泡时，Token / 费用是采集窗口合计，和主面板当前选的「今天 / 7D / 30D / 90D」对不上，也看不出统计的是哪段时间。

### 💡 改动说明

主面板时间范围存在 `tud.dashboardRange`。宠物是独立窗口，生产环境 `file://` 不共享 localStorage，所以把当前范围写进 `desktop-prefs.json`，经 IPC 同步给宠物（和主题同步同一套写法）。

气泡改为拉 `tud-usage-daily?days=`（和主面板同一套日历窗口），顶部标明「今天 / 近 7 天 / 近 30 天 / 近 90 天」。主面板改范围时，开着的气泡会跟着刷新。

未跟热力图点选的某一天、也未跟渠道筛选；这两项主面板里没有持久化。未改 `packages/dashboard`：桌宠只存在于 Desktop。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 桌面宠物点击后的 Token / 费用与主面板当前时间范围一致，并标明是今天还是近 7 / 30 / 90 天。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过