### PR TITLE
fix(core): preserve active settings when config updates fail

### DIFF
--- a/.changeset/purple-wolves-call.md
+++ b/.changeset/purple-wolves-call.md
@@ -1,0 +1,7 @@
+---
+"@juejin-opensource/jusage-core": patch
+"@juejin-opensource/jusage": patch
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复保存设置失败后，云端同步开关等设置仍可能在运行中生效、与已保存配置不一致的问题。

--- a/packages/core/src/server/local-api.ts
+++ b/packages/core/src/server/local-api.ts
@@ -495,7 +495,10 @@ export function createLocalApiApp(deps: LocalApiDeps): Hono {
       return c.json({ success: false, message: 'INVALID_JSON', data: null }, 400);
     }
 
-    const config = deps.getConfig();
+    const activeConfig = deps.getConfig();
+    // Stage edits so validation or persistence failures cannot mutate the
+    // configuration currently used by the local runtime.
+    const config = { ...activeConfig, juejin: { ...activeConfig.juejin } };
     const prevApiUrl = normalizeApiUrl(config.juejin.apiUrl ?? '');
     const prevToken = config.juejin.token?.trim() || null;
     const prevEnabled = config.juejin.enabled;
@@ -538,7 +541,10 @@ export function createLocalApiApp(deps: LocalApiDeps): Hono {
     }
 
     await saveConfig(deps.dataDir, config);
-    deps.onConfigChange?.(config);
+    // Preserve getConfig() callers that keep the original object and do not
+    // provide an onConfigChange callback.
+    activeConfig.juejin = config.juejin;
+    deps.onConfigChange?.(activeConfig);
 
     const nextApiUrl = normalizeApiUrl(config.juejin.apiUrl ?? '');
     const nextToken = config.juejin.token?.trim() || null;

