### PR TITLE
fix(cli): 校验 --source 参数，all 等同全量同步，未知值报错退出

### DIFF
--- a/.changeset/sync-source-arg-contract.md
+++ b/.changeset/sync-source-arg-contract.md
@@ -1,0 +1,6 @@
+---
+"@juejin-opensource/jusage-core": patch
+"@juejin-opensource/jusage": patch
+---
+
+`jusage sync --source` 与本地 API 的数据源参数现在有明确契约：`all`（含大小写与别名）等同全量同步；未知或拼错的数据源 CLI 以非零码退出并列出全部合法值，本地 API 返回 400（`UNKNOWN_SYNC_SOURCE`），不再静默同步 0 条数据却显示成功、刷新“上次同步”时间。帮助里的数据源列表改为从注册表生成，补上此前缺失的 `dsh`；sync 结果中的 `skipped/error` 会写入日志与终端输出。

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,6 +1,25 @@
-import { DEFAULT_PORT } from '@juejin-opensource/jusage-core';
+import {
+  DEFAULT_PORT,
+  SYNC_SOURCE_IDS,
+  normalizeSyncSource,
+} from '@juejin-opensource/jusage-core';
 
 export const DEFAULT_HOST = '127.0.0.1';
+
+/** `--source` 的合法取值提示，从 sync registry 生成，避免帮助与实现脱节。 */
+export function formatSyncSourceList(): string {
+  return ['all', ...SYNC_SOURCE_IDS].join(' | ');
+}
+
+/**
+ * 校验 `--source`：未传 / `all` 表示全量；别名与大小写归一为标准 id；
+ * 未知值抛错（由 main 打印并以非零码退出），绝不静默跳过。
+ */
+export function resolveSyncSource(raw?: string): string | undefined {
+  const resolved = normalizeSyncSource(raw);
+  if (resolved !== null) return resolved;
+  throw new Error(`未知的数据源: ${raw}\n可用值: ${formatSyncSourceList()}`);
+}
 
 export function isWildcardListenHost(host: string): boolean {
   return host === '0.0.0.0' || host === '::';
@@ -123,7 +142,7 @@ Commands:
 Options:
   --port <number>       面板端口（默认 ${DEFAULT_PORT}）
   --host <address>      面板监听地址（默认 ${DEFAULT_HOST}；局域网访问用 0.0.0.0）
-  --source <name>       sync 数据源：claude | codex | cursor | qoder | trae | gemini | opencode | copilot | antigravity | openclaw | hermes | zcode | pi | kimi | roocode | droid | kiro | cline | amp | qwen | codebuddy | workbuddy | grok | mimo | every-code | omp | kilo-cli | kilocode | goose | zed | warp | all
+  --source <name>       sync 数据源：${formatSyncSourceList()}
   --force               upload 时忽略云端同步开关，强制上报
   --reconcile           upload 时做全量对账
   -h, --help            显示帮助

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,6 +50,7 @@ import {
   parseArgs,
   printHelp,
   resolveDaysAgo,
+  resolveSyncSource,
 } from './args.js';
 import { writePid } from './daemon.js';
 import { cmdServiceStart, cmdServiceStatus, cmdServiceStop } from './service.js';
@@ -363,16 +364,19 @@ async function cmdStart(portArg?: number, hostArg?: string, daysAgo?: number): P
 }
 
 async function cmdSync(source?: string): Promise<void> {
+  // Reject unknown sources before touching config/log/lastSync state, so a
+  // typo exits non-zero instead of refreshing "上次同步" with zero work done.
+  const filter = resolveSyncSource(source);
   const { dir, config } = await loadConfig();
   await touchStatsSince(dir, config);
-  const scope = source ?? 'all';
+  const scope = filter ?? 'all';
   const started = Date.now();
   const logPath = syncLogPath(dir);
 
   await appendJsonLog(logPath, { event: 'start', source: scope });
 
   try {
-    const results = await syncAll(dir, config, source);
+    const results = await syncAll(dir, config, filter);
     await writeSyncDone(dir);
     await maybeUploadAfterSync(dir, config, collectWrittenBuckets(results));
     await appendJsonLog(logPath, {
@@ -384,9 +388,15 @@ async function cmdSync(source?: string): Promise<void> {
         eventsParsed: r.eventsParsed,
         bucketsWritten: r.bucketsWritten,
         filesProcessed: r.filesProcessed,
+        ...(r.skipped ? { skipped: true } : {}),
+        ...(r.error ? { error: r.error } : {}),
       })),
     });
     for (const r of results) {
+      if (r.skipped) {
+        console.log(`${r.source}: 跳过（${r.error ?? '无数据'}）`);
+        continue;
+      }
       console.log(
         `${r.source}: ${r.eventsParsed} 条消息, ${r.bucketsWritten} 个桶写入, ${r.filesProcessed} 个文件`,
       );

--- a/packages/cli/test/args.test.js
+++ b/packages/cli/test/args.test.js
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { formatListenUrl, normalizeListenHost, parseArgs } from '../dist/args.js';
+import {
+  formatListenUrl,
+  formatSyncSourceList,
+  normalizeListenHost,
+  parseArgs,
+  resolveSyncSource,
+} from '../dist/args.js';
 
 test('parseArgs reads --host and --port without defaulting them', () => {
   const parsed = parseArgs(['node', 'jusage', 'start', '--host', '0.0.0.0', '--port', '9000']);
@@ -48,4 +54,40 @@ test('parseArgs throws when --host has no value', () => {
 test('formatListenUrl maps wildcard bind to loopback', () => {
   assert.equal(formatListenUrl('0.0.0.0', 8452), 'http://127.0.0.1:8452');
   assert.equal(formatListenUrl('::1', 8452), 'http://[::1]:8452');
+});
+
+test('parseArgs reads --source in both forms', () => {
+  assert.equal(
+    parseArgs(['node', 'jusage', 'sync', '--source', 'claude']).source,
+    'claude',
+  );
+  assert.equal(
+    parseArgs(['node', 'jusage', 'sync', '--source=codex']).source,
+    'codex',
+  );
+});
+
+test('resolveSyncSource maps missing/empty/all to full sweep', () => {
+  assert.equal(resolveSyncSource(undefined), undefined);
+  assert.equal(resolveSyncSource(''), undefined);
+  assert.equal(resolveSyncSource('all'), undefined);
+});
+
+test('resolveSyncSource normalizes case and aliases', () => {
+  assert.equal(resolveSyncSource(' Claude '), 'claude');
+  assert.equal(resolveSyncSource('dsh'), 'dsh');
+  assert.equal(resolveSyncSource('kilo'), 'kilo-cli');
+  assert.equal(resolveSyncSource('qwen-code'), 'qwen');
+});
+
+test('resolveSyncSource rejects unknown sources with the valid list', () => {
+  assert.throws(() => resolveSyncSource('cluade'), /未知的数据源: cluade/);
+  assert.throws(() => resolveSyncSource('cluade'), /claude/);
+});
+
+test('help source list comes from the registry and keeps all + dsh', () => {
+  const list = formatSyncSourceList();
+  assert.ok(list.startsWith('all | '));
+  assert.ok(list.includes(' dsh '));
+  assert.ok(list.includes('claude'));
 });

--- a/packages/core/src/server/local-api.ts
+++ b/packages/core/src/server/local-api.ts
@@ -20,6 +20,7 @@ import type {
   TudConfigUpdate,
   TudConfigView,
 } from '../types.js';
+import { normalizeSyncSource } from '../sync/index.js';
 import { normalizeApiUrl, uploadToServer } from '../upload/index.js';
 import {
   ensureLocalCollectRange,
@@ -573,7 +574,16 @@ export function createLocalApiApp(deps: LocalApiDeps): Hono {
     } catch {
       // empty body ok
     }
-    const result = await runSync(deps, source);
+    // `all`/missing → full sweep; unknown values must 400 instead of running
+    // zero parsers behind a success envelope.
+    const filter = normalizeSyncSource(source);
+    if (filter === null) {
+      return c.json(
+        { success: false, message: 'UNKNOWN_SYNC_SOURCE', data: null },
+        400,
+      );
+    }
+    const result = await runSync(deps, filter);
     return c.json(
       ok({
         ok: result.ok,

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -556,6 +556,37 @@ export const SYNC_SOURCE_IDS = [
 
 export type SyncSourceId = (typeof SYNC_SOURCE_IDS)[number];
 
+/** Accepted spellings that map onto a canonical source id (see syncOneSource). */
+const SYNC_SOURCE_ALIASES: Record<string, SyncSourceId> = {
+  'roo-code': 'roocode',
+  'qwen-code': 'qwen',
+  'grok-build': 'grok',
+  mimocode: 'mimo',
+  everycode: 'every-code',
+  kilo: 'kilo-cli',
+  'kilo-code': 'kilocode',
+};
+
+/**
+ * Normalize a user-supplied source filter (CLI `--source`, local API body).
+ *
+ * - missing / empty / `all` → `undefined`（全量同步）
+ * - known id or alias（大小写不敏感）→ canonical id
+ * - anything else → `null`; the caller must reject it instead of passing it
+ *   on, otherwise the sync silently runs zero parsers while reporting success.
+ */
+export function normalizeSyncSource(
+  raw: string | undefined | null,
+): SyncSourceId | undefined | null {
+  if (raw == null) return undefined;
+  const value = raw.trim().toLowerCase();
+  if (!value || value === 'all') return undefined;
+  if ((SYNC_SOURCE_IDS as readonly string[]).includes(value)) {
+    return value as SyncSourceId;
+  }
+  return SYNC_SOURCE_ALIASES[value] ?? null;
+}
+
 async function syncOneSource(
   dataDir: string,
   config: TudConfig,
@@ -659,11 +690,15 @@ export async function syncAll(
   config: TudConfig,
   source?: string,
 ): Promise<SyncResult[]> {
-  if (source) {
-    if (source === 'omp' && ompAgentDirCollidesWithPi()) {
+  // CLI / local API validate and normalize before calling in; treat `all`
+  // as a full sweep here too so no direct caller can hit the
+  // unknown-source branch with it.
+  const filter = source === 'all' ? undefined : source;
+  if (filter) {
+    if (filter === 'omp' && ompAgentDirCollidesWithPi()) {
       return [];
     }
-    return [await syncOneSource(dataDir, config, source)];
+    return [await syncOneSource(dataDir, config, filter)];
   }
 
   // One cursors.json load/save per round instead of per channel.

--- a/packages/core/test/sync-source-arg.test.ts
+++ b/packages/core/test/sync-source-arg.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLocalApiApp } from '../src/server/local-api.js';
+import { BucketStore, type LocalApiDeps } from '../src/server/state.js';
+import {
+  SYNC_SOURCE_IDS,
+  normalizeSyncSource,
+  type SyncResult,
+} from '../src/sync/index.js';
+import type { TudConfig } from '../src/types.js';
+
+test('normalizeSyncSource maps missing/empty/all to full sweep', () => {
+  assert.equal(normalizeSyncSource(undefined), undefined);
+  assert.equal(normalizeSyncSource(null), undefined);
+  assert.equal(normalizeSyncSource(''), undefined);
+  assert.equal(normalizeSyncSource('  '), undefined);
+  assert.equal(normalizeSyncSource('all'), undefined);
+  assert.equal(normalizeSyncSource('ALL'), undefined);
+});
+
+test('normalizeSyncSource keeps every registered id', () => {
+  for (const id of SYNC_SOURCE_IDS) {
+    assert.equal(normalizeSyncSource(id), id);
+  }
+});
+
+test('normalizeSyncSource trims, lowercases and resolves aliases', () => {
+  assert.equal(normalizeSyncSource(' Claude '), 'claude');
+  assert.equal(normalizeSyncSource('DSH'), 'dsh');
+  assert.equal(normalizeSyncSource('roo-code'), 'roocode');
+  assert.equal(normalizeSyncSource('qwen-code'), 'qwen');
+  assert.equal(normalizeSyncSource('grok-build'), 'grok');
+  assert.equal(normalizeSyncSource('mimocode'), 'mimo');
+  assert.equal(normalizeSyncSource('everycode'), 'every-code');
+  assert.equal(normalizeSyncSource('kilo'), 'kilo-cli');
+  assert.equal(normalizeSyncSource('kilo-code'), 'kilocode');
+});
+
+test('normalizeSyncSource rejects unknown values with null', () => {
+  assert.equal(normalizeSyncSource('cluade'), null);
+  assert.equal(normalizeSyncSource('does-not-exist'), null);
+});
+
+function config(): TudConfig {
+  return {
+    deviceId: 'device-test',
+    statsSince: '2026-01-01T00:00:00.000Z',
+    hostname: 'test',
+    dataDir: '/tmp/tud-test',
+    juejin: {
+      enabled: false,
+      apiUrl: 'https://usage.example.com',
+      authMode: 'bearer',
+      token: null,
+    },
+  };
+}
+
+function appWithRunnerSpy() {
+  const calls: Array<string | undefined> = [];
+  const runnerResults: SyncResult[] = [
+    {
+      source: 'claude',
+      eventsParsed: 3,
+      filesProcessed: 1,
+      bucketsWritten: 2,
+      writtenBuckets: [],
+    },
+    {
+      source: 'workbuddy',
+      eventsParsed: 0,
+      filesProcessed: 0,
+      bucketsWritten: 0,
+      writtenBuckets: [],
+      skipped: true,
+      error: 'not installed / no local data',
+    },
+  ];
+  const value = config();
+  const deps: LocalApiDeps = {
+    dataDir: value.dataDir,
+    getConfig: () => value,
+    bucketStore: new BucketStore(),
+    runSyncViaRunner: async (_reason, source) => {
+      calls.push(source);
+      return runnerResults;
+    },
+  };
+  return { app: createLocalApiApp(deps), calls, runnerResults };
+}
+
+function postTriggerSync(app: ReturnType<typeof createLocalApiApp>, body?: unknown) {
+  return app.request('/functions/tud-trigger-sync', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body === undefined ? '{}' : JSON.stringify(body),
+  });
+}
+
+test('tud-trigger-sync rejects unknown source with 400 and runs nothing', async () => {
+  const { app, calls } = appWithRunnerSpy();
+  const response = await postTriggerSync(app, { source: 'cluade' });
+  assert.equal(response.status, 400);
+  const envelope = (await response.json()) as {
+    success: boolean;
+    message: string;
+    data: unknown;
+  };
+  assert.equal(envelope.success, false);
+  assert.equal(envelope.message, 'UNKNOWN_SYNC_SOURCE');
+  assert.equal(envelope.data, null);
+  assert.equal(calls.length, 0);
+});
+
+test('tud-trigger-sync treats all/empty body as a full sweep', async () => {
+  const { app, calls } = appWithRunnerSpy();
+
+  const allResponse = await postTriggerSync(app, { source: 'all' });
+  assert.equal(allResponse.status, 200);
+
+  const emptyResponse = await postTriggerSync(app);
+  assert.equal(emptyResponse.status, 200);
+
+  assert.deepEqual(calls, [undefined, undefined]);
+});
+
+test('tud-trigger-sync normalizes single-source aliases and keeps result fields', async () => {
+  const { app, calls, runnerResults } = appWithRunnerSpy();
+  const response = await postTriggerSync(app, { source: ' Claude ' });
+  assert.equal(response.status, 200);
+  assert.deepEqual(calls, ['claude']);
+
+  const envelope = (await response.json()) as {
+    success: boolean;
+    data: { ok: boolean; results: SyncResult[] } | null;
+  };
+  assert.equal(envelope.success, true);
+  // skipped/error must survive the API envelope so callers can tell a
+  // no-op apart from a healthy sync.
+  assert.deepEqual(envelope.data?.results, runnerResults);
+});


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [ ] Web

（`packages/core` 的本地 API 契约同步修复；Desktop / Web 前端代码零改动——`tud-trigger-sync` 返回 400 时，面板现有的「同步失败」toast 分支会自然生效，此前它因 `ok` 恒为 true 而是死代码。）

### 🔗 关联 Issue

close #87

### 💡 改动说明

**原来的问题**：帮助文本把 `all` 列为 `--source` 的合法取值，但 `syncOneSource()` 不认识它，返回 `{skipped: true, error: 'unknown source: all'}`；`cmdSync` 丢弃 `skipped/error` 字段，于是 `jusage sync --source=all`（以及任何拼错的 source）**一个 parser 都不跑**，却打印 `all: 0 条消息, 0 个桶写入, 0 个文件`、exit 0，并照常刷新 `sync.done`（即面板/托盘的「上次同步」）。照官方帮助操作或在 cron 里写 `--source=all` 的用户会长期静默采集不到数据，且日志里连 error 字符串都没有。另外帮助列表是手工维护的，漏了已支持的 `dsh`。

**这版怎么改**（校验统一收在 sync registry 一处，CLI 与本地 API 都走它）：

1. core 新增 `normalizeSyncSource()`：未传 / 空串 / `all`（大小写不敏感）→ 全量；合法 id 与既有别名（`roo-code`、`qwen-code`、`kilo` 等，与 `syncOneSource` 的 case 一致）归一为标准 id；未知值返回 `null` 交由边界拒绝。`syncAll` 自身也把 `'all'` 视为全量兜底；
2. CLI：`cmdSync` 在**动任何状态之前**校验，未知值打印错误与全部合法值、exit 1，不再刷新「上次同步」；结果里的 `skipped/error` 现在会写入 `sync.log` 的 done 事件并在终端显示（如 `cursor: 跳过（Cursor 未登录）`）；
3. 本地 API：`tud-trigger-sync` 对未知 source 返回 `400 UNKNOWN_SYNC_SOURCE`，不再包装成成功响应；
4. 帮助的 source 列表改为从 `SYNC_SOURCE_IDS` 生成，`dsh` 回归，后续新增 source 不会再漏。

**改前（`main` @ `cc21d8e` 实测）**：

```text
$ jusage sync --source=all
all: 0 条消息, 0 个桶写入, 0 个文件
exit code = 0        # sync.done 被刷新，sync.log 无 error

$ jusage sync --source=cluade
cluade: 0 条消息, 0 个桶写入, 0 个文件
exit code = 0
```

**改后（同一台机器、隔离数据目录 + 真实 Agent 日志，30 天窗口实测）**：

```text
$ jusage sync --source=cluade
未知的数据源: cluade
可用值: all | claude | codex | cursor | qoder | trae | gemini | opencode | copilot | antigravity | openclaw | hermes | zcode | dsh | pi | kimi | roocode | droid | kiro | cline | amp | qwen | codebuddy | workbuddy | grok | mimo | every-code | omp | kilo-cli | kilocode | goose | zed | warp
exit code = 1        # sync.done 未被触碰

$ jusage sync --source=Claude          # 大小写归一
claude: 18890 条消息, 775 个桶写入, 180 个文件
exit code = 0

$ jusage sync --source=all             # 真正全量：32 个 source 全部执行
claude: 1 条消息, 1 个桶写入, 1 个文件
codex: 148312 条消息, 2040 个桶写入, 1345 个文件
cursor: 跳过（Cursor 未登录）
zcode: 52 条消息, 2 个桶写入, 1 个文件
...（其余 source 0 条，55s 完成）
exit code = 0
```

**测试**：core 270 个用例全过（新增 7 个：`normalizeSyncSource` 全量取值 / 别名 / 拒绝，`tud-trigger-sync` 400、`all` 全量、别名归一与 `skipped/error` 透传）；CLI 18 个全过（新增 `--source` 解析、`resolveSyncSource`、帮助列表含 `dsh` 断言）；`pnpm build` 全仓通过（含 desktop）。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | `jusage sync --source` 现在有明确契约：`all` 等同全量同步；未知或拼错的数据源以非零码退出并列出全部合法值，不再静默同步 0 条数据却显示成功、刷新「上次同步」；帮助列表从注册表生成，补上缺失的 `dsh`；`skipped/error` 会进入终端输出与日志 |
| `@juejin-opensource/jusage-core` | patch | 本地 API `tud-trigger-sync` 对未知数据源返回 400（`UNKNOWN_SYNC_SOURCE`）；`syncAll` 把 `all` 视为全量同步 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：本次未改 UI，`packages/dashboard/src` 与 `apps/desktop/src/renderer` 均无需改动
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过
