### PR TITLE
feat(core): add GPT-6 Astra pricing

### DIFF
--- a/.changeset/gpt-6-astra-pricing.md
+++ b/.changeset/gpt-6-astra-pricing.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-core": patch
+---
+
+新增 GPT-6 Astra 的官方 Token 定价，准确计算该模型的用量费用。

--- a/packages/core/src/pricing/pricing.json
+++ b/packages/core/src/pricing/pricing.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
     "units": "usd_per_million_tokens",
-    "generated_at": "2026-09-03T00:00:00.000Z",
-    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes). Incremental models.dev sync on 2026-08-28: kept=416 (added=73, changed=13, removed=54). Gemini-only sync on 2026-09-03: kept=417 (added=google/gemini-3.8-flash, changed=0, removed=0). Official-only: cross-vendor hosting and cloud-partnership channels dropped."
+    "generated_at": "2026-09-05T00:00:00.000Z",
+    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes). Incremental models.dev sync on 2026-08-28: kept=416 (added=73, changed=13, removed=54). Gemini-only sync on 2026-09-03: kept=417 (added=google/gemini-3.8-flash, changed=0, removed=0). GPT-6 Astra sync on 2026-09-05: kept=418 (added=openai/gpt-6-astra, changed=0, removed=0). Official-only: cross-vendor hosting and cloud-partnership channels dropped."
   },
   "exact": {
     "alibaba/qvq-max": {
@@ -1455,6 +1455,10 @@
       "cache_read": 0.2,
       "cache_write": 2.5
     },
+    "openai/gpt-6-astra": {
+      "input": 10,
+      "output": 50
+    },
     "openai/gpt-5.6": {
       "input": 4,
       "output": 20,
@@ -2231,6 +2235,10 @@
     {
       "match": "gpt-5.6-terra",
       "ref": "openai/gpt-5.6-terra"
+    },
+    {
+      "match": "gpt-6-astra",
+      "ref": "openai/gpt-6-astra"
     },
     {
       "match": "gpt-5",


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

### 🔗 关联 Issue

无关联 Issue；补充 models.dev 最新发布模型的定价。

### 💡 改动说明

GPT-6 Astra 已在 models.dev 发布，但内置定价表尚未包含该模型，导致使用该模型时费用无法准确计算。

新增 `openai/gpt-6-astra` 的官方价格：每百万 Token 输入 $10、输出 $50；同时加入模型名匹配规则，支持带推理强度后缀的记录。models.dev 显示该模型于 2026-09-04 发布。

影响范围为共享 core 定价表：CLI 与 Desktop 均会使用更新后的费用计算；Web 使用服务端数据，不直接读取本地底表。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 新增 GPT-6 Astra 的官方 Token 定价，准确计算该模型的用量费用。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已验证模型名称及推理强度后缀均命中新价格
- [x] 已确认 Web 不直接读取本地定价底表
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过