--- a/packages/core/test/local-api-config.test.ts
+++ b/packages/core/test/local-api-config.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test, { type TestContext } from 'node:test';
+
+import { loadConfig } from '../src/config.js';
+import { configPath } from '../src/paths.js';
+import { createLocalApiApp } from '../src/server/local-api.js';
+import { BucketStore } from '../src/server/state.js';
+import type { TudConfig, TudConfigUpdate, TudConfigView } from '../src/types.js';
+
+async function fixture(
+  t: TestContext,
+  onConfigChange?: (config: TudConfig) => void,
+) {
+  const dir = await mkdtemp(join(tmpdir(), 'tud-config-api-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const { config } = await loadConfig(dir);
+  const app = createLocalApiApp({
+    dataDir: dir,
+    getConfig: () => config,
+    bucketStore: new BucketStore(),
+    onConfigChange,
+  });
+  // Keep the intentional filesystem failure below out of the test console.
+  app.onError(() => new Response('Internal Server Error', { status: 500 }));
+  return {
+    dir,
+    config,
+    app,
+    readSaved: async () =>
+      JSON.parse(await readFile(configPath(dir), 'utf8')) as TudConfig,
+    update: (body: TudConfigUpdate) =>
+      app.request('/functions/tud-config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }),
+  };
+}
+
+for (const apiUrl of ['invalid-url', 'file:///tmp/config', 'javascript:void(0)']) {
+  test(`rejected API URL ${apiUrl} leaves the active and saved config unchanged`, async (t) => {
+    let notifications = 0;
+    const f = await fixture(t, () => { notifications += 1; });
+    const before = structuredClone(f.config);
+
+    const response = await f.update({ juejin: { enabled: false, apiUrl } });
+    assert.equal(response.status, 400);
+    assert.equal((await response.json() as { message: string }).message, 'INVALID_API_URL');
+    assert.deepEqual(f.config, before);
+    assert.deepEqual(await f.readSaved(), before);
+    assert.equal(notifications, 0);
+
+    const readback = await f.app.request('/functions/tud-config');
+    const body = await readback.json() as { data: TudConfigView };
+    assert.equal(body.data.juejin.enabled, before.juejin.enabled);
+  });
+}
+
+test('a failed config save does not change active settings or notify listeners', async (t) => {
+  let notifications = 0;
+  const f = await fixture(t, () => { notifications += 1; });
+  const before = structuredClone(f.config);
+  // A directory at the destination deterministically rejects writeFile on all
+  // platforms without depending on user privileges or filesystem permissions.
+  await rm(configPath(f.dir));
+  await mkdir(configPath(f.dir));
+
+  const response = await f.update({
+    juejin: { enabled: false, apiUrl: 'https://example.invalid/usage', userName: 'changed' },
+  });
+  assert.equal(response.status, 500);
+  assert.deepEqual(f.config, before);
+  assert.equal(notifications, 0);
+});
+
+for (const withListener of [false, true]) {
+  test(`valid config updates persist and remain readable ${withListener ? 'with' : 'without'} a listener`, async (t) => {
+    const notifications: TudConfig[] = [];
+    const f = await fixture(t, withListener ? (next) => { notifications.push(next); } : undefined);
+    const before = structuredClone(f.config);
+
+    const response = await f.update({
+      juejin: {
+        enabled: false,
+        apiUrl: ' https://example.invalid/usage ',
+        token: ' "12345678" ',
+        userName: ' Fixture User ',
+        avatarLarge: ' https://example.invalid/avatar.png ',
+      },
+    });
+    assert.equal(response.status, 200);
+    const expected: TudConfig = {
+      ...before,
+      juejin: {
+        ...before.juejin,
+        enabled: false,
+        apiUrl: 'https://example.invalid/usage',
+        token: '12345678',
+        originUserId: '12345678',
+        userName: 'Fixture User',
+        avatarLarge: 'https://example.invalid/avatar.png',
+      },
+    };
+    assert.deepEqual(await f.readSaved(), expected);
+    assert.deepEqual(f.config, expected);
+    assert.equal(notifications.length, withListener ? 1 : 0);
+    if (withListener) assert.strictEqual(notifications[0], f.config);
+
+    const readback = await f.app.request('/functions/tud-config');
+    assert.deepEqual(await readback.json(), await response.json());
+
+    const clear = await f.update({
+      juejin: { token: null, originUserId: null, userName: null, avatarLarge: null },
+    });
+    assert.equal(clear.status, 200);
+    assert.equal(f.config.juejin.token, null);
+    assert.equal(f.config.juejin.originUserId, null);
+    assert.equal(f.config.juejin.userName, null);
+    assert.equal(f.config.juejin.avatarLarge, null);
+    assert.deepEqual(await f.readSaved(), f.config);
+  });
+}


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

修改的是两端共用的 Core 本地配置接口；Desktop 经 IPC、CLI 面板经 HTTP 使用该接口。未改动 UI。

### 🔗 关联 Issue

暂无关联 Issue。由配置接口的隔离回归测试复现。

### 💡 改动说明

`PUT /functions/tud-config` 原先直接修改运行中的配置对象，再验证地址并保存文件。例如初始开启云端同步时，提交 `{"juejin":{"enabled":false,"apiUrl":"invalid-url"}}` 会返回 `400 INVALID_API_URL`，但内存中的同步开关已经关闭，磁盘仍然是开启。文件保存失败时也会留下尚未保存的运行中设置。

现在先在配置副本上处理更新，保存成功后才替换活动配置中的 `juejin` 字段并调用 `onConfigChange`。验证或保存失败时，活动配置保持原样。保留顶层配置对象，兼容未提供 `onConfigChange` 回调、通过原对象读取配置的调用方；已有字段归一化和远端变更后的补报判断保持原有逻辑。

新增 6 项回归测试，覆盖无效地址及不支持的协议、文件保存失败、带/不带配置回调的合法更新、后续 GET 读取、字段归一化与清空。使用临时配置目录，不扫描真实工具数据、不向远端上报。

验证：

- 修复前新增测试：4 项失败、2 项通过，复现验证拒绝和持久化失败时的状态污染。
- 修复后配置接口、排行榜接口及配置加载/身份相关测试：33 项全部通过。
- `pnpm build` 通过；Dashboard 保留现有大 chunk 警告。
- `pnpm --filter @juejin-opensource/jusage-desktop typecheck` 通过。
- `pnpm changeset status --since upstream/main`、`git diff --check` 通过。

测试环境为 macOS / Node.js 22.17.0 / pnpm 11.1.2。未进行 Windows 实机验证或 Electron UI 手动操作验证。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 修复保存设置失败后，云端同步开关等设置仍可能在运行中生效、与已保存配置不一致的问题。 |
| `@juejin-opensource/jusage`（CLI） | patch | 修复保存设置失败后，云端同步开关等设置仍可能在运行中生效、与已保存配置不一致的问题。 |
| `@juejin-opensource/jusage-desktop` | patch | 修复保存设置失败后，云端同步开关等设置仍可能在运行中生效、与已保存配置不一致的问题。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`。
- [x] 已通过共享 Core API 回归测试，覆盖 CLI / Desktop 共用接口。
- [ ] CLI / Desktop 实机 UI 手动操作验证。
- [x] 未改动面板 UI，无需同步两份 renderer。
- [x] 已执行 `pnpm changeset` 并补齐本次 patch 说明。
- [x] `pnpm build` 通过。
