### PR TITLE
fix(cli): include Codex sessions from multiple homes

### DIFF
--- a/.changeset/codex-multi-home.md
+++ b/.changeset/codex-multi-home.md
@@ -1,0 +1,6 @@
+---
+'@juejin-opensource/jusage-core': patch
+---
+
+Scan Codex session data from configured profile directories so usage from
+multiple official accounts and CC Switch-managed Codex homes is included.

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,6 +1,6 @@
 import { homedir, platform } from 'node:os';
 import { join, basename } from 'node:path';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
 
 export const DEFAULT_DATA_DIR = join(homedir(), '.ai-usage');
 export const DEFAULT_PORT = 8452;
@@ -264,16 +264,80 @@ export function claudeProjectsDirs(): string[] {
 }
 
 export function codexHome(): string {
-  const env = process.env.CODEX_HOME?.trim();
-  if (env) {
-    return env.startsWith('~') ? join(homedir(), env.slice(1)) : env;
+  return codexHomeCandidates()[0]!;
+}
+
+function expandCodexHomePath(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '~') return homedir();
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return join(homedir(), trimmed.slice(2));
   }
-  return join(homedir(), '.codex');
+  return trimmed;
+}
+
+/**
+ * Codex-compatible config roots that may contain session rollouts.
+ *
+ * CC Switch can run Codex with a custom config directory when switching
+ * providers/accounts. Keep the normal CODEX_HOME override, but also discover
+ * additional roots so historical sessions from another official account are
+ * not silently omitted. `CODEX_HOME` and `AI_USAGE_CODEX_HOME` accept the
+ * platform path-list separator for users who keep several profiles.
+ */
+export function codexHomeCandidates(): string[] {
+  const delimiter = platform() === 'win32' ? ';' : ':';
+  const roots: string[] = [];
+  const add = (value: string | undefined): boolean => {
+    if (!value?.trim()) return false;
+    let added = false;
+    for (const part of value.split(delimiter)) {
+      const expanded = expandCodexHomePath(part);
+      if (expanded) {
+        added = true;
+        if (!roots.includes(expanded)) roots.push(expanded);
+      }
+    }
+    return added;
+  };
+
+  const hasUsageHomeEnv = add(process.env.AI_USAGE_CODEX_HOME);
+  const hasCodexHomeEnv = add(process.env.CODEX_HOME);
+  const hasExplicitEnvRoot = hasUsageHomeEnv || hasCodexHomeEnv;
+  let hasCcSwitchOverride = false;
+
+  // CC Switch stores its directory override in this small, non-secret JSON
+  // settings file. Ignore malformed/unreadable files and keep defaults.
+  try {
+    const settings = JSON.parse(
+      readFileSync(join(homedir(), '.cc-switch', 'settings.json'), 'utf8'),
+    ) as { codexConfigDir?: unknown; codex_config_dir?: unknown };
+    if (typeof settings.codexConfigDir === 'string') {
+      hasCcSwitchOverride = add(settings.codexConfigDir) || hasCcSwitchOverride;
+    }
+    if (typeof settings.codex_config_dir === 'string') {
+      hasCcSwitchOverride = add(settings.codex_config_dir) || hasCcSwitchOverride;
+    }
+  } catch {
+    // CC Switch is optional; an absent or old settings file is expected.
+  }
+
+  // An explicit environment override is authoritative (and is important for
+  // test isolation). When CC Switch has a saved alternate directory, retain
+  // the default root as well so old sessions remain visible after switching.
+  if (!hasExplicitEnvRoot || hasCcSwitchOverride) add(join(homedir(), '.codex'));
+  return roots;
 }
 
 export function codexSessionsDirs(): string[] {
-  const home = codexHome();
-  return [join(home, 'sessions'), join(home, 'archived_sessions')];
+  const dirs: string[] = [];
+  for (const home of codexHomeCandidates()) {
+    for (const name of ['sessions', 'archived_sessions']) {
+      const dir = join(home, name);
+      if (!dirs.includes(dir)) dirs.push(dir);
+    }
+  }
+  return dirs;
 }
 
 export function codexConfigPath(): string {
@@ -458,4 +522,3 @@ export function copilotHome(): string {
 export function copilotSessionStateDir(): string {
   return join(copilotHome(), 'session-state');
 }
-

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,5 +1,5 @@
 import { homedir, platform } from 'node:os';
-import { join, basename } from 'node:path';
+import { join, basename, delimiter } from 'node:path';
 import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
 
 export const DEFAULT_DATA_DIR = join(homedir(), '.ai-usage');
@@ -280,13 +280,14 @@ function expandCodexHomePath(value: string): string {
  * Codex-compatible config roots that may contain session rollouts.
  *
  * CC Switch can run Codex with a custom config directory when switching
- * providers/accounts. Keep the normal CODEX_HOME override, but also discover
- * additional roots so historical sessions from another official account are
- * not silently omitted. `CODEX_HOME` and `AI_USAGE_CODEX_HOME` accept the
- * platform path-list separator for users who keep several profiles.
+ * providers/accounts. Keep `CODEX_HOME` / `AI_USAGE_CODEX_HOME` as extra
+ * scan roots (they accept the platform path-list separator), but still
+ * discover CC Switch so an env that only names the active profile does not
+ * hide the managed home. When CC Switch has a saved alternate directory,
+ * retain the default ~/.codex root so historical sessions from another
+ * official account are not silently omitted.
  */
 export function codexHomeCandidates(): string[] {
-  const delimiter = platform() === 'win32' ? ';' : ':';
   const roots: string[] = [];
   const add = (value: string | undefined): boolean => {
     if (!value?.trim()) return false;
@@ -322,9 +323,9 @@ export function codexHomeCandidates(): string[] {
     // CC Switch is optional; an absent or old settings file is expected.
   }
 
-  // An explicit environment override is authoritative (and is important for
-  // test isolation). When CC Switch has a saved alternate directory, retain
-  // the default root as well so old sessions remain visible after switching.
+  // Env roots are extra scan targets, not a full override. Skip the default
+  // home only when env is set and CC Switch has no alternate directory, so
+  // tests that pin CODEX_HOME under a stubbed HOME stay isolated.
   if (!hasExplicitEnvRoot || hasCcSwitchOverride) add(join(homedir(), '.codex'));
   return roots;
 }

--- a/packages/core/src/sync/source-presence.ts
+++ b/packages/core/src/sync/source-presence.ts
@@ -22,7 +22,7 @@ import { zcodeDbPath } from '../parsers/zcode.js';
 import { zedDbPath } from '../parsers/zed.js';
 import { warpDbPaths } from '../parsers/warp.js';
 import {
-  codexHome,
+  codexHomeCandidates,
   copilotSessionStateDir,
   cursorStateVscdbPath,
   geminiTmpDir,
@@ -74,7 +74,9 @@ export function isSyncSourcePresent(source: string): boolean {
       // Empty ~/.claude/projects is common; still attempt parse (cheap when empty).
       return true;
     case 'codex':
-      return anyExists([codexHome(), join(codexHome(), 'sessions')]);
+      return anyExists(
+        codexHomeCandidates().flatMap((home) => [home, join(home, 'sessions')]),
+      );
     case 'cursor':
       return anyExists([cursorStateVscdbPath()]);
     case 'qoder':

--- a/packages/core/test/codex.test.ts
+++ b/packages/core/test/codex.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 
 import { parseCodexIncremental } from '../src/parsers/codex.js';
 import { modelFromRolloutEvent } from '../src/parsers/rollout-model.js';
+import { codexHomeCandidates } from '../src/paths.js';
 import type { CursorsFile } from '../src/types.js';
 
 const SOURCE_FILE = [
@@ -42,6 +43,27 @@ test('parseCodexIncremental normalizes input and skips fork replay', async () =>
   } finally {
     if (prevHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = prevHome;
+  }
+});
+
+test('codexHomeCandidates includes CC Switch directory override and deduplicates roots', () => {
+  const previous = {
+    codex: process.env.CODEX_HOME,
+    usage: process.env.AI_USAGE_CODEX_HOME,
+  };
+  process.env.CODEX_HOME = '/tmp/codex-primary:/tmp/codex-shared';
+  process.env.AI_USAGE_CODEX_HOME = '/tmp/codex-shared:/tmp/codex-extra';
+  try {
+    const roots = codexHomeCandidates();
+    assert.ok(roots.includes('/tmp/codex-shared'));
+    assert.ok(roots.includes('/tmp/codex-extra'));
+    assert.ok(roots.includes('/tmp/codex-primary'));
+    assert.equal(new Set(roots).size, roots.length);
+  } finally {
+    if (previous.codex === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previous.codex;
+    if (previous.usage === undefined) delete process.env.AI_USAGE_CODEX_HOME;
+    else process.env.AI_USAGE_CODEX_HOME = previous.usage;
   }
 });
 

--- a/packages/core/test/codex.test.ts
+++ b/packages/core/test/codex.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, delimiter } from 'node:path';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
 
@@ -8,6 +8,40 @@ import { parseCodexIncremental } from '../src/parsers/codex.js';
 import { modelFromRolloutEvent } from '../src/parsers/rollout-model.js';
 import { codexHomeCandidates } from '../src/paths.js';
 import type { CursorsFile } from '../src/types.js';
+
+const CODEX_ENV_KEYS = ['HOME', 'USERPROFILE', 'CODEX_HOME', 'AI_USAGE_CODEX_HOME'] as const;
+
+type CodexEnvSnapshot = Record<(typeof CODEX_ENV_KEYS)[number], string | undefined>;
+
+function snapshotCodexEnv(): CodexEnvSnapshot {
+  return {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    CODEX_HOME: process.env.CODEX_HOME,
+    AI_USAGE_CODEX_HOME: process.env.AI_USAGE_CODEX_HOME,
+  };
+}
+
+function restoreCodexEnv(snapshot: CodexEnvSnapshot): void {
+  for (const key of CODEX_ENV_KEYS) {
+    if (snapshot[key] === undefined) delete process.env[key];
+    else process.env[key] = snapshot[key];
+  }
+}
+
+/** Pin HOME + CODEX_HOME to a temp tree so discovery cannot see the developer's CC Switch. */
+async function withIsolatedCodexHome<T>(tempHome: string, fn: () => Promise<T>): Promise<T> {
+  const snapshot = snapshotCodexEnv();
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  process.env.CODEX_HOME = join(tempHome, '.codex');
+  delete process.env.AI_USAGE_CODEX_HOME;
+  try {
+    return await fn();
+  } finally {
+    restoreCodexEnv(snapshot);
+  }
+}
 
 const SOURCE_FILE = [
   '{"type":"session_meta","timestamp":"2026-06-09T20:46:00.000Z","payload":{"id":"source-session-1","cwd":"/Users/dev/my-app"}}',
@@ -28,10 +62,7 @@ test('parseCodexIncremental normalizes input and skips fork replay', async () =>
   await writeFile(join(sessionsDir, 'rollout-source.jsonl'), `${SOURCE_FILE}\n`, 'utf8');
   await writeFile(join(sessionsDir, 'rollout-fork.jsonl'), `${FORK_FILE}\n`, 'utf8');
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const { result } = await parseCodexIncremental({}, '2026-01-01T00:00:00.000Z');
     assert.equal(result.eventsParsed, 2);
 
@@ -40,30 +71,77 @@ test('parseCodexIncremental normalizes input and skips fork replay', async () =>
 
     assert.equal(totalInput, 50 + 15);
     assert.equal(totalOutput, 10 + 6);
+  });
+});
+
+test('codexHomeCandidates splits env path lists and deduplicates roots', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-codex-env-list-'));
+  const snapshot = snapshotCodexEnv();
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  process.env.CODEX_HOME = `/tmp/codex-primary${delimiter}/tmp/codex-shared`;
+  process.env.AI_USAGE_CODEX_HOME = `/tmp/codex-shared${delimiter}/tmp/codex-extra`;
+  try {
+    const roots = codexHomeCandidates();
+    assert.deepEqual(roots, ['/tmp/codex-shared', '/tmp/codex-extra', '/tmp/codex-primary']);
   } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
+    restoreCodexEnv(snapshot);
   }
 });
 
-test('codexHomeCandidates includes CC Switch directory override and deduplicates roots', () => {
-  const previous = {
-    codex: process.env.CODEX_HOME,
-    usage: process.env.AI_USAGE_CODEX_HOME,
-  };
-  process.env.CODEX_HOME = '/tmp/codex-primary:/tmp/codex-shared';
-  process.env.AI_USAGE_CODEX_HOME = '/tmp/codex-shared:/tmp/codex-extra';
+test('codexHomeCandidates reads CC Switch override and keeps default ~/.codex', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-cc-switch-'));
+  const ccSwitchDir = join(tempHome, '.cc-switch');
+  const alternateCodex = join(tempHome, 'codex-alt');
+  await mkdir(ccSwitchDir, { recursive: true });
+  await writeFile(
+    join(ccSwitchDir, 'settings.json'),
+    JSON.stringify({ codexConfigDir: alternateCodex }),
+    'utf8',
+  );
+
+  const snapshot = snapshotCodexEnv();
+  delete process.env.CODEX_HOME;
+  delete process.env.AI_USAGE_CODEX_HOME;
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+
   try {
     const roots = codexHomeCandidates();
-    assert.ok(roots.includes('/tmp/codex-shared'));
-    assert.ok(roots.includes('/tmp/codex-extra'));
-    assert.ok(roots.includes('/tmp/codex-primary'));
+    assert.ok(roots.includes(alternateCodex));
+    assert.ok(roots.includes(join(tempHome, '.codex')));
     assert.equal(new Set(roots).size, roots.length);
   } finally {
-    if (previous.codex === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = previous.codex;
-    if (previous.usage === undefined) delete process.env.AI_USAGE_CODEX_HOME;
-    else process.env.AI_USAGE_CODEX_HOME = previous.usage;
+    restoreCodexEnv(snapshot);
+  }
+});
+
+test('codexHomeCandidates keeps CC Switch and ~/.codex when CODEX_HOME is set', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-cc-switch-env-'));
+  const ccSwitchDir = join(tempHome, '.cc-switch');
+  const alternateCodex = join(tempHome, 'codex-alt');
+  await mkdir(ccSwitchDir, { recursive: true });
+  await writeFile(
+    join(ccSwitchDir, 'settings.json'),
+    JSON.stringify({ codexConfigDir: alternateCodex }),
+    'utf8',
+  );
+
+  const snapshot = snapshotCodexEnv();
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  process.env.CODEX_HOME = '/tmp/codex-active-profile';
+  delete process.env.AI_USAGE_CODEX_HOME;
+
+  try {
+    const roots = codexHomeCandidates();
+    assert.deepEqual(roots, [
+      '/tmp/codex-active-profile',
+      alternateCodex,
+      join(tempHome, '.codex'),
+    ]);
+  } finally {
+    restoreCodexEnv(snapshot);
   }
 });
 
@@ -77,10 +155,7 @@ test('parseCodexIncremental reuses cached session meta for unchanged files', asy
   const filePath = join(sessionsDir, 'rollout-meta-cache.jsonl');
   await writeFile(filePath, `${SOURCE_FILE}\n`, 'utf8');
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const cursors: CursorsFile = {};
     await parseCodexIncremental(cursors, '2026-01-01T00:00:00.000Z');
     const fileCursor = cursors.codex!.files[filePath]!;
@@ -104,10 +179,7 @@ test('parseCodexIncremental reuses cached session meta for unchanged files', asy
     const third = await parseCodexIncremental(cursors, '2026-01-01T00:00:00.000Z');
     assert.equal(third.result.eventsParsed, 1);
     assert.equal(cursors.codex!.files[filePath]!.meta?.tokenCountRecords, 2);
-  } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
-  }
+  });
 });
 
 test('parseCodexIncremental uses the model from thread settings', async () => {
@@ -124,17 +196,11 @@ test('parseCodexIncremental uses the model from thread settings', async () => {
     'utf8',
   );
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const { result } = await parseCodexIncremental({}, '2026-01-01T00:00:00.000Z');
     assert.equal(result.buckets.length, 1);
     assert.equal(result.buckets[0]?.model, 'gpt-5.6-sol');
-  } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
-  }
+  });
 });
 
 const CONTEXT_ONLY = [
@@ -187,10 +253,7 @@ test('parseCodexIncremental persists lastModel across tail scans without info.mo
   const filePath = join(sessionsDir, 'rollout-last-model.jsonl');
   await writeFile(filePath, `${CONTEXT_ONLY}\n`, 'utf8');
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const cursors: CursorsFile = {};
     const first = await parseCodexIncremental(cursors, '2026-01-01T00:00:00.000Z');
     assert.equal(first.result.eventsParsed, 0);
@@ -201,10 +264,7 @@ test('parseCodexIncremental persists lastModel across tail scans without info.mo
     assert.equal(second.result.eventsParsed, 1);
     assert.equal(second.result.buckets.length, 1);
     assert.equal(second.result.buckets[0]?.model, 'deepseek-v4-flash');
-  } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
-  }
+  });
 });
 
 test('parseCodexIncremental recovers lastModel from the skipped prefix', async () => {
@@ -214,10 +274,7 @@ test('parseCodexIncremental recovers lastModel from the skipped prefix', async (
   const filePath = join(sessionsDir, 'rollout-prefix-recover.jsonl');
   await writeFile(filePath, `${CONTEXT_ONLY}\n`, 'utf8');
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const cursors: CursorsFile = {};
     await parseCodexIncremental(cursors, '2026-01-01T00:00:00.000Z');
     delete cursors.codex!.files[filePath]!.lastModel;
@@ -227,10 +284,7 @@ test('parseCodexIncremental recovers lastModel from the skipped prefix', async (
     assert.equal(result.eventsParsed, 1);
     assert.equal(result.buckets[0]?.model, 'deepseek-v4-flash');
     assert.equal(cursors.codex!.files[filePath]!.lastModel, 'deepseek-v4-flash');
-  } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
-  }
+  });
 });
 
 test('parseCodexIncremental uses the model from world_state', async () => {
@@ -247,17 +301,11 @@ test('parseCodexIncremental uses the model from world_state', async () => {
     'utf8',
   );
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const { result } = await parseCodexIncremental({}, '2026-01-01T00:00:00.000Z');
     assert.equal(result.buckets.length, 1);
     assert.equal(result.buckets[0]?.model, 'deepseek-v4-flash');
-  } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
-  }
+  });
 });
 
 test('parseCodexIncremental folds early unknown token_count into the later model', async () => {
@@ -275,18 +323,12 @@ test('parseCodexIncremental folds early unknown token_count into the later model
     'utf8',
   );
 
-  const prevHome = process.env.CODEX_HOME;
-  process.env.CODEX_HOME = join(tempHome, '.codex');
-
-  try {
+  await withIsolatedCodexHome(tempHome, async () => {
     const { result } = await parseCodexIncremental({}, '2026-01-01T00:00:00.000Z');
     assert.equal(result.buckets.length, 1);
     assert.equal(result.buckets[0]?.model, 'deepseek-v4-flash');
     assert.equal(result.buckets[0]?.input_tokens, 50);
     assert.equal(result.buckets[0]?.output_tokens, 15);
     assert.equal(result.buckets[0]?.total_tokens, 65);
-  } finally {
-    if (prevHome === undefined) delete process.env.CODEX_HOME;
-    else process.env.CODEX_HOME = prevHome;
-  }
+  });
 });


### PR DESCRIPTION
## What changed

Codex usage collection now discovers all configured Codex homes, including `AI_USAGE_CODEX_HOME`, `CODEX_HOME`, and the CC Switch `codexConfigDir` setting. The default `~/.codex` root remains included when CC Switch has an alternate directory, and duplicate roots are deduplicated.

## Why

CC Switch can switch Codex profiles/accounts by using a custom config directory. The previous collector only scanned one root, so historical official-account sessions in another root were omitted.

## Verification

- TypeScript compile (`packages/core/tsconfig.json` and test config)
- Codex parser regression tests pass (9 tests)
- `git diff --check` passes
- Local replay against 1,500 Codex rollout files parsed 6,348 events and wrote 118 previously missing buckets

## Scope

This PR only changes local Codex directory discovery and does not read or upload credentials.