### PR TITLE
fix(core): preserve settings when persisting sync timestamps

### DIFF
--- a/.changeset/swift-readers-divide.md
+++ b/.changeset/swift-readers-divide.md
@@ -1,0 +1,7 @@
+---
+"@juejin-opensource/jusage-core": patch
+"@juejin-opensource/jusage": patch
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复后台同步或上报完成时可能覆盖刚保存的设置、重新开启云端同步的问题，并避免保存设置时回退最近同步或上报时间。

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,10 +58,12 @@
     "test:compile": "tsc -p tsconfig.test.json && node -e \"require('node:fs').copyFileSync('src/pricing/pricing.json','dist-test/src/pricing/pricing.json')\""
   },
   "dependencies": {
-    "hono": "^4.7.5"
+    "hono": "^4.7.5",
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.13.10",
+    "@types/proper-lockfile": "^4.1.4",
     "typescript": "^5.8.2"
   },
   "engines": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { hostname } from 'node:os';
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { lock } from 'proper-lockfile';
 
 import type { TudConfig } from './types.js';
 import { configPath, resolveDataDir, syncLogPath } from './paths.js';
@@ -246,7 +247,7 @@ async function recoverCorruptConfig(
     config.juejin.token = salvaged.token;
   }
   ensureIdentity(config);
