### PR TITLE
fix(core): 扩大时间范围时用快照覆盖重扫结果，不再重复累计

### DIFF
--- a/.changeset/sync-range-expand-replace.md
+++ b/.changeset/sync-range-expand-replace.md
@@ -1,0 +1,7 @@
+---
+"@juejin-opensource/jusage-core": patch
+"@juejin-opensource/jusage": patch
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复把面板时间范围从 7 天扩大到 30 / 90 天后 Token、费用和会话数被重复计算的问题：扩大范围触发的历史重扫改为用重扫结果覆盖已有数据，不再和旧数据相加；Desktop 的同步进程也会在主进程清空 cursor 后丢弃自己的缓存，保证补扫真的执行。

--- a/apps/desktop/src/main/local-runtime.ts
+++ b/apps/desktop/src/main/local-runtime.ts
@@ -40,6 +40,7 @@ import {
 } from '@juejin-opensource/jusage-core';
 import { evictCliAutostart } from './evict-cli-autostart';
 import {
+  invalidateSyncWorkerCursors,
   isSyncWorkerRunning,
   runSyncViaWorker,
   startSyncWorker,
@@ -217,6 +218,9 @@ function buildApp(state: {
     getHookStatus: () => getHookStatus(state.dir),
     onConfigChange: (next) => {
       if (runtime) runtime.config = next;
+    },
+    onCursorsCleared: () => {
+      invalidateSyncWorkerCursors();
     },
     onSync: async () => {
       notifySynced();

--- a/apps/desktop/src/main/sync-worker-host.ts
+++ b/apps/desktop/src/main/sync-worker-host.ts
@@ -153,6 +153,20 @@ export async function startSyncWorker(dataDir: string): Promise<boolean> {
   }
 }
 
+/**
+ * Tell the worker its cached cursors.json copy is stale. Posted before the sync
+ * that follows a range expansion, so the rescan actually re-reads the logs.
+ * utilityProcess messages keep their order, so the reset lands first.
+ */
+export function invalidateSyncWorkerCursors(): void {
+  if (!child || !ready) return;
+  try {
+    child.postMessage({ type: 'invalidateCursors' } satisfies SyncWorkerRequest);
+  } catch {
+    // A worker that is gone reloads cursors.json from disk when it restarts.
+  }
+}
+
 export function stopSyncWorker(): void {
   stopping = true;
   lastDataDir = null;

--- a/apps/desktop/src/main/sync-worker-protocol.ts
+++ b/apps/desktop/src/main/sync-worker-protocol.ts
@@ -3,6 +3,8 @@ import type { SyncResult } from '@juejin-opensource/jusage-core';
 export type SyncWorkerRequest =
   | { type: 'init'; dataDir: string }
   | { type: 'runSync'; id: number; reason: string; source?: string }
+  /** Main cleared cursors.json on disk; the worker must drop its cached copy. */
+  | { type: 'invalidateCursors' }
   | { type: 'stop' };
 
 export type SyncWorkerResponse =

--- a/apps/desktop/src/main/sync-worker.ts
+++ b/apps/desktop/src/main/sync-worker.ts
@@ -7,6 +7,7 @@ import {
   createSyncRunner,
   kickBackfillDrain,
   loadConfig,
+  resetCursorsCache,
   stopBackfillDrain,
   syncLogPath,
   type SyncResult,
@@ -64,6 +65,14 @@ async function handle(msg: SyncWorkerRequest): Promise<void> {
     });
     process.stdout.write(`[tud-sync-worker] ready pid=${process.pid}\n`);
     post({ type: 'ready', pid: process.pid });
+    return;
+  }
+
+  if (msg.type === 'invalidateCursors') {
+    // Main owns cursors.json (range expansion clears it) but parsers run here.
+    // Without this the worker keeps serving its cached offsets, reports "no new
+    // events" and the widened window never backfills.
+    if (dataDir) resetCursorsCache(dataDir);
     return;
   }
 

--- a/packages/core/src/server/state.ts
+++ b/packages/core/src/server/state.ts
@@ -98,6 +98,12 @@ export interface LocalApiDeps {
   ) => Promise<SyncResult[]>;
   onSync?: (source?: string) => Promise<void>;
   onConfigChange?: (config: TudConfig) => void;
+  /**
+   * Fired right after cursors.json was cleared for a backfill. Processes that
+   * cache cursors elsewhere (Desktop sync worker) must drop their copy here,
+   * otherwise they keep replaying stale offsets and skip the rescan.
+   */
+  onCursorsCleared?: () => void | Promise<void>;
   getHookStatus?: () => Promise<HookStatus>;
 }
 
@@ -324,8 +330,11 @@ export async function runSync(
 /**
  * Expand local collect floor to cover `days` (今天/7D/30D/90D).
  * When expansion is needed, clears cursors only (keeps queue) and re-syncs so
- * parsers re-read Agent logs for the wider window. Also moves upload
- * `statsSince` earlier (never later) so the cloud window can catch up.
+ * parsers re-read Agent logs for the wider window. Rows the rescan re-emits
+ * replace their queue counterpart (see `parsedFullRescan`), so widening the
+ * range backfills history without recounting what is already stored. Also
+ * moves upload `statsSince` earlier (never later) so the cloud window can
+ * catch up.
  */
 export async function ensureLocalCollectRange(
   deps: LocalApiDeps,
@@ -370,6 +379,7 @@ export async function ensureLocalCollectRange(
 
   // Keep existing queue; only reset incremental cursors so parsers backfill.
   await clearCursors(deps.dataDir);
+  await deps.onCursorsCleared?.();
   const sync = await runSync(deps);
   return { expanded: true, config, sync };
 }

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -105,6 +105,45 @@ function bucketChanged(a: QueueBucket, b: QueueBucket): boolean {
   );
 }
 
+/**
+ * True when a cursors.json slot still carries incremental state (file offsets,
+ * dedup ids, cumulative watermarks). Empty shells a parser leaves behind when
+ * it finds nothing (`{ files: {} }`) do not count as state.
+ */
+function hasCursorState(value: unknown): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value !== 'object') return true;
+  for (const key in value as Record<string, unknown>) {
+    if (hasCursorState((value as Record<string, unknown>)[key])) return true;
+  }
+  return false;
+}
+
+function statefulCursorSlots(cursors: CursorsFile): Set<string> {
+  const slots = new Set<string>();
+  for (const [slot, value] of Object.entries(cursors)) {
+    if (hasCursorState(value)) slots.add(slot);
+  }
+  return slots;
+}
+
+/**
+ * A parser that started the round with an empty cursor slot re-read its source
+ * from the beginning, so the buckets it returns are a full snapshot of the
+ * collect window — not a delta on top of what the queue already holds.
+ *
+ * Detected from the slot the parse just filled instead of a source→slot table:
+ * every parser owns its own top-level key in cursors.json, so new sources stay
+ * covered without extra bookkeeping.
+ */
+function parsedFullRescan(before: Set<string>, after: CursorsFile): boolean {
+  for (const [slot, value] of Object.entries(after)) {
+    if (!before.has(slot) && hasCursorState(value)) return true;
+  }
+  return false;
+}
+
 async function syncSourceBuckets(
   dataDir: string,
   config: TudConfig,
@@ -122,11 +161,12 @@ async function syncSourceBuckets(
     };
     cursors: Awaited<ReturnType<typeof loadCursors>>;
   }>,
-  options?: { replace?: boolean; sharedCursors?: CursorsFile },
+  options?: { sharedCursors?: CursorsFile },
 ): Promise<SyncResult> {
   const collectSince = resolveLocalCollectSince(config);
   const shared = options?.sharedCursors;
   let cursors = shared ?? (await loadCursors(dataDir));
+  const statefulBefore = statefulCursorSlots(cursors);
   const { result, cursors: nextCursors } = await parseFn(cursors, collectSince);
   cursors = nextCursors;
 
@@ -169,12 +209,17 @@ async function syncSourceBuckets(
   );
   const existingMap = new Map(existing.map((r) => [bucketKey(r), r]));
 
+  // Widening the local range (7D → 90D) clears cursors so parsers backfill.
+  // Their output then repeats rows the queue already has, so adding it on top
+  // would count every already ingested event twice. Snapshot rows replace.
+  const snapshot = parsedFullRescan(statefulBefore, cursors);
+
   const toAppend: QueueBucket[] = [];
   const working = new Map(existingMap);
   for (const delta of result.buckets) {
     const key = bucketKey(delta);
     const prev = working.get(key);
-    working.set(key, options?.replace ? delta : prev ? mergeBuckets(prev, delta) : delta);
+    working.set(key, snapshot ? delta : prev ? mergeBuckets(prev, delta) : delta);
   }
   const touched = new Set(result.buckets.map((bucket) => unknownAlignGroupKey(bucket)));
   const everyCodeUnknownGroups = new Set<string>();

--- a/packages/core/test/range-expand.test.ts
+++ b/packages/core/test/range-expand.test.ts
@@ -1,0 +1,344 @@
+import assert from 'node:assert/strict';
+import { appendFile, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import {
+  clearCursors,
+  loadCursors,
+  loadRecentBuckets,
+  resetCursorsCache,
+} from '../src/queue/index.js';
+import { resetJsonlWalkCache } from '../src/parsers/shared.js';
+import { BucketStore, ensureLocalCollectRange } from '../src/server/state.js';
+import { syncAll } from '../src/sync/index.js';
+import type { QueueBucket, TudConfig } from '../src/types.js';
+
+const DAY_MS = 24 * 3600_000;
+
+function daysAgoIso(days: number, hourOffset = 0): string {
+  return new Date(Date.now() - days * DAY_MS + hourOffset * 3600_000).toISOString();
+}
+
+/** Config with both floors at `days` ago, like the dashboard 7D / 90D switch. */
+function configForDays(days: number): TudConfig {
+  return {
+    deviceId: 'test-device',
+    statsSince: daysAgoIso(days),
+    localCollectSince: daysAgoIso(days),
+    hostname: 'test-host',
+    dataDir: '',
+    juejin: { enabled: false, apiUrl: '', authMode: 'device', token: null },
+  } as TudConfig;
+}
+
+function claudeLine(opts: {
+  id: string;
+  timestamp: string;
+  input: number;
+  output: number;
+}): string {
+  return JSON.stringify({
+    type: 'assistant',
+    uuid: `uuid-${opts.id}`,
+    requestId: `req-${opts.id}`,
+    timestamp: opts.timestamp,
+    cwd: '/tmp/demo',
+    message: {
+      id: `msg-${opts.id}`,
+      model: 'claude-sonnet-4-5',
+      usage: { input_tokens: opts.input, output_tokens: opts.output },
+    },
+  });
+}
+
+interface Totals {
+  total: number;
+  conversations: number;
+}
+
+async function queueTotals(dataDir: string, config: TudConfig): Promise<Totals> {
+  const rows: QueueBucket[] = await loadRecentBuckets(
+    dataDir,
+    config.localCollectSince ?? config.statsSince,
+  );
+  return {
+    total: rows.reduce((sum, row) => sum + row.total_tokens, 0),
+    conversations: rows.reduce((sum, row) => sum + row.conversation_count, 0),
+  };
+}
+
+/** Fresh HOME so parsers only see the fixtures written by one test. */
+async function makeHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'tud-range-home-'));
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  resetJsonlWalkCache();
+  return home;
+}
+
+async function makeDataDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'tud-range-data-'));
+  resetCursorsCache(dir);
+  return dir;
+}
+
+async function writeClaudeSession(home: string, name: string, lines: string[]): Promise<string> {
+  const projectDir = join(home, '.claude', 'projects', '-tmp-demo');
+  await mkdir(projectDir, { recursive: true });
+  const file = join(projectDir, name);
+  await writeFile(file, `${lines.join('\n')}\n`, 'utf8');
+  resetJsonlWalkCache();
+  return file;
+}
+
+function withHome(fn: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    const prevHome = process.env.HOME;
+    const prevProfile = process.env.USERPROFILE;
+    try {
+      await fn();
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevProfile;
+      resetJsonlWalkCache();
+    }
+  };
+}
+
+test(
+  'widening the collect range does not recount already ingested usage',
+  withHome(async () => {
+    const home = await makeHome();
+    const dataDir = await makeDataDir();
+    await writeClaudeSession(home, 'session-recent.jsonl', [
+      claudeLine({ id: 'a', timestamp: daysAgoIso(2), input: 100, output: 20 }),
+    ]);
+
+    const week = configForDays(7);
+    await syncAll(dataDir, week, 'claude');
+    assert.deepEqual(await queueTotals(dataDir, week), { total: 120, conversations: 1 });
+
+    // ensureLocalCollectRange: move the floor, clear cursors, re-sync.
+    const quarter = configForDays(90);
+    await clearCursors(dataDir);
+    await syncAll(dataDir, quarter, 'claude');
+
+    assert.deepEqual(await queueTotals(dataDir, quarter), { total: 120, conversations: 1 });
+  }),
+);
+
+test(
+  '7D then 90D matches a plain 90D scan',
+  withHome(async () => {
+    const home = await makeHome();
+    await writeClaudeSession(home, 'session-mixed.jsonl', [
+      claudeLine({ id: 'old', timestamp: daysAgoIso(40), input: 200, output: 40 }),
+      claudeLine({ id: 'recent', timestamp: daysAgoIso(2), input: 100, output: 20 }),
+    ]);
+
+    const week = configForDays(7);
+    const quarter = configForDays(90);
+
+    const expanded = await makeDataDir();
+    await syncAll(expanded, week, 'claude');
+    assert.deepEqual(await queueTotals(expanded, week), { total: 120, conversations: 1 });
+    await clearCursors(expanded);
+    await syncAll(expanded, quarter, 'claude');
+
+    const direct = await makeDataDir();
+    await syncAll(direct, quarter, 'claude');
+
+    assert.deepEqual(await queueTotals(direct, quarter), { total: 360, conversations: 2 });
+    assert.deepEqual(await queueTotals(expanded, quarter), await queueTotals(direct, quarter));
+  }),
+);
+
+test(
+  'repeated rescans stay idempotent',
+  withHome(async () => {
+    const home = await makeHome();
+    const dataDir = await makeDataDir();
+    await writeClaudeSession(home, 'session-retry.jsonl', [
+      claudeLine({ id: 'a', timestamp: daysAgoIso(2), input: 100, output: 20 }),
+    ]);
+
+    const quarter = configForDays(90);
+    await syncAll(dataDir, quarter, 'claude');
+    const first = await queueTotals(dataDir, quarter);
+
+    // A crash between clearCursors and sync, or a poll racing the expansion,
+    // makes the same rescan run more than once.
+    for (let i = 0; i < 2; i++) {
+      await clearCursors(dataDir);
+      await syncAll(dataDir, quarter, 'claude');
+      assert.deepEqual(await queueTotals(dataDir, quarter), first);
+    }
+  }),
+);
+
+test(
+  'incremental sync after a rescan still adds new events',
+  withHome(async () => {
+    const home = await makeHome();
+    const dataDir = await makeDataDir();
+    const file = await writeClaudeSession(home, 'session-live.jsonl', [
+      claudeLine({ id: 'a', timestamp: daysAgoIso(2), input: 100, output: 20 }),
+    ]);
+
+    const quarter = configForDays(90);
+    await syncAll(dataDir, quarter, 'claude');
+    await clearCursors(dataDir);
+    await syncAll(dataDir, quarter, 'claude');
+    assert.deepEqual(await queueTotals(dataDir, quarter), { total: 120, conversations: 1 });
+
+    // Same hour as the snapshot row: the delta must land on top of it.
+    await appendFile(
+      file,
+      `${claudeLine({
+        id: 'b',
+        timestamp: daysAgoIso(2, 0.1),
+        input: 25,
+        output: 5,
+      })}\n`,
+      'utf8',
+    );
+    await syncAll(dataDir, quarter, 'claude');
+
+    assert.deepEqual(await queueTotals(dataDir, quarter), { total: 150, conversations: 2 });
+  }),
+);
+
+test(
+  'codex backfill replaces its rows instead of stacking them',
+  withHome(async () => {
+    const home = await makeHome();
+    const dataDir = await makeDataDir();
+    const prevCodexHome = process.env.CODEX_HOME;
+    const codexHome = join(home, '.codex');
+    process.env.CODEX_HOME = codexHome;
+    try {
+      const day = new Date(Date.now() - 2 * DAY_MS);
+      const sessionsDir = join(
+        codexHome,
+        'sessions',
+        String(day.getUTCFullYear()),
+        String(day.getUTCMonth() + 1).padStart(2, '0'),
+        String(day.getUTCDate()).padStart(2, '0'),
+      );
+      await mkdir(sessionsDir, { recursive: true });
+      await writeFile(
+        join(sessionsDir, 'rollout-range.jsonl'),
+        `${[
+          JSON.stringify({
+            type: 'session_meta',
+            timestamp: daysAgoIso(2),
+            payload: { id: 'range-session', cwd: '/tmp/demo' },
+          }),
+          JSON.stringify({
+            type: 'event_msg',
+            timestamp: daysAgoIso(2),
+            payload: {
+              type: 'token_count',
+              info: {
+                last_token_usage: {
+                  input_tokens: 50,
+                  cached_input_tokens: 0,
+                  output_tokens: 10,
+                  reasoning_output_tokens: 0,
+                  total_tokens: 60,
+                },
+                model: 'gpt-5.4',
+              },
+            },
+          }),
+        ].join('\n')}\n`,
+        'utf8',
+      );
+      resetJsonlWalkCache();
+
+      const quarter = configForDays(90);
+      await syncAll(dataDir, quarter, 'codex');
+      const first = await queueTotals(dataDir, quarter);
+      assert.equal(first.total, 60);
+
+      await clearCursors(dataDir);
+      await syncAll(dataDir, quarter, 'codex');
+      assert.deepEqual(await queueTotals(dataDir, quarter), first);
+    } finally {
+      if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = prevCodexHome;
+    }
+  }),
+);
+
+test('ensureLocalCollectRange only clears cursors when the floor moves earlier', async () => {
+  const dataDir = await makeDataDir();
+  const config = configForDays(7);
+  const cleared: number[] = [];
+  const synced: string[] = [];
+  const deps = {
+    dataDir,
+    getConfig: () => config,
+    bucketStore: new BucketStore(),
+    runSyncViaRunner: async (reason: string) => {
+      synced.push(reason);
+      return [];
+    },
+    onCursorsCleared: () => {
+      cleared.push(Date.now());
+    },
+  };
+
+  await clearCursors(dataDir);
+  await loadCursors(dataDir);
+
+  const expand = await ensureLocalCollectRange(deps, 90);
+  assert.equal(expand.expanded, true);
+  assert.equal(cleared.length, 1, 'worker cursor cache must be invalidated on expand');
+  assert.equal(synced.length, 1);
+  const widened = expand.config.localCollectSince;
+
+  // Narrowing back only changes the display window: no clear, no rescan, and
+  // the collect floor stays where the wider range left it.
+  const shrink = await ensureLocalCollectRange(deps, 7);
+  assert.equal(shrink.expanded, false);
+  assert.equal(shrink.sync, null);
+  assert.equal(cleared.length, 1);
+  assert.equal(synced.length, 1);
+  assert.equal(shrink.config.localCollectSince, widened);
+});
+
+test(
+  'sync worker: cursors cleared by another process only backfill once the cache is dropped',
+  withHome(async () => {
+    const home = await makeHome();
+    const dataDir = await makeDataDir();
+    await writeClaudeSession(home, 'session-worker.jsonl', [
+      claudeLine({ id: 'old', timestamp: daysAgoIso(40), input: 200, output: 40 }),
+      claudeLine({ id: 'recent', timestamp: daysAgoIso(2), input: 100, output: 20 }),
+    ]);
+
+    const week = configForDays(7);
+    const quarter = configForDays(90);
+    await syncAll(dataDir, week, 'claude');
+    assert.deepEqual(await queueTotals(dataDir, week), { total: 120, conversations: 1 });
+
+    // Desktop main clears cursors.json on disk; the worker still has the file
+    // cached in memory, so its parsers report "nothing new" and skip the
+    // backfill entirely.
+    await writeFile(join(dataDir, 'cursors.json'), '{}\n', 'utf8');
+    const stale = await syncAll(dataDir, quarter, 'claude');
+    assert.equal(stale[0]?.bucketsWritten, 0);
+    assert.deepEqual(await queueTotals(dataDir, quarter), { total: 120, conversations: 1 });
+
+    // `invalidateCursors` drops that cached copy: the backfill lands and the
+    // already ingested row is replaced rather than added twice.
+    resetCursorsCache(dataDir);
+    await syncAll(dataDir, quarter, 'claude');
+    assert.deepEqual(await queueTotals(dataDir, quarter), { total: 360, conversations: 2 });
+  }),
+);


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

