### PR TITLE
fix(desktop): keep tray hourly axis labels from clipping

### DIFF
--- a/.changeset/tray-hourly-axis-clip.md
+++ b/.changeset/tray-hourly-axis-clip.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 macOS 系统托盘用量弹窗中，小时趋势图最左侧横坐标（如 0h）被裁切显示不全的问题。

--- a/apps/desktop/src/renderer/components/TrayTrendChart.tsx
+++ b/apps/desktop/src/renderer/components/TrayTrendChart.tsx
@@ -104,7 +104,8 @@ export function TrayTrendChart({
             <ComposedChart
               accessibilityLayer
               data={rows}
-              margin={{ top: 8, right: 4, bottom: 0, left: -8 }}
+              // Hidden Y axis has no gutter; a negative left margin clips "0h".
+              margin={{ top: 8, right: 12, bottom: 0, left: 12 }}
             >
               {metric === 'cost' ? (
                 <defs>


### PR DESCRIPTION
### 🏷️ 变动类型

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

仅 macOS 系统托盘用量弹窗里的趋势图。`TrayTrendChart` 只存在于 Desktop，Dashboard 无同名副本。

### 🔗 关联 Issue

自己点系统托盘时踩到的：选「今天」后，小时趋势图最左侧横坐标 `0h` 被卡片裁切，只剩半个字。

### 💡 改动说明

托盘图隐藏了 Y 轴，又把 Recharts `margin.left` 设成 `-8`，想把柱子贴到卡片左缘。Recharts 3 隐藏轴不再预留槽位，第一个刻度（`0h`）就被画到 SVG 外面，卡片 `overflow-hidden` 再把它切掉。

现在左右边距改为正的 12px，让首尾刻度留在 SVG 里。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 修复 macOS 系统托盘用量弹窗中，小时趋势图最左侧横坐标（如 0h）被裁切显示不全的问题。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [ ] `pnpm build` 通过