### PR TITLE
chore(pricing): 更新价格（新增 Fable 5.1，去重匹配项）

### DIFF
--- a/.changeset/claude-fable-5-1-pricing.md
+++ b/.changeset/claude-fable-5-1-pricing.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-core": patch
+---
+
+支持 Claude Fable 5.1 的准确用量计价，CLI 与 Desktop 费用统计将使用最新价格。

--- a/packages/core/src/pricing/pricing.json
+++ b/packages/core/src/pricing/pricing.json
@@ -473,6 +473,12 @@
       "cache_read": 1,
       "cache_write": 12.5
     },
+    "anthropic/claude-fable-5-1": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
     "anthropic/claude-haiku-4-5-20251001": {
       "input": 1,
       "output": 5,
@@ -2078,6 +2084,10 @@
       "ref": "anthropic/claude-mythos-5"
     },
     {
+      "match": "claude-fable-5-1",
+      "ref": "anthropic/claude-fable-5-1"
+    },
+    {
       "match": "claude-fable-5",
       "ref": "anthropic/claude-fable-5"
     },
@@ -2100,6 +2110,10 @@
     {
       "match": "claude-4.6-opus",
       "ref": "anthropic/claude-opus-4-6"
+    },
+    {
+      "match": "claude-fable-5-1",
+      "ref": "anthropic/claude-fable-5-1"
     },
     {
       "match": "claude-fable-5",

--- a/packages/core/src/pricing/pricing.json
+++ b/packages/core/src/pricing/pricing.json
@@ -2112,14 +2112,6 @@
       "ref": "anthropic/claude-opus-4-6"
     },
     {
-      "match": "claude-fable-5-1",
-      "ref": "anthropic/claude-fable-5-1"
-    },
-    {
-      "match": "claude-fable-5",
-      "ref": "anthropic/claude-fable-5"
-    },
-    {
       "match": "claude",
       "ref": "anthropic/claude-sonnet-4-5"
     },

--- a/packages/core/test/pricing.test.ts
+++ b/packages/core/test/pricing.test.ts
@@ -41,6 +41,7 @@ test.afterEach(() => {
   resetPricingRuntime();
 });
 
+
 test('getModelPricing resolves claude-opus-4-6 from pricing table', () => {
   const p = getModelPricing('claude-opus-4-6');
   assert.ok(p.input > 0);
@@ -59,6 +60,14 @@ test('claude-fable-5 with spaces normalizes and still avoids the catch-all', () 
   const p = getModelPricing('Claude Fable 5', { source: 'claude' });
   assert.equal(p.input, 10);
   assert.equal(p.output, 50);
+});
+
+test('claude-fable-5-1 resolves its distinct cache-read price', () => {
+  const p = getModelPricing('claude-fable-5-1', { source: 'claude' });
+  assert.equal(p.input, 10);
+  assert.equal(p.output, 50);
+  assert.equal(p.cache_read, 0.25);
+  assert.equal(p.cache_write, 12.5);
 });
 
 test('bare claude still falls through to the fuzzy catch-all', () => {
@@ -191,6 +200,16 @@ test('cursor claude-fable-5 reasoning tiers resolve to fable-5, not sonnet', () 
     const p = getModelPricing(m, { source: 'cursor' });
     assert.equal(p.input, 10, m);
     assert.equal(p.output, 50, m);
+  }
+});
+
+test('cursor claude-fable-5-1 reasoning tiers resolve to fable-5-1', () => {
+  for (const m of ['claude-fable-5-1-thinking-max', 'claude-fable-5-1-thinking-high']) {
+    const p = getModelPricing(m, { source: 'cursor' });
+    assert.equal(p.input, 10, m);
+    assert.equal(p.output, 50, m);
+    assert.equal(p.cache_read, 0.25, m);
+    assert.equal(p.cache_write, 12.5, m);
   }
 });
 
@@ -498,4 +517,3 @@ test('roundCostUsd keeps 8 decimals instead of rounding to cents', () => {
   assert.notEqual(roundCostUsd(4.516), 4.52);
 });
 });
-


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI

### 💡 改动说明

models.dev 已发布 Claude Fable 5.1（`claude-fable-5-1`，2026-09-01）。补充其输入、输出及缓存价格，并增加专属模糊匹配，避免带推理后缀的型号误用 Claude Fable 5 的缓存读取价格。

价格（美元 / 百万 token）：输入 10、输出 50、缓存读取 0.25、缓存写入 12.5。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 支持 Claude Fable 5.1 的准确用量计价，CLI 与 Desktop 费用统计将使用最新价格。 |

### ☑️ 自查清单

- [x] 分支命名符合规范并 PR 回 `main`
- [x] 已执行 changeset
- [x] Core 测试通过（250 项）
- [x] `pnpm build` 通过