改动主要在 `packages/core`（CLI / Desktop 共用的同步层），Desktop 额外补了一条 worker 消息。分支按「影响最大的一端」命名为 `fix/cli/...`，但两端都会生效；Web 无关。

### 🔗 关联 Issue

fix #60

### 💡 改动说明

**1. 原来的问题**

扩大面板时间范围（7D → 30D / 90D）时，`ensureLocalCollectRange()` 会清掉 cursor 让 parser 回读更早的日志，但保留原有 queue；重扫产出的 bucket 又被 `mergeBuckets()` 和已有 bucket **逐字段相加**，于是同一条记录被算了两遍。`syncSourceBuckets()` 上的 `options.replace` 覆盖分支全仓库没有调用方，等于永远走加法。

同一条 fixture（2 天前 120 token + 40 天前 240 token）：

| 场景 | 修复前 | 修复后 | 期望 |
| --- | --- | --- | --- |
| 先 7D | 120 tokens / 1 会话 | 120 / 1 | 120 / 1 |
| 7D → 扩到 90D | **480 / 3** | 360 / 2 | 360 / 2 |
| 从零直接 90D | 360 / 2 | 360 / 2 | 360 / 2 |

Desktop 还有一条相反的漏算路径：主进程清掉磁盘 cursor，parser 却跑在同步 utilityProcess 里，worker 的进程内 `cursorsCache` 没人通知，于是 `eventsParsed=0`，90 天历史压根没补进来；等 worker 重启读到空 cursor，又会掉进上面那条重复累计的路径。

