### PR TITLE
feat(web): pin personal rank and raise leaderboard limit to 100

### DIFF
--- a/.changeset/rank-top-100-pin.md
+++ b/.changeset/rank-top-100-pin.md
@@ -1,0 +1,6 @@
+---
+"@juejin-opensource/jusage-dashboard": minor
+"@juejin-opensource/jusage-core": patch
+---
+
+排行榜公开榜扩到前 100，并在列表顶部置顶展示自己的真实名次。

--- a/packages/core/src/leaderboard.ts
+++ b/packages/core/src/leaderboard.ts
@@ -1,2 +1,2 @@
-/** Public leaderboards expose at most the first 50 ranked users. */
-export const LEADERBOARD_DEFAULT_LIMIT = 50;
+/** Public leaderboards expose at most the first 100 ranked users. */
+export const LEADERBOARD_DEFAULT_LIMIT = 100;

--- a/packages/core/test/local-api-leaderboard.test.ts
+++ b/packages/core/test/local-api-leaderboard.test.ts
@@ -62,7 +62,7 @@ test('leaderboard is unconfigured when cloud sync settings are incomplete', asyn
     assert.equal(body.success, true);
     assert.equal(body.data?.configured, false);
     assert.equal(body.data?.days, 1);
-    assert.equal(body.data?.limit, 50);
+    assert.equal(body.data?.limit, 100);
     assert.equal(body.data?.metric, 'tokens');
   }
 });
@@ -179,7 +179,7 @@ test('leaderboard overview returns a stable unconfigured catalog shape', async (
   assert.equal(body.data?.configured, false);
   assert.equal(body.data?.range, 'all');
   assert.equal(body.data?.days, null);
-  assert.equal(body.data?.limit, 50);
+  assert.equal(body.data?.limit, 100);
   assert.deepEqual(body.data?.tools, []);
   assert.equal(body.data?.global.tokens.totalUsers, 0);
 });
