### PR TITLE
fix(pricing): GPT-6 Astra 补上缓存读写单价，命中缓存的 Token 不再按 0 计费

### DIFF
--- a/.changeset/gpt-6-astra-cache-rates.md
+++ b/.changeset/gpt-6-astra-cache-rates.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-core": patch
+---
+
+修正 GPT-6 Astra 的定价：补上缓存读取（$1 / 百万 Token）与缓存写入（$12.5 / 百万 Token）单价，命中缓存的输入 Token 不再按 0 计费，Codex 等来源的费用不再明显偏低。

--- a/packages/core/src/pricing/pricing.json
+++ b/packages/core/src/pricing/pricing.json
@@ -1,8 +1,8 @@
 {
   "_meta": {
     "units": "usd_per_million_tokens",
-    "generated_at": "2026-09-05T00:00:00.000Z",
-    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes). Incremental models.dev sync on 2026-08-28: kept=416 (added=73, changed=13, removed=54). Gemini-only sync on 2026-09-03: kept=417 (added=google/gemini-3.8-flash, changed=0, removed=0). GPT-6 Astra sync on 2026-09-05: kept=418 (added=openai/gpt-6-astra, changed=0, removed=0). Official-only: cross-vendor hosting and cloud-partnership channels dropped."
+    "generated_at": "2026-09-07T00:00:00.000Z",
+    "note": "Official-channel-only pricing bundle from models.dev. Scoped to anthropic/openai/google/google-vertex(/anthropic)/xai/deepseek/alibaba(/-cn)/moonshotai(/-cn)/minimax(/-cn)/xiaomi/mistral(/-cn)/zai/zhipuai/volcengine. Excludes audio/video/image/embedding/tts/stt/realtime/transcription/moderation models. All third-party / community / AWS ARN / region variants were removed 2026-08-27 — any (source, model) emitted by the parsers resolves to the official price via matcher prefix-strip. Build stats: kept=426. Manually supplemented 118 entries on 2026-08-27 from an external price feed (claude-3.x, claude-mythos-5, opus-4/-4-1/-4-8-fast/-5-fast, sonnet-4, gpt-5, gpt-5.x-codex, gpt-5.5-fast/flex, gpt-5.6-*-batch/fast/flex, o1-mini/preview, gemini-1.5/2.0/3.x, deepseek-coder/r1/v3.x/v4, qwen-coder/qwen3.7-flash/qwen3.8, glm-4.5-airx/x/glm-5-code, kimi-k2/k2.7-code/k3/kimi-for-coding/moonshot-v1, mistral-medium-3-5/ministral/codestral-2508, grok-3/4/4.20/code-fast, cursor, hy3, doubao-seed-2.x, step, ling/ring, longcat, agnes). Incremental models.dev sync on 2026-08-28: kept=416 (added=73, changed=13, removed=54). Gemini-only sync on 2026-09-03: kept=417 (added=google/gemini-3.8-flash, changed=0, removed=0). GPT-6 Astra sync on 2026-09-05: kept=418 (added=openai/gpt-6-astra, changed=0, removed=0). GPT-6 Astra cache rates supplemented on 2026-09-07 from the OpenAI model page: cache_read=1, cache_write=12.5 (changed=1). Official-only: cross-vendor hosting and cloud-partnership channels dropped."
   },
   "exact": {
     "alibaba/qvq-max": {
@@ -1457,7 +1457,9 @@
     },
     "openai/gpt-6-astra": {
       "input": 10,
-      "output": 50
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5
     },
     "openai/gpt-5.6": {
       "input": 4,

--- a/packages/core/test/pricing.test.ts
+++ b/packages/core/test/pricing.test.ts
@@ -189,6 +189,29 @@ test('cursor gpt-5.6 sol/terra tiers resolve to their own model', () => {
   assert.equal(terra.output, 12);
 });
 
+test('gpt-6-astra carries official cache read/write rates for every name variant', () => {
+  for (const m of ['gpt-6-astra', 'openai/gpt-6-astra', 'gpt-6-astra-xhigh', 'gpt-6-astra-max']) {
+    const p = getModelPricing(m, { source: 'codex' });
+    assert.equal(p.input, 10, m);
+    assert.equal(p.output, 50, m);
+    assert.equal(p.cache_read, 1, m);
+    assert.equal(p.cache_write, 12.5, m);
+  }
+});
+
+test('gpt-6-astra codex row bills cached input at the cache-read rate, not zero', () => {
+  const row = makeRow({
+    source: 'codex',
+    model: 'gpt-6-astra',
+    input_tokens: 100_000,
+    cached_input_tokens: 1_000_000,
+    output_tokens: 10_000,
+    total_tokens: 1_110_000,
+  });
+  // 0.1M × $10 + 1M × $1 + 0.01M × $50
+  assert.equal(roundCostUsd(computeRowCost(row)), 2.5);
+});
+
 test('cursor gpt-5.4-mini tier resolves to mini, not gpt-5.4', () => {
   const p = getModelPricing('gpt-5.4-mini-medium', { source: 'cursor' });
   assert.equal(p.input, 0.75);


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

（改动只在 `packages/core` 的定价底表与测试，两端共用同一实现；Web 使用服务端数据，不直接读取本地底表。无 UI 改动。）

### 🔗 关联 Issue

close #97

### 💡 改动说明

**原来的问题**：#86 新增的 `openai/gpt-6-astra` 条目只写了 `input` / `output`，缺 `cache_read` / `cache_write`。`toModelPricing` 把缺失字段补成 `0`，`computeRowCost` 再用 `cached_input_tokens × 0`，于是命中缓存的输入 Token 全部按 $0 计费。Codex 在 agent 场景下缓存命中占输入 Token 九成以上，本机 20 个 Astra 会话实测费用少算约 51%（官方价 $295.74，当前表 $145.03）。

**这版怎么改**：

1. `pricing.json` 按 [OpenAI 官方模型页](https://developers.openai.com/api/docs/models/gpt-6-astra) 补上 `cache_read: 1`、`cache_write: 12.5`（美元 / 百万 Token），与 [models.dev 数据](https://raw.githubusercontent.com/sst/models.dev/dev/providers/openai/models/gpt-6-astra.toml) 一致；`_meta` 记录本次补充。
2. 新增两条回归测试：`gpt-6-astra` / `openai/gpt-6-astra` / `gpt-6-astra-xhigh` / `gpt-6-astra-max` 四种模型名都命中完整四项单价；一条缓存占比高的 codex 行按 cache_read 计费（0.1M × $10 + 1M × $1 + 0.01M × $50 = $2.5），确保缓存部分不再为 0。

**不在本 PR 范围**：

- 超过 272K 输入的长上下文档位、Fast 2 倍、Batch / Flex 半价：日志里模型名都是同一个 `gpt-6-astra`，价格表无法区分，与其他模型的处理方式一致。
- 线上远端价格覆盖层（`tud-pricing`）尚无该模型条目，旧版本客户端会落到 default 兜底价；覆盖层优先级高于内置表，建议同步补上同一条目让新旧客户端立即生效（详见 #97）。

**测试**：core 279 个用例全过（含新增 2 条）；`pnpm build` 全仓通过。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 修正 GPT-6 Astra 的定价：补上缓存读取（$1 / 百万 Token）与缓存写入（$12.5 / 百万 Token）单价，命中缓存的输入 Token 不再按 0 计费，Codex 等来源的费用不再明显偏低。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已通过 core 单测与本机 Codex 数据验证费用计算（未跑端到端 sync）
- [x] 若改动了面板 UI：本次未改 UI，两份同构代码均无需改动
- [x] 已添加 changeset（`.changeset/gpt-6-astra-cache-rates.md`）
- [x] `pnpm build` 通过
