### PR TITLE
fix(desktop): compile auto-update tests instead of using --experimental-strip-types

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,13 +15,13 @@
     "dev:mock": "cross-env VITE_ENABLE_MOCK_DATA=true electron-vite dev",
     "build": "electron-vite build",
     "start": "electron-vite preview",
-    "test": "node --experimental-strip-types --test src/shared/auto-update.test.mts",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:mac:arm": "electron-vite build && electron-builder --mac --arm64",
     "build:win": "electron-vite build && electron-builder --win",
     "release:mac": "electron-vite build && electron-builder --mac --publish always",
     "release:win": "electron-vite build && electron-builder --win --publish always",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/shared/auto-update.test.js"
   },
   "dependencies": {
     "@fontsource-variable/jetbrains-mono": "5.2.8",

--- a/apps/desktop/src/shared/auto-update.test.ts
+++ b/apps/desktop/src/shared/auto-update.test.ts
@@ -6,7 +6,7 @@ import {
   isUpdateDownloadInProgress,
   shouldOfferUpdateRestart,
   updateDownloadPercent,
-} from './auto-update.ts';
+} from './auto-update.js';
 
 test('createDownloadedUpdateState keeps the downloaded package retryable', () => {
   assert.deepEqual(

--- a/apps/desktop/tsconfig.test.json
+++ b/apps/desktop/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "declaration": false,
+    "declarationMap": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": false,
+    "outDir": "dist-test",
+    "rootDir": "src",
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": [
+    "src/shared/auto-update.ts",
+    "src/shared/auto-update.test.ts"
+  ]
+}


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] ✅ 测试用例

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

Closes #75

### 💡 改动说明

**问题**：`pnpm --filter @juejin-opensource/jusage-desktop test` 在 Node 20（仓库最低支持版本）上失败：

```
node: bad option: --experimental-strip-types
```

`--experimental-strip-types` 是 Node 22.6 才引入的 flag，Node 20 不识别。该脚本来自 PR #56。

**修复方案**：与项目中其他测试保持一致的做法——用 `tsc` 编译后跑 `node --test`：

1. 新增 `apps/desktop/tsconfig.test.json`，`module: NodeNext`，输出到 `dist-test/`（已在 .gitignore）
2. 重命名 `auto-update.test.mts` → `auto-update.test.ts`，import 扩展名改为 `.js`（NodeNext 约定）
3. `test` 脚本改为 `tsc -p tsconfig.test.json && node --test dist-test/shared/auto-update.test.js`

**验证**：Node 20.20.2 上 5 个 auto-update 测试全部通过，`pnpm typecheck` 通过。

### 📝 Changelog

无需 changeset（纯测试基础设施改动，不影响用户）。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过（Node 20.20.2）
- [x] 未改动面板 UI
- [x] 纯测试改动，跳过 changeset
- [x] `pnpm typecheck` 通过