### PR TITLE
fix(desktop): guard optional app.dock access

### DIFF
--- a/.changeset/desktop-dock-optional-guard.md
+++ b/.changeset/desktop-dock-optional-guard.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 Desktop typecheck 报错：`app.dock` 在非 macOS 平台为可选，补齐两处缺失的存在性判断。

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -168,7 +168,7 @@ async function showMainWindowAsync(): Promise<void> {
     // Window was destroyed on close (tray-resident app). Rebuild it. On
     // macOS the dock was hidden at close; await the accessory→regular
     // transform so the freshly built window is not hidden by macOS mid-flight.
-    if (process.platform === 'darwin' && !app.dock.isVisible()) {
+    if (process.platform === 'darwin' && app.dock && !app.dock.isVisible()) {
       try {
         await app.dock.show();
       } catch {
@@ -427,7 +427,7 @@ void acquireDesktopInstanceLock().then((gotLock) => {
     // drops IPC (config-reset / deep-link) aimed at that doomed window.
     if (shouldStartHidden()) {
       if (process.platform === 'darwin') {
-        app.dock.hide();
+        app.dock?.hide();
       }
     } else {
       createWindow();


### PR DESCRIPTION
## 问题

`pnpm --filter @juejin-opensource/jusage-desktop typecheck` 当前在 `main` 上失败，报 3 个 TS18048：

```
src/main/index.ts(171,43): error TS18048: 'app.dock' is possibly 'undefined'.
src/main/index.ts(173,15): error TS18048: 'app.dock' is possibly 'undefined'.
src/main/index.ts(430,9): error TS18048: 'app.dock' is possibly 'undefined'.
```

`app.dock` 仅在 macOS 存在，Electron 因此将其标为可选。这两处调用都已经在 `process.platform === 'darwin'` 分支内，**运行时是安全的**，但 TS 无法从 platform 判断收窄属性类型。

## 修改

按同一文件里已有的写法补齐，没有引入新风格：

- `index.ts:171` 加 `app.dock &&` —— `:187` 处是完全相同的逻辑，本来就带了这个守卫
- `index.ts:430` 改为 `app.dock?.hide()` —— 对齐 `:328` 以及 `DesktopWindow.ts:117,128`

## 影响范围

仅 Desktop 主进程，2 行，无行为变化。

## 验证

- `pnpm --filter @juejin-opensource/jusage-desktop typecheck` 由失败转为通过
- `pnpm build` 全量通过
- 测试全绿：core 250/250、dashboard 61/61、cli 13/13

🤖 Generated with [Claude Code](https://claude.com/claude-code)