**2. 这版怎么改**

- **重扫 = 快照，覆盖而不是相加**（`packages/core/src/sync/index.ts`）。一个 parser 如果这一轮开始时 cursor 槽位是空的，它就是从头把源读了一遍，产出的 bucket 是该窗口的完整快照而非增量，因此直接覆盖 queue 里对应的行；带着真实 offset 续跑的增量同步仍然走原来的加法。
  判定方式是看这次 parse 新填出来的 cursor 槽位，而不是维护一张 source → 槽位映射表：每个 parser 都独占 cursors.json 里的一个顶层 key，这样以后新增数据源不用额外登记。也因此，不只是「切范围」这一条路径，**任何**从空 cursor 起跑的重扫（升级时 `alignLookbackFloors()` 前移采集下限、hook / 轮询抢在补扫前面、崩溃后重试）都同样安全。
  重扫**没有**重新产出的行保持原样，不做清零 —— Agent 日志会被自己清理（Claude Code 默认 30 天），清零会把用户已经采集到、日志里已经不存在的历史抹掉。
  被否掉的方案：给这次调用传一个 `rescan` 参数。它只覆盖「面板点了 90D」这一次调用，poll / hook / 崩溃重试抢先跑到时仍然是加法，所以改成由 cursor 状态自己决定。