@@ -197,7 +197,7 @@ test('leaderboard overview proxy forwards range and clamped limit', async () => 
     configured: true,
     range: 'month',
     days: 30,
-    limit: 50,
+    limit: 100,
     generatedAt: '2026-07-23T00:00:00.000Z',
     global: { cost: emptyBoard('cost'), tokens: emptyBoard('tokens') },
     tools: [],
@@ -219,7 +219,7 @@ test('leaderboard overview proxy forwards range and clamped limit', async () => 
     assert.equal(response.status, 200);
     assert.equal(
       requestedUrl,
-      'https://usage.example.com/functions/tud-leaderboard-overview?range=month&limit=50',
+      'https://usage.example.com/functions/tud-leaderboard-overview?range=month&limit=100',
     );
     assert.equal(body.data?.range, 'month');
   } finally {

--- a/packages/dashboard/src/components/RankModelCards.tsx
+++ b/packages/dashboard/src/components/RankModelCards.tsx
@@ -3,12 +3,14 @@ import { Avatar, Chip, Skeleton, Switch } from '@heroui/react';
 import { MyRankCard } from '@/components/MyRankCard';
 import { RankTitleDecor } from '@/components/RankDecorations';
 import type {
+  LeaderboardBoard,
   LeaderboardMetric,
   LeaderboardOverviewResponse,
   LeaderboardRow,
   LeaderboardUserProfile,
 } from '@/lib/api';
 import { formatTokens, formatUsd } from '@/lib/format';
+import { pinCurrentUserRows } from '@/lib/leaderboard';
 import { cn } from '@/lib/utils';
 
 type DetailedLeaderboardRow = LeaderboardRow & {
@@ -17,7 +19,7 @@ type DetailedLeaderboardRow = LeaderboardRow & {
 };
 
 const LIST_CARD =
-  'overflow-hidden rounded-2xl border border-white/60 bg-white/90 shadow-[0_8px_30px_rgb(15_60_120_/0.06)] dark:border-white/8 dark:bg-surface dark:shadow-[0_8px_30px_rgb(0_0_0_/0.35)]';
+  'rounded-2xl border border-white/60 bg-white/90 shadow-[0_8px_30px_rgb(15_60_120_/0.06)] dark:border-white/8 dark:bg-surface dark:shadow-[0_8px_30px_rgb(0_0_0_/0.35)]';
 
 /** Prefetch avatars slightly before they enter the viewport. */
 const AVATAR_ROOT_MARGIN = '240px 0px';
@@ -94,7 +96,11 @@ export function RankUserTable({
             refreshing && 'pointer-events-none opacity-60',
           )}
         >
-          <UserList board={board} profiles={profiles} />
+          <UserList
+            board={board}
+            hideFromLeaderboard={hideFromLeaderboard}
+            profiles={profiles}
+          />
         </div>
       )}
     </section>
@@ -103,19 +109,23 @@ export function RankUserTable({
 
 function UserList({
   board,
+  hideFromLeaderboard,
   profiles,
 }: {
-  board: { rows: LeaderboardRow[] } | null;
+  board: LeaderboardBoard | null;
+  hideFromLeaderboard: boolean;
   profiles: Record<string, LeaderboardUserProfile>;
 }) {
   const rows = board?.rows ?? [];
+  const currentUser = hideFromLeaderboard ? null : (board?.currentUser ?? null);
+  const displayRows = pinCurrentUserRows(rows, currentUser);
 
-  if (rows.length === 0) {
+  if (rows.length === 0 && !currentUser) {
     return (
       <div
         className={cn(
           LIST_CARD,
-          'flex min-h-56 flex-col items-center justify-center gap-2 text-center',
+          'flex min-h-56 flex-col items-center justify-center gap-2 overflow-hidden text-center',
         )}
       >
         <p className="text-sm">当前范围暂无用户排行数据</p>
@@ -130,7 +140,7 @@ function UserList({
         aria-hidden
         className="flex items-center gap-2 px-4 py-2.5 text-[11px] text-muted sm:gap-5 sm:px-6 sm:py-3 sm:text-xs"
       >
-        <span className="w-6 shrink-0 sm:w-8" />
+        <span className="w-10 shrink-0 sm:w-12" />
         <span className="min-w-0 flex-1">用户</span>
         <div className="flex shrink-0 items-center gap-2 sm:gap-8">
           <span className="w-[3.25rem] text-right sm:w-24">总 Token</span>
@@ -138,7 +148,7 @@ function UserList({
         </div>
       </div>
       <ol className="min-w-0">
-        {rows.map((row) => {
+        {displayRows.map(({ pinned, row }) => {
           const detailedRow = row as DetailedLeaderboardRow;
           const uid = detailedRow.uid ?? row.userHash;
           const profile = profiles[uid];
@@ -151,8 +161,13 @@ function UserList({
 
           return (
             <li
-              className="min-w-0 [content-visibility:auto] [contain-intrinsic-size:auto_56px] transition-colors hover:bg-black/[0.02] dark:hover:bg-white/[0.04]"
-              key={row.userHash}
+              className={cn(
+                'min-w-0 transition-colors hover:bg-black/[0.02] dark:hover:bg-white/[0.04]',
+                pinned
+                  ? 'sticky top-0 z-10 border-b border-[#1e80ff]/15 bg-[#eef6ff]/95 shadow-[0_8px_16px_rgb(15_60_120_/0.06)] dark:border-[#4b9cff]/20 dark:bg-[#16324f]/95 dark:shadow-[0_8px_16px_rgb(0_0_0_/0.25)]'
+                  : '[content-visibility:auto] [contain-intrinsic-size:auto_56px]',
+              )}
+              key={pinned ? `pinned-${row.userHash}` : row.userHash}
             >
               <div className="flex min-w-0 items-center gap-2 px-4 py-3 sm:gap-5 sm:px-6 sm:py-4">
                 <RankNumber rank={row.rank} />
@@ -245,7 +260,8 @@ function RankNumber({ rank }: { rank: number }) {
     <span
       aria-label={`第 ${rank} 名`}
       className={cn(
-        'w-6 shrink-0 text-center text-xl font-bold tabular-nums leading-none sm:w-8 sm:text-2xl',
+        'w-10 shrink-0 text-center font-bold tabular-nums leading-none sm:w-12',
+        rank > 99 ? 'text-base sm:text-lg' : 'text-xl sm:text-2xl',
         rank === 1 && 'text-[#F53F3F] dark:text-[#ff6b6b]',
         rank === 2 && 'text-[#F77234] dark:text-[#ff9a5c]',
         rank === 3 && 'text-[#FF7D00] dark:text-[#ffb020]',
@@ -284,9 +300,9 @@ function UsageMetrics({
 
 function UserListSkeleton() {
   return (
-    <div aria-label="用户排行榜加载中" className={cn(LIST_CARD, 'min-w-0')}>
+    <div aria-label="用户排行榜加载中" className={cn(LIST_CARD, 'min-w-0 overflow-hidden')}>
       <div className="flex items-center gap-2 px-4 py-2.5 sm:gap-5 sm:px-6 sm:py-3">
-        <span className="w-6 shrink-0 sm:w-8" />
+        <span className="w-10 shrink-0 sm:w-12" />
         <Skeleton className="h-3 w-8 rounded-md" />
         <div className="ml-auto flex shrink-0 items-center gap-2 sm:gap-8">
           <Skeleton className="h-3 w-12 rounded-md sm:w-16" />
@@ -298,7 +314,7 @@ function UserListSkeleton() {
           className="flex items-center gap-2 px-4 py-3 sm:gap-5 sm:px-6 sm:py-4"
           key={index}
         >
-          <Skeleton className="h-6 w-6 shrink-0 rounded-md sm:h-7 sm:w-8" />
+          <Skeleton className="h-6 w-10 shrink-0 rounded-md sm:h-7 sm:w-12" />
           <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-2.5">
             <Skeleton className="size-7 shrink-0 rounded-full sm:size-8" />
             <Skeleton className="h-4 w-24 max-w-full rounded-md sm:w-36" />

--- a/packages/dashboard/src/components/RankShareModal.tsx
+++ b/packages/dashboard/src/components/RankShareModal.tsx
@@ -255,7 +255,7 @@ function ShareLeaderboard({
       {!currentUser && (
         <div className="mt-4 flex items-center justify-between rounded-xl border border-dashed border-[#b9d8ff] bg-white/[0.32] px-3 py-2.5 text-[11px] dark:border-white/15 dark:bg-white/[0.05]">
           <span className="font-semibold text-[#5c7d9c] dark:text-[#a8c1da]">我的排名</span>
-          <span className="font-bold text-[#334e69] dark:text-[#f1f8ff]">99+名</span>
+          <span className="font-bold text-[#334e69] dark:text-[#f1f8ff]">登录后查看</span>
         </div>
       )}
     </div>

--- a/packages/dashboard/src/lib/leaderboard-mock-data.ts
+++ b/packages/dashboard/src/lib/leaderboard-mock-data.ts
@@ -6,10 +6,11 @@ import type {
   LeaderboardRow,
   ToolLeaderboard,
 } from '@juejin-opensource/jusage-core';
+import { LEADERBOARD_DEFAULT_LIMIT } from '@juejin-opensource/jusage-core/leaderboard';
 import mockHotList from '../../mock-users.json' with { type: 'json' };
 
-/** Mock list size; aligned with core LEADERBOARD_DEFAULT_LIMIT (50). */
-const MOCK_LEADERBOARD_LIMIT = 50;
+/** Mock list size; aligned with core LEADERBOARD_DEFAULT_LIMIT. */
+const MOCK_LEADERBOARD_LIMIT = LEADERBOARD_DEFAULT_LIMIT;
 
 type MockUser = Omit<LeaderboardRow, 'rank' | 'isCurrentUser'> & {
   avatarUrl?: string;

--- a/packages/dashboard/src/lib/leaderboard.test.ts
+++ b/packages/dashboard/src/lib/leaderboard.test.ts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  formatRankPosition,
   groupRankModelsByVendor,
   uniqueRankModelOptions,
   isRankRange,
+  pinCurrentUserRows,
 } from './leaderboard.ts';
+import type { LeaderboardRow } from './api.ts';
 
 describe('isRankRange', () => {
   it('accepts the four leaderboard ranges', () => {
@@ -152,6 +155,64 @@ describe('groupRankModelsByVendor', () => {
     assert.deepEqual(
       groupRankModelsByVendor(['gpt-5', 'gpt-5'])[0]?.models,
       ['gpt-5'],
+    );
+  });
+});
+
+describe('formatRankPosition', () => {
+  it('returns an em dash for missing ranks', () => {
+    assert.equal(formatRankPosition(null), '—');
+    assert.equal(formatRankPosition(undefined), '—');
+    assert.equal(formatRankPosition(0), '—');
+    assert.equal(formatRankPosition(-1), '—');
+  });
+
+  it('shows the actual rank including values above 99', () => {
+    assert.equal(formatRankPosition(1), '1');
+    assert.equal(formatRankPosition(99), '99');
+    assert.equal(formatRankPosition(100), '100');
+    assert.equal(formatRankPosition(237), '237');
+  });
+});
+
+function sampleRow(
+  userHash: string,
+  rank: number,
+  isCurrentUser = false,
+): LeaderboardRow {
+  return {
+    rank,
+    displayName: `用户 ${userHash}`,
+    userHash,
+    tokens: 1_000 - rank,
+    costUsd: 1,
+    isCurrentUser,
+  };
+}
+
+describe('pinCurrentUserRows', () => {
+  it('returns rows unchanged without a current user', () => {
+    const top = sampleRow('aaa', 1);
+    assert.deepEqual(pinCurrentUserRows([top], null), [
+      { pinned: false, row: top },
+    ]);
+  });
+
+  it('pins the current user above the existing rows', () => {
+    const top = sampleRow('aaa', 1);
+    const me = sampleRow('me', 2, true);
+    const result = pinCurrentUserRows([top, me], me);
+
+    assert.deepEqual(
+      result.map((item) => ({
+        pinned: item.pinned,
+        userHash: item.row.userHash,
+      })),
+      [
+        { pinned: true, userHash: 'me' },
+        { pinned: false, userHash: 'aaa' },
+        { pinned: false, userHash: 'me' },
+      ],
     );
   });
 });

--- a/packages/dashboard/src/lib/leaderboard.ts
+++ b/packages/dashboard/src/lib/leaderboard.ts
@@ -1,4 +1,8 @@
-import type { LeaderboardMetric, LeaderboardRange } from '@/lib/api';
+import type {
+  LeaderboardMetric,
+  LeaderboardRange,
+  LeaderboardRow,
+} from '@/lib/api';
 import { getModelProvider, type ModelProvider } from './model-provider.ts';
 
 export type RankRange = LeaderboardRange;
@@ -171,7 +175,17 @@ export function formatRankPosition(rank: number | null | undefined): string {
   if (rank === null || rank === undefined || !Number.isFinite(rank) || rank < 1) {
     return '—';
   }
-  return rank > 99 ? '> 99' : String(Math.floor(rank));
+  return String(Math.floor(rank));
+}
+
+/** Put the current user at the top of the list while keeping their Top N row. */
+export function pinCurrentUserRows(
+  rows: readonly LeaderboardRow[],
+  currentUser: LeaderboardRow | null,
+): Array<{ pinned: boolean; row: LeaderboardRow }> {
+  const listed = rows.map((row) => ({ pinned: false, row }));
+  if (!currentUser) return listed;
+  return [{ pinned: true, row: currentUser }, ...listed];
 }
 
 export function leaderboardMetricLabel(metric: LeaderboardMetric): string {


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [x] Web

Rank 页是 Web 专用（CLI 会把 `/rank` 重定向到用量页）。CLI / local-api 会把默认 `limit` 从 50 提到 100。Desktop renderer 没有 Rank 页副本，未改。

### 🔗 关联 Issue

排行榜需要展示前 100，并始终能看到自己的真实名次（即使不在 Top N 内）。

### 💡 改动说明

1. 公开榜原先只展示前 50，且自己不在 Top N 时前端看不到名次。
2. `LEADERBOARD_DEFAULT_LIMIT` 改为 100；列表顶部置顶「我」，榜内原位置仍保留。名次不再截成 `> 99`。隐藏自己 / 未登录不置顶。
3. 服务端全量计名次并返回 `currentUser` 在 **ai-usage** 仓库，本 PR 只覆盖 core 常量与 dashboard UI，需与那边一起上线。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 公开排行榜默认条数改为前 100。 |
| `@juejin-opensource/jusage-dashboard` | minor | 排行榜公开榜扩到前 100，并在列表顶部置顶展示自己的真实名次。 |

### ☑️ 自查清单

- [ ] 分支命名符合 `<type>/<end>/<short-desc>`（当前为已有分支 `feature/rank-support-100`）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改（renderer 无 Rank 页副本）
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [ ] `pnpm build` 通过

## Test plan

- [x] 登录后在前 100 内：列表置顶「我」，原位置仍有一条
- [x] 登录后在 100 名以外：只置顶「我」，展示真实名次
- [x] 打开「隐藏自己」：不置顶、不展示个人名次
- [x] 未登录：无置顶行；分享卡显示「登录后查看」