-  await saveConfig(dir, config);
+  await writeConfigUnlocked(dir, config);
   const recovery: CorruptConfigRecovery = {
     backupPath,
     tokenSalvaged: Boolean(salvaged.token),
@@ -263,10 +264,15 @@ async function recoverCorruptConfig(
 
 export async function loadConfig(dataDir?: string): Promise<LoadConfigResult> {
   const dir = await ensureDataDir(dataDir);
+  return withConfigLock(dir, () => loadConfigUnlocked(dir));
+}
+
+/** Caller holds the config lock, including initialization and migration writes. */
+async function loadConfigUnlocked(dir: string): Promise<LoadConfigResult> {
   const path = configPath(dir);
   if (!existsSync(path)) {
     const config = defaultConfig(dir);
-    await saveConfig(dir, config);
+    await writeConfigUnlocked(dir, config);
     return { dir, config };
   }
   const raw = await readFile(path, 'utf8');
@@ -283,13 +289,88 @@ export async function loadConfig(dataDir?: string): Promise<LoadConfigResult> {
   config.dataDir = dir;
   const { changed } = ensureIdentity(config);
   if (changed) {
-    await saveConfig(dir, config);
+    await writeConfigUnlocked(dir, config);
   }
   return { dir, config };
 }
 
 export async function saveConfig(dir: string, config: TudConfig): Promise<void> {
-  await writeFile(configPath(dir), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  await withConfigLock(dir, async () => {
+    const persisted = await readPersistedConfig(dir);
+    const next = { ...config };
+    // A settings snapshot may predate a completed background sync/upload.
+    // These fields belong to the runtime, not to the settings writer.
+    for (const field of ['lastSyncAt', 'lastUploadAt'] as const) {
+      if (persisted?.[field]) {
+        next[field] = latestTimestamp(persisted[field], config[field]);
+      }
+    }
+    await writeConfigUnlocked(dir, next);
+    for (const field of ['lastSyncAt', 'lastUploadAt'] as const) {
+      if (field in next) config[field] = next[field];
+    }
+  });
+}
+
+async function withConfigLock<T>(dir: string, operation: () => Promise<T>): Promise<T> {
+  // Both the main process and sync worker must use the same lock. It also
+  // covers a config that does not exist yet, and recovers locks left by crashes.
+  const release = await lock(configPath(dir), {
+    realpath: false,
+    stale: 10_000,
+    update: 5_000,
+    retries: { retries: 100, factor: 1.2, minTimeout: 10, maxTimeout: 200 },
+  });
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+async function readPersistedConfig(dir: string): Promise<TudConfig | null> {
+  let raw: string;
+  try {
+    raw = await readFile(configPath(dir), 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid config: expected an object');
+  }
+  return parsed as TudConfig;
+}
+
+async function writeConfigUnlocked(dir: string, config: TudConfig): Promise<void> {
+  const path = configPath(dir);
+  const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  const mode = await stat(path).then((info) => info.mode & 0o777).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return 0o600;
+    throw error;
+  });
+  try {
+    await writeFile(temporary, `${JSON.stringify(config, null, 2)}\n`, {
+      encoding: 'utf8', flag: 'wx', mode,
+    });
+    await rename(temporary, path);
+  } finally {
+    await unlink(temporary).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'ENOENT') throw error;
+    });
+  }
+}
+
+function latestTimestamp(
+  persisted: string | null | undefined,
+  proposed: string | null | undefined,
+): string | null | undefined {
+  const persistedMs = Date.parse(persisted ?? '');
+  const proposedMs = Date.parse(proposed ?? '');
+  return Number.isFinite(persistedMs) &&
+    (!Number.isFinite(proposedMs) || persistedMs > proposedMs)
+    ? persisted : proposed;
 }
 
 export async function touchStatsSince(
@@ -329,11 +410,25 @@ export async function touchStatsSince(
 }
 
 export async function setLastSyncAt(dir: string, config: TudConfig): Promise<void> {
-  config.lastSyncAt = new Date().toISOString();
-  await saveConfig(dir, config);
+  await setRuntimeTimestamp(dir, config, 'lastSyncAt');
 }
 
 export async function setLastUploadAt(dir: string, config: TudConfig): Promise<void> {
-  config.lastUploadAt = new Date().toISOString();
-  await saveConfig(dir, config);
+  await setRuntimeTimestamp(dir, config, 'lastUploadAt');
+}
+
+async function setRuntimeTimestamp(
+  dir: string,
+  config: TudConfig,
+  field: 'lastSyncAt' | 'lastUploadAt',
+): Promise<void> {
+  const completedAt = new Date().toISOString();
+  await withConfigLock(dir, async () => {
+    // Parsers/uploaders hold old snapshots across awaits. Never write their
+    // settings back just to record completion of background work.
+    const persisted = await readPersistedConfig(dir) ?? { ...config };
+    persisted[field] = latestTimestamp(persisted[field], completedAt);
+    await writeConfigUnlocked(dir, persisted);
+    config[field] = persisted[field];
+  });
 }

--- a/packages/core/test/config-concurrency.test.ts
+++ b/packages/core/test/config-concurrency.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { fork } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, readdir, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test, { type TestContext } from 'node:test';
+
+import { loadConfig, saveConfig, setLastSyncAt, setLastUploadAt } from '../src/config.js';
+import { configPath } from '../src/paths.js';
+import { createLocalApiApp } from '../src/server/local-api.js';
+import { BucketStore } from '../src/server/state.js';
+import type { TudConfig } from '../src/types.js';
+
+async function fixture(t: TestContext) {
+  const dir = await mkdtemp(join(tmpdir(), 'tud-config-concurrency-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const { config } = await loadConfig(dir);
+  const app = createLocalApiApp({
+    dataDir: dir,
+    getConfig: () => config,
+    bucketStore: new BucketStore(),
+  });
+  return {
+    dir, config,
+    readSaved: async () => JSON.parse(await readFile(configPath(dir), 'utf8')) as TudConfig,
+    disable: async () => {
+      const response = await app.request('/functions/tud-config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ juejin: {
+          enabled: false,
+          apiUrl: 'https://example.invalid/changed',
+          userName: 'saved by user',
+        } }),
+      });
+      assert.equal(response.status, 200);
+    },
+  };
+}
+
+async function writer(t: TestContext, dir: string, operation: string, rounds = 1) {
+  const child = fork(new URL('./fixtures/config-writer.js', import.meta.url),
+    [dir, operation, String(rounds)], { stdio: ['ignore', 'ignore', 'pipe', 'ipc'] });
+  let stderr = '';
+  child.stderr?.on('data', (chunk) => { stderr += String(chunk); });
+  const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+  t.after(async () => {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+    await exited;
+  });
+  let readyResolve!: () => void;
+  let readyReject!: (error: Error) => void;
+  let doneResolve!: () => void;
+  let doneReject!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => { readyResolve = resolve; readyReject = reject; });
+  const done = new Promise<void>((resolve, reject) => { doneResolve = resolve; doneReject = reject; });
+  // Child startup can fail before the caller begins awaiting completion.
+  void done.catch(() => {});
+  child.on('error', (error) => { readyReject(error); doneReject(error); });
+  child.on('message', (raw) => {
+    const message = raw as { type: string; error?: string };
+    if (message.type === 'ready') readyResolve();
+    if (message.type === 'error') {
+      const error = new Error(message.error);
+      readyReject(error); doneReject(error);
+    }
+  });
+  child.on('exit', (code) => {
+    if (code === 0) doneResolve();
+    else {
+      const error = new Error(`writer exited ${code}: ${stderr}`);
+      readyReject(error); doneReject(error);
+    }
+  });
+  await ready;
+  return { done, start: () => child.send('start') };
+}
+
+for (const operation of ['sync', 'upload']) {
+  test(`${operation} completion in another process preserves settings saved through the API`, { timeout: 15_000 }, async (t) => {
+    const f = await fixture(t);
+    const child = await writer(t, f.dir, operation);
+    await f.disable();
+    const savedSettings = (await f.readSaved()).juejin;
+    child.start();
+    await child.done;
+    const saved = await f.readSaved();
+    assert.deepEqual(saved.juejin, savedSettings);
+    assert.ok(saved[operation === 'sync' ? 'lastSyncAt' : 'lastUploadAt']);
+  });
+}
+
+test('settings saved from an older snapshot preserve completed sync and upload times', async (t) => {
+  const f = await fixture(t);
+  const settingsSnapshot = structuredClone(f.config);
+  await setLastSyncAt(f.dir, f.config);
+  await setLastUploadAt(f.dir, f.config);
+  const completed = await f.readSaved();
+  settingsSnapshot.juejin.enabled = false;
+  await saveConfig(f.dir, settingsSnapshot);
+  const saved = await f.readSaved();
+  assert.equal(saved.lastSyncAt, completed.lastSyncAt);
+  assert.equal(saved.lastUploadAt, completed.lastUploadAt);
+  assert.equal(saved.juejin.enabled, false);
+});
+
+test('concurrent settings, sync and upload writers retain settings and both timestamps', { timeout: 20_000 }, async (t) => {
+  const f = await fixture(t);
+  const writers = await Promise.all(['settings', 'sync', 'upload'].map((operation) =>
+    writer(t, f.dir, operation, 12)));
+  for (const child of writers) child.start();
+  let finished = false;
+  const completed = Promise.all(writers.map((child) => child.done))
+    .finally(() => { finished = true; });
+  try {
+    // These reads deliberately do not take the lock. Atomic replacement must
+    // keep config.json parseable even for non-cooperating readers.
+    while (!finished) await f.readSaved();
+  } finally {
+    await completed;
+  }
+  const saved = await f.readSaved();
+  assert.equal(saved.juejin.enabled, false);
+  assert.equal(saved.juejin.userName, 'saved-11');
+  assert.ok(saved.lastSyncAt);
+  assert.ok(saved.lastUploadAt);
+  assert.ok(!(await readdir(f.dir)).some((name) => name.endsWith('.lock') || name.endsWith('.tmp')));
+});
+
+test('timestamp setters still initialize an unsaved fixture and update the caller', async (t) => {
+  const f = await fixture(t);
+  await rm(configPath(f.dir));
+  await setLastSyncAt(f.dir, f.config);
+  await setLastUploadAt(f.dir, f.config);
+  const saved = await f.readSaved();
+  assert.equal(saved.deviceId, f.config.deviceId);
+  assert.equal(saved.lastSyncAt, f.config.lastSyncAt);
+  assert.equal(saved.lastUploadAt, f.config.lastUploadAt);
+});
+
+test('failed timestamp writes leave corrupt contents intact and release the lock', async (t) => {
+  const f = await fixture(t);
+  const previousTime = f.config.lastSyncAt;
+  await writeFile(configPath(f.dir), '{broken', 'utf8');
+  await assert.rejects(setLastSyncAt(f.dir, f.config), SyntaxError);
+  assert.equal(f.config.lastSyncAt, previousTime);
+  assert.equal(await readFile(configPath(f.dir), 'utf8'), '{broken');
+  assert.ok(!(await readdir(f.dir)).some((name) => name.endsWith('.lock') || name.endsWith('.tmp')));
+
+  const recovered = await loadConfig(f.dir);
+  assert.ok(recovered.recoveredFromCorrupt);
+  await setLastSyncAt(f.dir, recovered.config);
+});
+
+test('configuration can be loaded after recovering a stale crash lock', async (t) => {
+  const f = await fixture(t);
+  const lockPath = `${configPath(f.dir)}.lock`;
+  await mkdir(lockPath);
+  const old = new Date(Date.now() - 60_000);
+  await utimes(lockPath, old, old);
+  const loaded = await loadConfig(f.dir);
+  assert.equal(loaded.config.deviceId, f.config.deviceId);
+  assert.ok(!(await readdir(f.dir)).includes('config.json.lock'));
+});
+
+test('concurrent first loads agree on a single initialized identity', async (t) => {
+  const f = await fixture(t);
+  await rm(configPath(f.dir));
+  const loaded = await Promise.all(Array.from({ length: 5 }, () => loadConfig(f.dir)));
+  const saved = await f.readSaved();
+  assert.ok(loaded.every(({ config }) => config.deviceId === saved.deviceId));
+  assert.ok(!(await readdir(f.dir)).some((name) => name.endsWith('.lock') || name.endsWith('.tmp')));
+});

