### PR TITLE
fix(core): WorkBuddy 用量按 sessions.cwd 归属真实项目，不再全归 unknown

### DIFF
--- a/.changeset/workbuddy-project-cwd.md
+++ b/.changeset/workbuddy-project-cwd.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-core": patch
+---
+
+修复 WorkBuddy 用量的项目归属：此前所有 WorkBuddy 用量都固定归到 `unknown` 项目——SQLite 兜底查询明明已取回 `sessions.cwd` 却未使用，JSONL 明细路径也未解析项目。现在两条路径都通过 `sessions` 表的工作目录解析真实项目名（目录不存在回退 basename，cwd 缺失/为空保持 `unknown`），项目维度报表对 WorkBuddy 生效。

--- a/packages/core/src/parsers/workbuddy.ts
+++ b/packages/core/src/parsers/workbuddy.ts
@@ -12,6 +12,7 @@ import { basename, join } from 'node:path';
 import { stat } from 'node:fs/promises';
 
 import type { CursorsFile, QueueBucket, TokenTotals } from '../types.js';
+import { resolveProjectName } from '../project-name.js';
 import { toUtcHalfHourStart } from '../queue/keys.js';
 import {
   accumulateBucket,
@@ -160,6 +161,37 @@ export interface ParseWorkbuddyResult {
   error?: string;
 }
 
+/** Empty / non-string cwd (e.g. LEFT JOIN miss) stays 'unknown'. */
+function projectFromCwd(cwd: unknown): string {
+  if (typeof cwd !== 'string' || !cwd.trim()) return 'unknown';
+  return resolveProjectName(cwd.trim());
+}
+
+/**
+ * `sessions.id → cwd` from workbuddy.db; JSONL messages only carry a
+ * sessionId, the working directory lives in this table.
+ */
+function loadWorkbuddySessionCwds(dbPath: string): Map<string, string> {
+  const map = new Map<string, string>();
+  if (!sqliteTableExists(dbPath, 'sessions')) return map;
+  try {
+    const rows = readSqliteWithSnapshot(dbPath, (snap) =>
+      queryDbJson(snap, 'SELECT id, cwd FROM sessions WHERE cwd IS NOT NULL', {
+        timeout: 10_000,
+        maxBuffer: 16 * 1024 * 1024,
+      }),
+    );
+    for (const row of rows) {
+      const id = typeof row.id === 'string' ? row.id.trim() : '';
+      const cwd = typeof row.cwd === 'string' ? row.cwd.trim() : '';
+      if (id && cwd) map.set(id, cwd);
+    }
+  } catch {
+    // Best effort; unresolved sessions stay 'unknown'.
+  }
+  return map;
+}
+
 export async function parseWorkbuddyIncremental(
   cursors: CursorsFile,
   statsSince: string,
@@ -186,6 +218,14 @@ export async function parseWorkbuddyIncremental(
   const workbuddyHome = resolveWorkbuddyHome(env);
   const dbPath = join(workbuddyHome, 'workbuddy.db');
   const dbExists = existsSync(dbPath);
+
+  // Loaded on first use so idle rounds skip the extra sqlite read.
+  let sessionCwds: Map<string, string> | null = null;
+  const getSessionCwd = (sessionId: string): string | undefined => {
+    if (!dbExists) return undefined;
+    if (!sessionCwds) sessionCwds = loadWorkbuddySessionCwds(dbPath);
+    return sessionCwds.get(sessionId);
+  };
 
   let eventsParsed = 0;
   let filesProcessed = 0;
@@ -268,7 +308,7 @@ export async function parseWorkbuddyIncremental(
         bucketState,
         'workbuddy',
         model,
-        'unknown',
+        projectFromCwd(getSessionCwd(sessionId)),
         hourStart,
         { ...delta, conversation_count: 1 },
         WORKBUDDY_COLLECTOR,
@@ -360,7 +400,7 @@ export async function parseWorkbuddyIncremental(
           bucketState,
           'workbuddy',
           model,
-          'unknown',
+          projectFromCwd(row.cwd),
           hourStart,
           delta,
           WORKBUDDY_COLLECTOR,

--- a/packages/core/test/p2-parsers.test.ts
+++ b/packages/core/test/p2-parsers.test.ts
@@ -171,6 +171,96 @@ test('parseWorkbuddyIncremental subtracts cacheRead and cacheCreate from prompt'
     assert.equal(result.buckets[0]!.cached_input_tokens, 15);
     assert.equal(result.buckets[0]!.cache_creation_input_tokens, 5);
     assert.equal(result.buckets[0]!.output_tokens, 40);
+    // No workbuddy.db → no cwd source → project stays unknown.
+    assert.equal(result.buckets[0]!.project, 'unknown');
+  } finally {
+    if (prev === undefined) delete process.env.WORKBUDDY_HOME;
+    else process.env.WORKBUDDY_HOME = prev;
+  }
+});
+
+test('parseWorkbuddyIncremental resolves JSONL projects via sessions.cwd', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tud-wb-proj-'));
+  const prev = process.env.WORKBUDDY_HOME;
+  process.env.WORKBUDDY_HOME = home;
+  try {
+    const db = new DatabaseSync(join(home, 'workbuddy.db'));
+    db.exec('CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT, cwd TEXT)');
+    db.prepare('INSERT INTO sessions (id, model, cwd) VALUES (?, ?, ?)').run(
+      'sess-a',
+      'wb-model',
+      '/Users/me/wb-app',
+    );
+    db.close();
+
+    const projects = join(home, 'projects');
+    await mkdir(projects, { recursive: true });
+    const filePath = join(projects, 'sess-a.jsonl');
+    const message = (sessionId: string, id: string) =>
+      JSON.stringify({
+        sessionId,
+        id,
+        timestamp: Date.parse('2026-07-24T11:00:00.000Z'),
+        providerData: {
+          model: 'wb-model',
+          rawUsage: { prompt_tokens: 100, completion_tokens: 40 },
+        },
+      }) + '\n';
+    await writeFile(filePath, message('sess-a', 'm1') + message('sess-nodb', 'm2'));
+
+    const { result } = await parseWorkbuddyIncremental({}, SINCE, {
+      projectFiles: [filePath],
+      defaultModel: 'auto',
+    });
+    assert.equal(result.eventsParsed, 2);
+    const byProject = new Map(result.buckets.map((b) => [b.project, b]));
+    // cwd path does not exist → git lookup falls back to basename.
+    assert.ok(byProject.has('wb-app'));
+    // Session without a sessions row keeps 'unknown'.
+    assert.ok(byProject.has('unknown'));
+  } finally {
+    if (prev === undefined) delete process.env.WORKBUDDY_HOME;
+    else process.env.WORKBUDDY_HOME = prev;
+  }
+});
+
+test('parseWorkbuddyIncremental sqlite fallback uses queried cwd', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'tud-wb-sql-'));
+  const prev = process.env.WORKBUDDY_HOME;
+  process.env.WORKBUDDY_HOME = home;
+  try {
+    const db = new DatabaseSync(join(home, 'workbuddy.db'));
+    db.exec('CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT, cwd TEXT)');
+    db.exec(
+      'CREATE TABLE session_usage (session_id TEXT PRIMARY KEY, used INTEGER, updated_at INTEGER)',
+    );
+    const insertSession = db.prepare(
+      'INSERT INTO sessions (id, model, cwd) VALUES (?, ?, ?)',
+    );
+    insertSession.run('s1', 'model-a', '/Users/me/wb-sql-app');
+    insertSession.run('s2', 'model-b', '');
+    const insertUsage = db.prepare(
+      'INSERT INTO session_usage (session_id, used, updated_at) VALUES (?, ?, ?)',
+    );
+    const ts = Date.parse('2026-07-24T12:00:00.000Z');
+    insertUsage.run('s1', 100, ts);
+    insertUsage.run('s2', 50, ts);
+    // s3 has usage but no sessions row (LEFT JOIN miss → cwd null).
+    insertUsage.run('s3', 30, ts);
+    db.close();
+
+    const { result } = await parseWorkbuddyIncremental({}, SINCE, {
+      projectFiles: [],
+      defaultModel: 'auto',
+    });
+    assert.equal(result.eventsParsed, 3);
+    const byModel = new Map(result.buckets.map((b) => [b.model, b]));
+    assert.equal(byModel.get('model-a')!.project, 'wb-sql-app');
+    assert.equal(byModel.get('model-a')!.input_tokens, 100);
+    // Empty cwd and missing sessions row both stay 'unknown'.
+    assert.equal(byModel.get('model-b')!.project, 'unknown');
+    assert.equal(byModel.get('auto')!.project, 'unknown');
+    assert.equal(byModel.get('auto')!.input_tokens, 30);
   } finally {
     if (prev === undefined) delete process.env.WORKBUDDY_HOME;
     else process.env.WORKBUDDY_HOME = prev;


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

（改动只在 `packages/core` 的 workbuddy parser，两端共用同一实现；无 UI 改动。）

### 🔗 关联 Issue

close #91

### 💡 改动说明

**原来的问题**：WorkBuddy 两条采集路径写桶时都硬编码 `'unknown'` 项目——SQLite 兜底查询**已经 `SELECT s.cwd`**（`LEFT JOIN sessions`）却从未读取该列；JSONL 明细路径也没有任何项目解析，尽管消息带 `sessionId` 且 `workbuddy.db` 的 `sessions` 表就是 `id → cwd` 映射。结果是该 source 100% 的用量都落在 `unknown` 项目，项目维度报表完全失效。

**这版怎么改**：两条路径统一走 `resolveProjectName()`（编码路径解码 → git 仓库根 → basename 兜底，claude/copilot/dsh 同款）：

1. SQLite 兜底：直接使用查询结果里的 `row.cwd`；
2. JSONL 明细：首次需要时懒加载一次 `SELECT id, cwd FROM sessions`（`sqliteTableExists` 守卫 + `readSqliteWithSnapshot` 现成基建），按 `sessionId` 查映射。懒加载保证无新数据的空转轮次不多出 sqlite 读取；
3. 边界保持保守：cwd 为空、`LEFT JOIN` 未命中、db 或 `sessions` 表不存在 → 维持 `unknown`；目录不存在 → basename 兜底（不报错）。

**改前（`main` @ `cc21d8e`，隔离 fixture + 真实 CLI 实测）**：

```json
[
  { "project": "unknown", "model": "db-model", "total_tokens": 500 },
  { "project": "unknown", "model": "wb-model", "total_tokens": 400 }
]
```

**改后（全新环境，同一 fixture）**：

```text
聚合行: [ { project: "e2e-wb-backend",  model: "db-model", total_tokens: 500 },
          { project: "e2e-wb-frontend", model: "wb-model", total_tokens: 400 } ]
清 cursors 重扫: 2 条消息, 0 个桶写入 → 聚合行与合计（900）不变   ← 重扫收敛
```

**测试**：core 265 个用例全过。新增：JSONL 经 `sessions.cwd` 解析项目（含无 sessions 行 → `unknown`）；SQLite 兜底三态（cwd 正常 / 为空 / LEFT JOIN 未命中）——这也是 sqlite 兜底路径的**首批测试覆盖**；现有无 db 用例补充 `project === 'unknown'` 断言。`pnpm build` 全仓通过。

**已知边界（不在本 PR 范围，与 #89/#90 同源）**：修复前已入 queue 的历史 `unknown` 行，在扩大时间范围全量重扫时会与重扫产出的真实项目行并存（bucket key 含 project，快照替换无法配对）。升级场景实测：旧存量 900（unknown）+ 重扫 900（真实项目）= 1800 双计。"快照重扫时如何处理未被复现的 stale 行"是 replay 协议的通用问题（copilot / workbuddy 已各有一个数据点），建议单独立项讨论。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 修复 WorkBuddy 用量的项目归属：不再全部归到 `unknown`，改为按会话工作目录（`sessions.cwd`）解析真实项目名，项目维度报表对 WorkBuddy 生效 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：本次未改 UI，两份同构代码均无需改动
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过