- **Desktop worker 失效 cursor 缓存**：`SyncWorkerRequest` 增加 `invalidateCursors`，`LocalApiDeps` 增加 `onCursorsCleared` 钩子，主进程清 cursor 后先发失效消息再发 `runSync`（utilityProcess 消息保序，失效必定先到）。CLI 单进程，`clearCursors()` 本来就会更新自己的缓存，无需改动。

**3. 测试**

新增 `packages/core/test/range-expand.test.ts`，7 条用例覆盖 issue 里提的验收口径，改动前 6 条全红、改动后全绿：

- 扩大范围不重复计算已采集用量；
- 「先 7D 再扩 90D」与「直接 90D」结果完全一致；
- 重复重扫幂等（崩溃重试 / 轮询与补扫抢跑）；
- 重扫之后的增量同步仍然能把新事件加上去（防止覆盖语义误伤正常增量）；
- codex 侧同样生效（另一类 parser）；
- `ensureLocalCollectRange()` 只在下限前移时清 cursor 并通知 worker，缩小范围不清、不重扫、不动已采集数据；
- worker 形态：外部进程清 cursor 后，只有丢掉缓存才能补扫，且补扫不重复计数。

`pnpm build` 通过；`packages/core` 254 条测试、`packages/cli` 13 条测试全绿。`apps/desktop` 的 `typecheck` 只剩 `src/main/index.ts` 里 3 处既有的 `app.dock` 报错，与本次改动无关。

**已知遗留（本 PR 未处理）**：`createSyncRunner` 会把并发的 sync 合流，如果点 90D 的瞬间正好有一轮 sync 在跑，这次补扫会被合并掉、要等下一轮轮询才补上（数字不会错，只是补历史晚一点）。这属于 runner 的调度语义，需要跨进程改 runSync 签名，建议单独一个 PR。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | 修复把面板时间范围从 7 天扩大到 30 / 90 天后 Token、费用和会话数被重复计算的问题：扩大范围触发的历史重扫改为用重扫结果覆盖已有数据，不再和旧数据相加；Desktop 的同步进程也会在主进程清空 cursor 后丢弃自己的缓存，保证补扫真的执行。 |
| `@juejin-opensource/jusage-core` | patch | 同上 |
| `@juejin-opensource/jusage-desktop` | patch | 同上 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：本次没动面板 UI，`packages/dashboard/src` 与 `apps/desktop/src/renderer` 都无需同步
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过
