### PR TITLE
fix(core): normalize encoded cwd in project distribution

### DIFF
--- a/.changeset/project-display-name.md
+++ b/.changeset/project-display-name.md
@@ -1,0 +1,7 @@
+---
+"@juejin-opensource/jusage-core": patch
+"@juejin-opensource/jusage": patch
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复项目分布把工作目录编码路径（如 `%2FUsers%2F...`）直接当标题展示的问题。CLI、Web 与 Desktop 面板同步修复。

--- a/apps/desktop/src/renderer/lib/dashboard-data.ts
+++ b/apps/desktop/src/renderer/lib/dashboard-data.ts
@@ -1,4 +1,5 @@
 import { parseDailyModelKey } from '@juejin-opensource/jusage-core/daily-model-key';
+import { normalizeProjectName } from '@juejin-opensource/jusage-core/project-label';
 import { addLocalDays } from '@juejin-opensource/jusage-core/timezone';
 import type {
   DailyUsageRow,
@@ -383,7 +384,26 @@ function buildProjectRowsFromDaily(
   day: DailyUsageRow,
   sourceFallback: Map<string, string>,
 ): ProjectBreakdownRow[] {
-  const projects = (day.projects ?? []).filter((row) => row.tokens > 0);
+  const collapsed = new Map<
+    string,
+    { project: string; tokens: number; models: Record<string, number> }
+  >();
+  for (const row of day.projects ?? []) {
+    if (row.tokens <= 0) continue;
+    const project = normalizeProjectName(row.project);
+    const current = collapsed.get(project) ?? {
+      project,
+      tokens: 0,
+      models: {},
+    };
+    current.tokens += row.tokens;
+    for (const [key, tokens] of Object.entries(row.models ?? {})) {
+      if (tokens <= 0) continue;
+      current.models[key] = (current.models[key] ?? 0) + tokens;
+    }
+    collapsed.set(project, current);
+  }
+  const projects = Array.from(collapsed.values());
   if (projects.length === 0) return [];
 
   const dayTokenTotal = projects.reduce((sum, row) => sum + row.tokens, 0);
@@ -607,6 +627,24 @@ function buildMetricTrend(
   };
 }
 
+function collapseProjectDistribution(
+  projects: ProjectBreakdownRow[],
+): Array<{ label: string; tokens: number; costUsd: number }> {
+  const byName = new Map<
+    string,
+    { label: string; tokens: number; costUsd: number }
+  >();
+  for (const row of projects) {
+    const name = normalizeProjectName(row.project);
+    const label = name === 'unknown' ? '未知项目' : name;
+    const current = byName.get(name) ?? { label, tokens: 0, costUsd: 0 };
+    current.tokens += row.tokens;
+    current.costUsd += row.costUsd;
+    byName.set(name, current);
+  }
+  return Array.from(byName.values());
+}
+
 function buildDistributions(
   sources: UsageDataset['summary']['bySource'],
   models: ModelBreakdownRow[],
@@ -644,11 +682,7 @@ function buildDistributions(
     projects:
       projects.length > 0
         ? normalizeDistribution(
-            projects.map((row) => ({
-              label: row.project === 'unknown' ? '未知项目' : row.project,
-              tokens: row.tokens,
-              costUsd: row.costUsd,
-            })),
+            collapseProjectDistribution(projects),
             summary,
             6,
           )

--- a/apps/desktop/src/renderer/lib/dashboard-mock-data.ts
+++ b/apps/desktop/src/renderer/lib/dashboard-mock-data.ts
@@ -1,3 +1,4 @@
+import { normalizeProjectName } from '@juejin-opensource/jusage-core/project-label';
 import type { DailyUsageRow, HourlyUsageRow, ModelBreakdownRow } from './api.ts';
 
 /** Presentation model shared by server-backed dashboard components. */
@@ -194,34 +195,69 @@ export function buildProjectModelUsage(
   }>,
   totalTokens = 0,
 ): DashboardProjectUsageRow[] {
-  return rows
-    .filter((row) => row.tokens > 0)
-    .map((row) => {
-      const models = (row.models ?? [])
-        .filter((model) => model.tokens > 0)
+  const byProject = new Map<
+    string,
+    {
+      project: string;
+      tokens: number;
+      costUsd: number;
+      models: Map<
+        string,
+        { model: string; source: string; tokens: number; costUsd: number }
+      >;
+    }
+  >();
+
+  for (const row of rows) {
+    if (row.tokens <= 0) continue;
+    const project = normalizeProjectName(row.project);
+    const current = byProject.get(project) ?? {
+      project,
+      tokens: 0,
+      costUsd: 0,
+      models: new Map(),
+    };
+    current.tokens += row.tokens;
+    current.costUsd += row.costUsd;
+    for (const model of row.models ?? []) {
+      if (model.tokens <= 0) continue;
+      const pairKey = `${model.source}\0${model.model}`;
+      const existing = current.models.get(pairKey) ?? {
+        model: model.model,
+        source: model.source,
+        tokens: 0,
+        costUsd: 0,
+      };
+      existing.tokens += model.tokens;
+      existing.costUsd += model.costUsd;
+      current.models.set(pairKey, existing);
+    }
+    byProject.set(project, current);
+  }
+
+  const merged = Array.from(byProject.values());
+  const tokenTotal =
+    totalTokens > 0
+      ? totalTokens
+      : merged.reduce((sum, row) => sum + row.tokens, 0);
+
+  return merged
+    .map((row) => ({
+      project: row.project,
+      label: row.project === 'unknown' ? '未知项目' : row.project,
+      tokens: row.tokens,
+      costUsd: Math.round(row.costUsd * 100) / 100,
+      pct: tokenTotal > 0 ? (row.tokens / tokenTotal) * 100 : 0,
+      models: [...row.models.values()]
         .map((model) => ({
           model: model.model,
           source: model.source,
           tokens: model.tokens,
           costUsd: Math.round(model.costUsd * 100) / 100,
-          pct:
-            model.pct ??
-            (row.tokens > 0 ? (model.tokens / row.tokens) * 100 : 0),
+          pct: row.tokens > 0 ? (model.tokens / row.tokens) * 100 : 0,
         }))
-        .sort((a, b) => b.tokens - a.tokens);
-
-      return {
-        project: row.project,
-        label: row.project === 'unknown' ? '未知项目' : row.project,
-        tokens: row.tokens,
-        costUsd: Math.round(row.costUsd * 100) / 100,
-        pct:
-          totalTokens > 0
-            ? (row.tokens / totalTokens) * 100
-            : (row.pct ?? 0),
-        models,
-      };
-    })
+        .sort((a, b) => b.tokens - a.tokens),
+    }))
     .sort((a, b) => b.tokens - a.tokens);
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,10 @@
     "./timezone": {
       "types": "./dist/timezone.d.ts",
       "import": "./dist/timezone.js"
+    },
+    "./project-label": {
+      "types": "./dist/project-label.d.ts",
+      "import": "./dist/project-label.js"
     }
   },
   "files": [

--- a/packages/core/src/aggregate-cache.ts
+++ b/packages/core/src/aggregate-cache.ts
@@ -9,6 +9,7 @@ import {
   aggregateUsageSummary,
 } from './aggregate.js';
 import { sealedDailyCachePath } from './paths.js';
+import { normalizeProjectName } from './project-label.js';
 import { roundCostUsd } from './pricing/index.js';
 import {
   DEFAULT_STATS_TIMEZONE,
@@ -29,7 +30,8 @@ import type {
   UsageSummary,
 } from './types.js';
 
-const CACHE_VERSION = 2;
+/** Bump when sealed project keys change (v3: encoded cwd → folder name). */
+const CACHE_VERSION = 3;
 /** Epoch lower bound so single-day aggregates are not clipped by statsSince. */
 const EPOCH_SINCE = '1970-01-01T00:00:00.000Z';
 
@@ -174,10 +176,11 @@ function mergeProjectRows(parts: SealedProjectRow[]): ProjectBreakdownRow[] {
   >();
   let totalTokens = 0;
   for (const row of parts) {
+    const projectName = normalizeProjectName(row.project);
     const project =
-      byProject.get(row.project) ??
+      byProject.get(projectName) ??
       {
-        project: row.project,
+        project: projectName,
         tokens: 0,
         costUsd: 0,
         models: new Map(),
@@ -196,7 +199,7 @@ function mergeProjectRows(parts: SealedProjectRow[]): ProjectBreakdownRow[] {
       existing.costUsd += m.costUsd;
       project.models.set(key, existing);
     }
-    byProject.set(row.project, project);
+    byProject.set(projectName, project);
     totalTokens += row.tokens;
   }
   return Array.from(byProject.values())

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -7,6 +7,7 @@ import type {
   UsageSummary,
 } from './types.js';
 import { dailyModelKey } from './daily-model-key.js';
+import { normalizeProjectName } from './project-label.js';
 import { computeRowCost, computeTokens, roundCostUsd } from './pricing/index.js';
 import { ingestBucketKey } from './queue/keys.js';
 import {
@@ -198,7 +199,7 @@ export function aggregateDaily(
     const modelKey = dailyModelKey(row.source, row.model);
     day.models.set(modelKey, (day.models.get(modelKey) ?? 0) + tokens);
 
-    const projectName = row.project || 'unknown';
+    const projectName = normalizeProjectName(row.project || 'unknown');
     const project =
       day.projects.get(projectName) ??
       { tokens: 0, models: new Map<string, number>() };
@@ -353,8 +354,9 @@ export function aggregateModelBreakdown(
     entry.costUsd += cost;
     byModel.set(key, entry);
 
-    const project = byProject.get(row.project) ?? {
-      project: row.project,
+    const projectName = normalizeProjectName(row.project || 'unknown');
+    const project = byProject.get(projectName) ?? {
+      project: projectName,
       tokens: 0,
       costUsd: 0,
       models: new Map(),
@@ -367,7 +369,7 @@ export function aggregateModelBreakdown(
     projectModel.tokens += tokens;
     projectModel.costUsd += cost;
     project.models.set(key, projectModel);
-    byProject.set(row.project, project);
+    byProject.set(projectName, project);
     totalTokens += tokens;
   }
 

--- a/packages/core/src/parsers/shared.ts
+++ b/packages/core/src/parsers/shared.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { QueueBucket, TokenTotals } from '../types.js';
+import { normalizeProjectName } from '../project-label.js';
 import { alignUnknownIntoDominant } from '../queue/align-unknown.js';
 
 export type BucketAccumulator = Map<
@@ -121,14 +122,15 @@ export function accumulateBucket(
   collector?: string,
 ): void {
   const coll = collector?.trim() || '';
-  const key = bucketStateKey(source, model, project, hourStart, coll);
+  const projectName = normalizeProjectName(project);
+  const key = bucketStateKey(source, model, projectName, hourStart, coll);
   const existing = state.get(key);
   if (existing) {
     const merged = sumTokenTotals(existing, delta);
     state.set(key, {
       ...merged,
       model,
-      project,
+      project: projectName,
       hour_start: hourStart,
       ...(coll ? { collector: coll } : {}),
     });
@@ -136,7 +138,7 @@ export function accumulateBucket(
     state.set(key, {
       ...delta,
       model,
-      project,
+      project: projectName,
       hour_start: hourStart,
       ...(coll ? { collector: coll } : {}),
     });

--- a/packages/core/src/project-label.ts
+++ b/packages/core/src/project-label.ts
@@ -1,0 +1,70 @@
+/**
+ * Browser-safe project display helpers.
+ * Keep this file free of node: imports — dashboard/desktop import it via
+ * `@juejin-opensource/jusage-core/project-label`.
+ *
+ * Contract: a project label is the last folder of a filesystem path.
+ * Encodings are unwrapped first; short names (`peeple-app`) stay as-is.
+ *
+ * Wrappers this helper understands:
+ *   percent-encoding  `%2FUsers%2Fme%2Fapp`
+ *   file URL          `file:///Users/me/app`
+ *   raw path          `/Users/me/app` or `C:\Users\me\app`
+ */
+
+/** RFC 3986 percent-encoded octet. Not a product-specific `/` check. */
+const PERCENT_ENCODED_OCTET = /%[0-9A-Fa-f]{2}/;
+
+function posixBasename(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/, '');
+  const i = normalized.lastIndexOf('/');
+  const name = (i >= 0 ? normalized.slice(i + 1) : normalized).trim();
+  return name || 'unknown';
+}
+
+/**
+ * Unwrap `%XX` sequences, including accidental double-encoding.
+ * Invalid sequences (e.g. trailing `%`) stay as-is — decodeURIComponent throws.
+ */
+function unwrapPercentEncoding(raw: string): string {
+  let current = raw;
+  for (let i = 0; i < 4; i++) {
+    if (!PERCENT_ENCODED_OCTET.test(current)) return current;
+    try {
+      const next = decodeURIComponent(current);
+      if (next === current) return current;
+      current = next;
+    } catch {
+      return current;
+    }
+  }
+  return current;
+}
+
+function stripFileUrl(value: string): string {
+  if (!/^file:/i.test(value)) return value;
+  let rest = value.replace(/^file:\/\//i, '');
+  if (/^localhost\//i.test(rest)) rest = rest.slice('localhost'.length);
+  if (rest !== '' && !rest.startsWith('/') && !/^[A-Za-z]:/.test(rest)) {
+    rest = `/${rest}`;
+  }
+  return unwrapPercentEncoding(rest);
+}
+
+/**
+ * Unwrap encodings to a filesystem path (or the original short name).
+ */
+export function decodeEncodedProjectPath(raw: string): string {
+  const value = unwrapPercentEncoding(raw).trim();
+  return stripFileUrl(value).trim();
+}
+
+/**
+ * Display / aggregate project key: unwrap encodings, then last path segment.
+ * Does not spawn git — safe in hot aggregate loops and in the renderer.
+ */
+export function normalizeProjectName(project: string): string {
+  const decoded = decodeEncodedProjectPath(project).replace(/[\\/]+$/, '');
+  if (!decoded || decoded === 'unknown') return 'unknown';
+  return posixBasename(decoded);
+}

--- a/packages/core/src/project-name.ts
+++ b/packages/core/src/project-name.ts
@@ -1,6 +1,13 @@
 import { execFileSync } from 'node:child_process';
 import { basename } from 'node:path';
 
+import { decodeEncodedProjectPath } from './project-label.js';
+
+export {
+  decodeEncodedProjectPath,
+  normalizeProjectName,
+} from './project-label.js';
+
 const GIT_TIMEOUT_MS = 2_000;
 
 /** Per-process: absolute dir → resolved project name (incl. basename fallback). */
@@ -65,7 +72,8 @@ function gitToplevel(dir: string): string | null {
  * Missing git, non-repo dirs, and timeouts all fall through to (2) silently.
  */
 export function resolveProjectName(dir: string): string {
-  const normalized = normalizeDir(dir);
+  const decoded = decodeEncodedProjectPath(dir);
+  const normalized = normalizeDir(decoded);
   if (!normalized) return 'unknown';
 
   const cached = pathCache.get(normalized);

--- a/packages/core/test/aggregate-cache.test.ts
+++ b/packages/core/test/aggregate-cache.test.ts
@@ -70,7 +70,7 @@ test('AggregateCache seals history and serves daily without rescanning today-onl
     assert.equal(cache.sealedDayCount(), before);
 
     const raw = await readFile(join(dir, 'cache', 'daily-sealed.json'), 'utf8');
-    assert.ok(raw.includes('"version":2'));
+    assert.ok(raw.includes('"version":3'));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/aggregate.test.ts
+++ b/packages/core/test/aggregate.test.ts
@@ -38,6 +38,30 @@ function makeRow(
   };
 }
 
+test('aggregateModelBreakdown merges URI-encoded cwd with folder name', () => {
+  const result = aggregateModelBreakdown(
+    [
+      makeRow('%2FUsers%2Fme%2Fcode%2Fai-usage', 200),
+      makeRow('ai-usage', 100),
+      makeRow('%2FUsers%2Fme%2Fcode%2Fdocs-site', 50),
+    ],
+    30,
+    '1970-01-01T00:00:00.000Z',
+  );
+
+  assert.deepEqual(
+    result.projects.map(({ project, tokens, pct }) => ({
+      project,
+      tokens,
+      pct,
+    })),
+    [
+      { project: 'ai-usage', tokens: 300, pct: 85.7 },
+      { project: 'docs-site', tokens: 50, pct: 14.3 },
+    ],
+  );
+});
+
 test('aggregateModelBreakdown includes project totals and percentages', () => {
   const result = aggregateModelBreakdown(
     [makeRow('ai-usage', 300), makeRow('docs-site', 100)],
@@ -103,6 +127,24 @@ test('aggregateDaily keeps same model name under different sources separate', ()
   assert.equal(models[dailyModelKey('qoder', 'auto')], 40);
   assert.equal(parseDailyModelKey(dailyModelKey('qoder', 'auto')).source, 'qoder');
   assert.equal(parseDailyModelKey(dailyModelKey('qoder', 'auto')).model, 'auto');
+});
+
+test('aggregateDaily merges URI-encoded cwd with folder name', () => {
+  const result = aggregateDaily(
+    [
+      makeRow('%2FUsers%2Fme%2Fcode%2Fai-usage', 200, 'claude', 'opus'),
+      makeRow('ai-usage', 100, 'codex', 'gpt-5'),
+    ],
+    30,
+    '1970-01-01T00:00:00.000Z',
+  );
+
+  assert.equal(result.days.length, 1);
+  const projects = result.days[0]?.projects ?? [];
+  assert.deepEqual(
+    projects.map(({ project, tokens }) => ({ project, tokens })),
+    [{ project: 'ai-usage', tokens: 300 }],
+  );
 });
 
 test('aggregateDaily nests projects with source+model keys', () => {

--- a/packages/core/test/jsonl-walk-cache.test.ts
+++ b/packages/core/test/jsonl-walk-cache.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { findJsonlFiles, resetJsonlWalkCache } from '../src/parsers/shared.js';
+import {
+  accumulateBucket,
+  findJsonlFiles,
+  resetJsonlWalkCache,
+} from '../src/parsers/shared.js';
+import type { TokenTotals } from '../src/types.js';
 
 test('findJsonlFiles reuses directory listing when mtime is unchanged', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'tud-jsonl-walk-'));
@@ -30,4 +35,35 @@ test('findJsonlFiles reuses directory listing when mtime is unchanged', async ()
     resetJsonlWalkCache();
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+function tokenDelta(total: number): TokenTotals {
+  return {
+    input_tokens: total,
+    output_tokens: 0,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: total,
+    conversation_count: 1,
+  };
+}
+
+test('accumulateBucket decodes URI-encoded cwd and merges with folder name', () => {
+  const state = new Map();
+  const hour = '2026-07-24T15:00:00.000Z';
+  accumulateBucket(
+    state,
+    'grok',
+    'grok-4',
+    '%2FUsers%2Fme%2Fcode%2Fai-usage',
+    hour,
+    tokenDelta(200),
+  );
+  accumulateBucket(state, 'grok', 'grok-4', 'ai-usage', hour, tokenDelta(100));
+
+  assert.equal(state.size, 1);
+  const row = [...state.values()][0]!;
+  assert.equal(row.project, 'ai-usage');
+  assert.equal(row.total_tokens, 300);
 });

--- a/packages/core/test/p2-parsers.test.ts
+++ b/packages/core/test/p2-parsers.test.ts
@@ -358,7 +358,8 @@ test('parseGrokBuildIncremental diffs updates.jsonl high-water marks', async () 
   const prev = process.env.AI_USAGE_GROK_HOME;
   process.env.AI_USAGE_GROK_HOME = home;
   try {
-    const sessionDir = join(home, 'sessions', 'encoded-cwd', 'sess-grok-1');
+    const encodedCwd = encodeURIComponent('/Users/me/apps/demo-app');
+    const sessionDir = join(home, 'sessions', encodedCwd, 'sess-grok-1');
     await mkdir(sessionDir, { recursive: true });
     await writeFile(join(sessionDir, 'signals.json'), JSON.stringify({ primaryModelId: 'grok-3' }));
     const updatesPath = join(sessionDir, 'updates.jsonl');
@@ -385,6 +386,7 @@ test('parseGrokBuildIncremental diffs updates.jsonl high-water marks', async () 
     const first = await parseGrokBuildIncremental({}, SINCE);
     assert.equal(first.result.eventsParsed, 2);
     assert.equal(first.result.buckets[0]!.source, 'grok');
+    assert.equal(first.result.buckets[0]!.project, 'demo-app');
     const firstTotal = first.result.buckets.reduce((sum, b) => sum + b.total_tokens, 0);
     assert.equal(firstTotal, 250);
 

--- a/packages/core/test/project-name.test.ts
+++ b/packages/core/test/project-name.test.ts
@@ -6,6 +6,8 @@ import { execFileSync } from 'node:child_process';
 import test from 'node:test';
 
 import {
+  decodeEncodedProjectPath,
+  normalizeProjectName,
   resetProjectNameCache,
   resolveProjectName,
 } from '../src/project-name.js';
@@ -76,6 +78,44 @@ test(
     }
   },
 );
+
+test('decodeEncodedProjectPath unwraps encodings to a filesystem path', () => {
+  assert.equal(
+    decodeEncodedProjectPath('%2FUsers%2Fyipan%2Fcode%2Fdemo%2Fjuejin-usage'),
+    '/Users/yipan/code/demo/juejin-usage',
+  );
+  assert.equal(
+    decodeEncodedProjectPath('%252FUsers%252Fme%252Fapp'),
+    '/Users/me/app',
+  );
+  assert.equal(decodeEncodedProjectPath('peeple-app'), 'peeple-app');
+  assert.equal(decodeEncodedProjectPath('%'), '%');
+  assert.equal(decodeEncodedProjectPath('100%'), '100%');
+});
+
+test('normalizeProjectName uses the last folder of any path-like value', () => {
+  assert.equal(
+    normalizeProjectName('%2FUsers%2Fyipan%2Fcode%2Fdemo%2Fjuejin-usage'),
+    'juejin-usage',
+  );
+  assert.equal(normalizeProjectName('%5CUsers%5Cme%5Capp'), 'app');
+  assert.equal(normalizeProjectName('%252FUsers%252Fme%252Fapp'), 'app');
+  assert.equal(normalizeProjectName('file:///Users/me/apps/demo-app'), 'demo-app');
+  assert.equal(normalizeProjectName('peeple-app'), 'peeple-app');
+  assert.equal(normalizeProjectName('juejin-usage'), 'juejin-usage');
+  assert.equal(normalizeProjectName('/Users/me/apps/demo-app'), 'demo-app');
+  assert.equal(normalizeProjectName('C:\\\\Users\\\\me\\\\app'), 'app');
+  assert.equal(normalizeProjectName('unknown'), 'unknown');
+  assert.equal(normalizeProjectName(''), 'unknown');
+});
+
+test('resolveProjectName decodes encoded cwd then uses basename fallback', () => {
+  resetProjectNameCache();
+  assert.equal(
+    resolveProjectName('%2Ftmp%2Ftud-missing-proj-dir%2Fdemo-app'),
+    'demo-app',
+  );
+});
 
 test('resolveProjectName caches by path', () => {
   resetProjectNameCache();

--- a/packages/dashboard/src/lib/dashboard-data.test.ts
+++ b/packages/dashboard/src/lib/dashboard-data.test.ts
@@ -182,6 +182,85 @@ test('projectDashboardForDate builds project usage from that day projects', () =
   );
 });
 
+test('project usage decodes URI-encoded cwd and merges with folder name', () => {
+  const today = localDateNow();
+  const yesterday = addLocalDays(today, -1);
+  const dataset = datasetWithDays(
+    [
+      {
+        date: yesterday,
+        tokens: 300,
+        costUsd: 3,
+        models: {},
+        projects: [
+          {
+            project: '%2FUsers%2Fme%2Fcode%2Fai-usage',
+            tokens: 200,
+            models: { [dailyModelKey('grok', 'grok-4')]: 200 },
+          },
+          {
+            project: 'ai-usage',
+            tokens: 100,
+            models: { [dailyModelKey('codex', 'gpt-5')]: 100 },
+          },
+        ],
+      },
+    ],
+    {
+      projectRows: [
+        {
+          project: '%2FUsers%2Fme%2Fcode%2Fai-usage',
+          tokens: 200,
+          costUsd: 2,
+          pct: 66.7,
+          models: [
+            {
+              model: 'grok-4',
+              source: 'grok',
+              tokens: 200,
+              costUsd: 2,
+              pct: 100,
+            },
+          ],
+        },
+        {
+          project: 'ai-usage',
+          tokens: 100,
+          costUsd: 1,
+          pct: 33.3,
+          models: [
+            {
+              model: 'gpt-5',
+              source: 'codex',
+              tokens: 100,
+              costUsd: 1,
+              pct: 100,
+            },
+          ],
+        },
+      ],
+    },
+  );
+
+  const rangeView = buildDashboardDataFromDataset(dataset, 7);
+  assert.equal(rangeView.projectModelUsage.length, 1);
+  assert.equal(rangeView.projectModelUsage[0]?.project, 'ai-usage');
+  assert.equal(rangeView.projectModelUsage[0]?.label, 'ai-usage');
+  assert.equal(rangeView.projectModelUsage[0]?.tokens, 300);
+  assert.equal(rangeView.projectModelUsage[0]?.models.length, 2);
+  assert.ok(
+    rangeView.distributions.projects.some((row) => row.label === 'ai-usage'),
+  );
+  assert.ok(
+    !rangeView.distributions.projects.some((row) => row.label.includes('%2F')),
+  );
+
+  const dayView = projectDashboardForDate(rangeView, yesterday);
+  assert.equal(dayView.projectModelUsage.length, 1);
+  assert.equal(dayView.projectModelUsage[0]?.project, 'ai-usage');
+  assert.equal(dayView.projectModelUsage[0]?.tokens, 300);
+});
+
 test('projectDashboardForDate keeps empty project usage when day has no projects', () => {
   const today = localDateNow();
   const yesterday = addLocalDays(today, -1);

--- a/packages/dashboard/src/lib/dashboard-data.ts
+++ b/packages/dashboard/src/lib/dashboard-data.ts
@@ -1,4 +1,5 @@
 import { parseDailyModelKey } from '@juejin-opensource/jusage-core/daily-model-key';
+import { normalizeProjectName } from '@juejin-opensource/jusage-core/project-label';
 import type {
   DailyUsageRow,
   HourlyUsageRow,
@@ -359,7 +360,26 @@ function buildProjectRowsFromDaily(
   day: DailyUsageRow,
   sourceFallback: Map<string, string>,
 ): ProjectBreakdownRow[] {
-  const projects = (day.projects ?? []).filter((row) => row.tokens > 0);
+  const collapsed = new Map<
+    string,
+    { project: string; tokens: number; models: Record<string, number> }
+  >();
+  for (const row of day.projects ?? []) {
+    if (row.tokens <= 0) continue;
+    const project = normalizeProjectName(row.project);
+    const current = collapsed.get(project) ?? {
+      project,
+      tokens: 0,
+      models: {},
+    };
+    current.tokens += row.tokens;
+    for (const [key, tokens] of Object.entries(row.models ?? {})) {
+      if (tokens <= 0) continue;
+      current.models[key] = (current.models[key] ?? 0) + tokens;
+    }
+    collapsed.set(project, current);
+  }
+  const projects = Array.from(collapsed.values());
   if (projects.length === 0) return [];
 
   const dayTokenTotal = projects.reduce((sum, row) => sum + row.tokens, 0);
@@ -518,6 +538,24 @@ function emptyHourlyRow(
   };
 }
 
+function collapseProjectDistribution(
+  projects: ProjectBreakdownRow[],
+): Array<{ label: string; tokens: number; costUsd: number }> {
+  const byName = new Map<
+    string,
+    { label: string; tokens: number; costUsd: number }
+  >();
+  for (const row of projects) {
+    const name = normalizeProjectName(row.project);
+    const label = name === 'unknown' ? '未知项目' : name;
+    const current = byName.get(name) ?? { label, tokens: 0, costUsd: 0 };
+    current.tokens += row.tokens;
+    current.costUsd += row.costUsd;
+    byName.set(name, current);
+  }
+  return Array.from(byName.values());
+}
+
 function buildDistributions(
   sources: UsageDataset['summary']['bySource'],
   models: ModelBreakdownRow[],
@@ -558,11 +596,7 @@ function buildDistributions(
     projects:
       projects.length > 0
         ? normalizeDistribution(
-            projects.map((row) => ({
-              label: row.project === 'unknown' ? '未知项目' : row.project,
-              tokens: row.tokens,
-              costUsd: row.costUsd,
-            })),
+            collapseProjectDistribution(projects),
             summary,
             6,
           )

--- a/packages/dashboard/src/lib/dashboard-mock-data.ts
+++ b/packages/dashboard/src/lib/dashboard-mock-data.ts
@@ -1,3 +1,4 @@
+import { normalizeProjectName } from '@juejin-opensource/jusage-core/project-label';
 import type { DailyUsageRow, HourlyUsageRow, ModelBreakdownRow } from './api.ts';
 
 export const DASHBOARD_WEEKDAYS = [
@@ -530,34 +531,69 @@ export function buildProjectModelUsage(
   }>,
   totalTokens = 0,
 ): DashboardProjectUsageRow[] {
-  return rows
-    .filter((row) => row.tokens > 0)
-    .map((row) => {
-      const models = (row.models ?? [])
-        .filter((model) => model.tokens > 0)
+  const byProject = new Map<
+    string,
+    {
+      project: string;
+      tokens: number;
+      costUsd: number;
+      models: Map<
+        string,
+        { model: string; source: string; tokens: number; costUsd: number }
+      >;
+    }
+  >();
+
+  for (const row of rows) {
+    if (row.tokens <= 0) continue;
+    const project = normalizeProjectName(row.project);
+    const current = byProject.get(project) ?? {
+      project,
+      tokens: 0,
+      costUsd: 0,
+      models: new Map(),
+    };
+    current.tokens += row.tokens;
+    current.costUsd += row.costUsd;
+    for (const model of row.models ?? []) {
+      if (model.tokens <= 0) continue;
+      const pairKey = `${model.source}\0${model.model}`;
+      const existing = current.models.get(pairKey) ?? {
+        model: model.model,
+        source: model.source,
+        tokens: 0,
+        costUsd: 0,
+      };
+      existing.tokens += model.tokens;
+      existing.costUsd += model.costUsd;
+      current.models.set(pairKey, existing);
+    }
+    byProject.set(project, current);
+  }
+
+  const merged = Array.from(byProject.values());
+  const tokenTotal =
+    totalTokens > 0
+      ? totalTokens
+      : merged.reduce((sum, row) => sum + row.tokens, 0);
+
+  return merged
+    .map((row) => ({
+      project: row.project,
+      label: row.project === 'unknown' ? '未知项目' : row.project,
+      tokens: row.tokens,
+      costUsd: roundCurrency(row.costUsd),
+      pct: percentage(row.tokens, tokenTotal),
+      models: [...row.models.values()]
         .map((model) => ({
           model: model.model,
           source: model.source,
           tokens: model.tokens,
           costUsd: roundCurrency(model.costUsd),
-          pct:
-            model.pct ??
-            percentage(model.tokens, row.tokens),
+          pct: percentage(model.tokens, row.tokens),
         }))
-        .sort((a, b) => b.tokens - a.tokens);
-
-      return {
-        project: row.project,
-        label: row.project === 'unknown' ? '未知项目' : row.project,
-        tokens: row.tokens,
-        costUsd: roundCurrency(row.costUsd),
-        pct:
-          totalTokens > 0
-            ? percentage(row.tokens, totalTokens)
-            : (row.pct ?? 0),
-        models,
-      };
-    })
+        .sort((a, b) => b.tokens - a.tokens),
+    }))
     .sort((a, b) => b.tokens - a.tokens);
 }
 


### PR DESCRIPTION
### 🏷️ 变动类型

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [x] Web

跨端：core 统一规范化项目名；`packages/dashboard` 与 `apps/desktop/src/renderer` 两份同构面板一起改了展示合并。

### 🔗 关联 Issue

自己在本地面板「项目分布」里踩到的：Grok 等工具把 URI 编码的工作目录（`%2FUsers%2Fyipan%2F...`）当成项目名写入 bucket，列表一截断就全变成 `%2FUsers%2Fyipa...`。

### 💡 改动说明

**原来的问题：** 项目名直接用会话目录名。Grok 的目录是 `encodeURIComponent(cwd)`，没有 `/`，截断后看不出项目。不是某一个 parser 独有的展示事故——谁把路径当项目名，面板都会这样画。

**这版怎么改：** 项目名只在三个公共入口规范化（解码百分号编码 / `file://`，再取最后一级目录）：

1. 写入：所有解析器都走的 `accumulateBucket`
2. 聚合：历史 queue / sealed cache（cache version 2 → 3，启动会重建）
3. 展示：dashboard 与 Desktop renderer 合并同名项目后再画标题

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | 修复项目分布把工作目录编码路径（如 `%2FUsers%2F...`）直接当标题展示的问题。CLI、Web 与 Desktop 面板同步修复。 |
| `@juejin-opensource/jusage-core` | patch | 修复项目分布把工作目录编码路径（如 `%2FUsers%2F...`）直接当标题展示的问题。CLI、Web 与 Desktop 面板同步修复。 |
| `@juejin-opensource/jusage-desktop` | patch | 修复项目分布把工作目录编码路径（如 `%2FUsers%2F...`）直接当标题展示的问题。CLI、Web 与 Desktop 面板同步修复。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过