### PR TITLE
fix(desktop): keep toast close buttons below window drag region

### DIFF
--- a/.changeset/thick-pears-cut.md
+++ b/.changeset/thick-pears-cut.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 Desktop 同步和更新提示的关闭按钮被窗口拖拽区域遮挡、无法手动关闭的问题。

--- a/apps/desktop/src/renderer/components/AppToastProvider.tsx
+++ b/apps/desktop/src/renderer/components/AppToastProvider.tsx
@@ -10,7 +10,8 @@ export function AppToastProvider({
 }) {
   return (
     <Toast.Provider
-      className="sm:min-w-0"
+      // Keep the toast and its outer close button below the 32px window drag region.
+      className="top-12 sm:min-w-0"
       placement="top end"
       queue={queue}
       width={0}


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

Fixes #78

### 💡 改动说明

Desktop 顶部有 32px 高的窗口拖拽区域。Toast 默认距顶部 16px，其外置关闭按钮位于 12–32px，完全落在拖拽区域内。鼠标从提示正文移向关闭按钮时，Electron 的窗口拖拽区域会截走鼠标事件，导致按钮消失、无法手动关闭。

将 Desktop `AppToastProvider` 的顶部间距设为 `top-12`（48px），使关闭按钮位于 44–64px，避开拖拽栏，并留有间距。保留现有消息宽度、关闭逻辑、自动消失和堆叠行为。

已核对 Dashboard：Web/CLI 使用默认 `ToastProvider`，没有 Desktop 的原生窗口拖拽区域，因此无需同步调整。

验证：

- `pnpm build` 通过（Core、Desktop、Dashboard、CLI）。
- 使用真实 Desktop Toast 组件、样式及相同的 32px 标题栏布局，在 Chrome 本地验证页检查按钮坐标；修复后鼠标从正文移至关闭按钮时保持可见，点击能关闭提示。
- 连续添加更新、同步两条消息，逐条关闭通过；自动消失通过。
- 尚未执行 Electron 原生窗口及 macOS/Windows 安装包验收；以下截图为 Chrome 中的 Desktop 组件布局对比。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 修复 Desktop 同步和更新提示的关闭按钮被窗口拖拽区域遮挡、无法手动关闭的问题。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`，从源仓库 `main` 创建并 PR 回 `main`
- [ ] 已在受影响的端本地自测通过（Desktop 组件的 Chrome 验证通过；Electron 原生窗口验收待补充）
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 是否都需要改
- [x] 已执行 `pnpm changeset`，包含 Desktop patch changeset
- [x] `pnpm build` 通过

### 对比截图

修复前：关闭按钮位于顶部 12–32px，与窗口拖拽栏重叠。


![修复前：关闭按钮与拖拽栏重叠](https://github.com/user-attachments/assets/4c57dd29-8e43-4a58-96e1-a6b03858ad68)

修复后：关闭按钮位于顶部 44–64px，鼠标移入按钮后仍可见。

![修复后：关闭按钮避开拖拽栏](https://github.com/user-attachments/assets/47f75bbf-57b8-4673-a1e2-e2d32a6041af)
