### PR TITLE
fix(web): surface leaderboard load errors with retry

### DIFF
--- a/.changeset/rank-page-error-retry.md
+++ b/.changeset/rank-page-error-retry.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-dashboard": patch
+---
+
+排行榜页在接口加载失败时不再误报「暂无数据」，改为显示明确错误提示并支持一键重试。

--- a/packages/dashboard/src/hooks/useLeaderboardData.ts
+++ b/packages/dashboard/src/hooks/useLeaderboardData.ts
@@ -33,6 +33,7 @@ export function useLeaderboardData(
   const { authStatus } = useJuejinAuth();
   const [revision, setRevision] = useState(0);
   const lastKeyRef = useRef<string | null>(null);
+  const manualReloadRef = useRef(false);
   const [state, setState] = useState<LeaderboardDataState>({
     data: null,
     loading: true,
@@ -40,7 +41,8 @@ export function useLeaderboardData(
     error: null,
   });
 
-  const reload = useCallback(() => {
+  const reload = useCallback((options?: { silent?: boolean }) => {
+    manualReloadRef.current = options?.silent !== true;
     setRevision((current) => current + 1);
   }, []);
 
@@ -63,6 +65,10 @@ export function useLeaderboardData(
 
     // Skeleton only when empty. Filter/range switches keep prior rows visible
     // (refreshing). Same-key polls stay silent to avoid periodic layout jumps.
+    // Manual reloads always surface the refreshing state so the retry button
+    // gives feedback even when the key is unchanged.
+    const isManualReload = manualReloadRef.current;
+    manualReloadRef.current = false;
     setState((current) => {
       if (current.data == null) {
         return {
@@ -74,7 +80,7 @@ export function useLeaderboardData(
       }
       const isFilterChange =
         lastKeyRef.current != null && lastKeyRef.current !== key;
-      if (isFilterChange) {
+      if (isFilterChange || isManualReload) {
         return {
           ...current,
           loading: false,
@@ -120,7 +126,7 @@ export function useLeaderboardData(
     const tick = (now: number) => {
       if (now - last >= POLL_MS) {
         last = now;
-        reload();
+        reload({ silent: true });
       }
       rafId = requestAnimationFrame(tick);
     };
@@ -128,7 +134,7 @@ export function useLeaderboardData(
 
     const onFocus = () => {
       last = performance.now();
-      reload();
+      reload({ silent: true });
     };
     window.addEventListener('focus', onFocus);
 

--- a/packages/dashboard/src/pages/RankPage.tsx
+++ b/packages/dashboard/src/pages/RankPage.tsx
@@ -141,8 +141,44 @@ export function RankPage() {
       />
 
       <div className="space-y-6">
+        {error != null && data == null && (
+          <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center">
+            <div className="min-w-0 flex-1">
+              <StatusBanner
+                description={error}
+                title="排行榜加载失败"
+                tone="error"
+              />
+            </div>
+            <Button
+              className="shrink-0 self-start sm:self-center"
+              onPress={() => reload()}
+              variant="secondary"
+            >
+              重试
+            </Button>
+          </div>
+        )}
+        {error != null && data != null && (
+          <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center">
+            <div className="min-w-0 flex-1">
+              <StatusBanner
+                description={`${error}。下面显示的是上次成功加载的数据，可能不是最新的。`}
+                title="排行榜刷新失败"
+                tone="warn"
+              />
+            </div>
+            <Button
+              className="shrink-0 self-start sm:self-center"
+              onPress={() => reload()}
+              variant="secondary"
+            >
+              重试
+            </Button>
+          </div>
+        )}
         {showAnonymousAuthWarn && (
-          <div className="flex max-w-2xl flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center">
             <div className="min-w-0 flex-1">
               <StatusBanner
                 description="无法标注你的排名。请前往设置绑定鉴权 Token，或登录后再查看个人名次。"
@@ -161,18 +197,20 @@ export function RankPage() {
             </Button>
           </div>
         )}
-        <RankUserTable
-          global={data?.global ?? null}
-          hideFromLeaderboard={hideFromLeaderboard}
-          hideToggleDisabled={hideToggleSaving}
-          loading={loading}
-          metric={metric}
-          onHideFromLeaderboardChange={onHideFromLeaderboardChange}
-          onMetricChange={setMetric}
-          profiles={profiles}
-          refreshing={refreshing}
-          showHideToggle={showHideToggle}
-        />
+        {!(error != null && data == null) && (
+          <RankUserTable
+            global={data?.global ?? null}
+            hideFromLeaderboard={hideFromLeaderboard}
+            hideToggleDisabled={hideToggleSaving}
+            loading={loading}
+            metric={metric}
+            onHideFromLeaderboardChange={onHideFromLeaderboardChange}
+            onMetricChange={setMetric}
+            profiles={profiles}
+            refreshing={refreshing}
+            showHideToggle={showHideToggle}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Show an error banner with retry when the leaderboard first-load fails instead of a misleading "no data yet" empty state. Keep previously loaded rows visible with a warning banner when a refresh fails, and let manual retry bypass silent background polling so the button actually triggers a reload.

<!--
提交前请对照 CONTRIBUTING.md 确认：
- 分支从 main 拉出，也 PR 回 main，命名为 <type>/<end>/<short-desc>
- 影响用户的改动已执行 pnpm changeset，并把生成的文件一起提交
- 下面的信息填完整，维护者 review 通过后合并
-->

### 🏷️ 变动类型

<!-- 勾选一项；如果一个 PR 同时做了好几类事情，考虑拆开提。 -->

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

<!-- 勾选本次改动实际影响的端。跨端改动请全部勾上，并在下方说明各端的差异。 -->

- [ ] Desktop
- [ ] CLI
- [x] Web

### 🔗 关联 Issue
无。
<!--
写 close #123 或 fix #123，合并时 GitHub 会自动关掉对应 issue。
没有对应 issue 的话，说明这个改动是怎么来的（自己踩到的坑、群里反馈的、等等）。
-->

### 💡 改动说明

<!--
说清三件事：
1. 原来有什么问题，什么场景下会遇到；
2. 这版怎么改的，为什么选这个方案（如果有其他方案被否掉，也提一句）；
3. 动了 UI 或交互，贴改动前后的对比图或录屏。
-->
原问题
   - 排行榜接口请求失败时，榜单拿到空数据，页面显示「当前范围暂无用户排行数据 / 产生用量后再回来看看」，把网络故障误报成「用户没有用量」，比白屏更有误导性。
   - 页面上的重试按钮触发的是同 key 静默刷新，走了 `return current` 的静默分支，点击后没有任何反馈，等于失效。

改法
   - 区分两种失败场景：
     - 首次加载失败（还没有任何数据）：榜单整体替换为 error 横幅 + 「重试」按钮，文案使用真实错误信息。
     - 刷新失败但已有数据：保留旧榜单不覆盖，顶部挂 warn 横幅 + 重试，并注明「下面显示的是上次成功加载的数据，可能不是最新的」。
   - 为 useLeaderboardData 增加手动重试与静默轮询的区分：手动 `reload()` 走 refreshing 有反馈，10 秒轮询与窗口 focus 用 `reload({ silent: true })` 保持无感，避免周期性布局跳动。

<img width="1098" height="681" alt="image" src="https://github.com/user-attachments/assets/cf89a976-8b31-4831-bfd3-a551a6614640" />


### 📝 Changelog

<!--
下表填你在 `pnpm changeset` 里写的那句话，两边保持一致；删掉本次没有改动的包。

这段会原样进入 CHANGELOG 和 Release 说明，是给用户看的 —— 请写「用户能感知到什么变化」，
而不是「我改了哪个函数」。破坏性变更以 **Breaking:** 开头，并在上面的改动说明里写清迁移方式。

纯文档 / CI 改动不需要 changeset，可以整表删掉，写一句「无需 changeset」。
写法可参考 https://keepachangelog.com/zh-CN/1.1.0/
-->

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-dashboard` | patch | 排行榜页在接口加载失败时不再误报「暂无数据」，改为显示明确错误提示并支持一键重试。  | |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [x] `pnpm build` 通过
