### PR TITLE
fix(desktop): refresh tray sync timestamp

### DIFF
--- a/.changeset/fresh-trays-shine.md
+++ b/.changeset/fresh-trays-shine.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 macOS 托盘弹窗在后台空同步后仍显示过期“最近同步”时间的问题。

--- a/apps/desktop/src/renderer/components/TrayPopoverView.tsx
+++ b/apps/desktop/src/renderer/components/TrayPopoverView.tsx
@@ -78,7 +78,9 @@ export function TrayPopoverView() {
       setLastSyncAt(status.lastSyncAt);
       setNow(Date.now());
     } catch {
-      setLastSyncAt(null);
+      // Keep the last known timestamp. A transient IPC/API failure must not
+      // make a previously synced tray look as though it has never synced.
+      setNow(Date.now());
     }
   }, []);
 
@@ -95,17 +97,30 @@ export function TrayPopoverView() {
         void reloadSyncStatus();
       }, 250);
     };
+    // The native popover stays mounted while hidden, so mount-only status
+    // loading leaves this footer stale after an empty background sync.
+    const onFocus = () => {
+      void reloadSyncStatus();
+    };
     window.addEventListener(DATA_SYNCED_EVENT, onSynced);
+    window.addEventListener('focus', onFocus);
     return () => {
       window.clearTimeout(timer);
       window.removeEventListener(DATA_SYNCED_EVENT, onSynced);
+      window.removeEventListener('focus', onFocus);
     };
   }, [reload, reloadSyncStatus]);
 
   useEffect(() => {
-    const timer = window.setInterval(() => setNow(Date.now()), 30_000);
+    const tick = () => {
+      setNow(Date.now());
+      if (document.visibilityState !== 'hidden') {
+        void reloadSyncStatus();
+      }
+    };
+    const timer = window.setInterval(tick, 5 * 60_000);
     return () => window.clearInterval(timer);
-  }, []);
+  }, [reloadSyncStatus]);
 
   const availableTools = useMemo(
     () => toolModelUsage.filter((row) => row.tokens > 0),


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

### 🔗 关联 Issue

排查托盘弹窗“最近同步”时间长期未更新的反馈后发现。

### 💡 改动说明

托盘弹窗被隐藏后会保留渲染器；当后台同步没有新增用量时，界面不会收到数据刷新事件，因此可能持续显示过期的“最近同步”时间。

现在弹窗重新聚焦时会轻量读取同步状态；弹窗可见期间每 5 分钟复核一次。状态读取的短暂失败会保留上一次有效时间，避免误显示为“从未”。不修改 Core 同步、IPC 契约或 CLI/Web 行为。

已确认此组件只存在于 Desktop，Dashboard 无同名副本。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 修复 macOS 托盘弹窗在后台空同步后仍显示过期“最近同步”时间的问题。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地构建通过
- [x] 已确认 Dashboard 无需同步修改
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过