--- a/packages/core/test/fixtures/config-writer.ts
+++ b/packages/core/test/fixtures/config-writer.ts
@@ -1,0 +1,30 @@
+import { loadConfig, saveConfig, setLastSyncAt, setLastUploadAt } from '../../src/config.js';
+
+const dir = process.argv[2]!;
+const operation = process.argv[3]!;
+const rounds = Number(process.argv[4] ?? '1');
+const { config } = await loadConfig(dir);
+process.send?.({ type: 'ready' });
+
+process.once('message', async () => {
+  try {
+    // Intentionally keep the snapshot obtained before the parent updates settings.
+    for (let i = 0; i < rounds; i++) {
+      if (operation === 'sync') {
+        await setLastSyncAt(dir, config);
+      } else if (operation === 'upload') {
+        await setLastUploadAt(dir, config);
+      } else {
+        config.juejin.enabled = false;
+        config.juejin.userName = `saved-${i}`;
+        await saveConfig(dir, config);
+      }
+    }
+    process.send?.({ type: 'done' });
+  } catch (error) {
+    process.exitCode = 1;
+    process.send?.({ type: 'error', error: String(error) });
+  } finally {
+    process.disconnect();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,10 +144,16 @@ importers:
       hono:
         specifier: ^4.7.5
         version: 4.12.28
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
     devDependencies:
       '@types/node':
         specifier: ^22.13.10
         version: 22.20.1
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       typescript:
         specifier: ^5.8.2
         version: 5.9.3
@@ -1362,6 +1368,9 @@ packages:
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
 
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
   '@types/react-dom@19.2.4':
     resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
@@ -1372,6 +1381,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -2849,6 +2861,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -4730,6 +4745,10 @@ snapshots:
       xmlbuilder: 15.1.1
     optional: true
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
   '@types/react-dom@19.2.4(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -4741,6 +4760,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.20.1
+
+  '@types/retry@0.12.5': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -6322,6 +6343,12 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   pump@3.0.4:
     dependencies:


### PR DESCRIPTION
后台同步或上报持有旧配置快照时，完成后的时间戳写入会把用户刚保存的设置覆盖回去，例如重新开启已经关闭的云端同步。现在时间戳在跨进程锁内按字段更新；保存设置也会保留已完成的同步、上报时间。

### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

修改共享 Core 配置持久化逻辑。Desktop 的主进程、同步子进程，以及 CLI 使用同一套读写入口；配置格式和 API 字段保持兼容，未改动 renderer。

### 🔗 关联 Issue

暂无关联 Issue。通过真实子进程与本地配置 API 的隔离回归测试复现。

### 💡 改动说明

复现步骤：

1. 同步/上报子进程先读取开启云端同步的配置快照。
2. 主进程通过 `PUT /functions/tud-config` 关闭云端同步，接口返回 200，文件中的 `enabled` 确实为 false。
3. 子进程完成工作，使用旧快照调用 `setLastSyncAt` 或 `setLastUploadAt`。
4. 原实现保存整份旧快照，将 `enabled` 重新写为 true，同时可能覆盖新保存的远端地址、个人资料等设置。

反向顺序也有问题：设置快照早于同步完成时，保存该快照会将最近同步/上报时间回退。

本次修复：

- 使用 `proper-lockfile` 对配置初始化、迁移/恢复、保存及时间戳更新进行跨进程互斥。锁支持有限重试与崩溃遗留锁的过期恢复。
- 时间戳更新在锁内读取最新配置，只修改对应字段；保存设置时保留更新的运行时戳。
- 同目录临时文件写入后通过 rename 替换，避免并发读者看到半写 JSON；错误路径清理临时文件并释放锁。
- 保留时间戳 setter 更新调用方对象及未保存配置初始化的已有行为。已存在的损坏 JSON 不会被后台时间戳更新静默覆盖，仍由 `loadConfig` 执行既有恢复流程。
- 仅新增锁库及其类型依赖，保留其他依赖版本。

新增 8 项回归测试，覆盖同步/上报子进程的旧快照、旧设置快照、三个子进程交错写入与无锁读取、未保存配置、损坏 JSON、过期锁恢复和并发初始化。测试只操作临时目录，不读取真实工具记录或上报用户数据。

### 验证

- 初始 5 项复现测试在修复前：4 项失败、1 项通过。
- 修复后 Core 配置、API、范围扩展及上报相关测试：64 项全部通过，包含 8 项新增测试。
- CLI 测试：13 项全部通过。
- `pnpm build` 通过，Dashboard 保留既有大 chunk 警告。
- Desktop 独立 `typecheck` 通过。
- `pnpm install --frozen-lockfile --offline`、`pnpm changeset status --since upstream/main`、`git diff --check` 通过。

测试环境：macOS / Node.js 22.17.0 / pnpm 11.1.2。未做 Windows 实机或已打包 Electron UI 手动验证。互斥保证适用于采用本次 Core 读写入口的进程；直接编辑文件或旧版进程绕过锁的写入不受协调。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 修复后台同步或上报完成时可能覆盖刚保存的设置、重新开启云端同步的问题，并避免保存设置时回退最近同步或上报时间。 |
| `@juejin-opensource/jusage`（CLI） | patch | 修复后台同步或上报完成时可能覆盖刚保存的设置、重新开启云端同步的问题，并避免保存设置时回退最近同步或上报时间。 |
| `@juejin-opensource/jusage-desktop` | patch | 修复后台同步或上报完成时可能覆盖刚保存的设置、重新开启云端同步的问题，并避免保存设置时回退最近同步或上报时间。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`，从官方 main 独立创建。
- [x] 共享 Core API 与真实子进程并发回归测试通过。
- [ ] Windows 实机 / 已打包 Electron UI 手动验证。
- [x] 未改动 UI，无需同步 Dashboard / Desktop renderer。
- [x] 已执行 `pnpm changeset` 并补齐 patch 说明。
- [x] `pnpm build` 通过。
