### PR TITLE
fix(desktop): keep tray 30d and 90d axis labels readable

### DIFF
--- a/.changeset/tray-daily-axis-labels.md
+++ b/.changeset/tray-daily-axis-labels.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+---
+
+修复 macOS 系统托盘用量弹窗在 30 天 / 90 天范围下，每日趋势图横坐标被裁切或互相重叠的问题。

--- a/apps/desktop/src/renderer/components/TrayTrendChart.tsx
+++ b/apps/desktop/src/renderer/components/TrayTrendChart.tsx
@@ -104,8 +104,12 @@ export function TrayTrendChart({
             <ComposedChart
               accessibilityLayer
               data={rows}
-              // Hidden Y axis has no gutter; a negative left margin clips "0h".
-              margin={{ top: 8, right: 12, bottom: 0, left: 12 }}
+              // Hidden Y axis has no gutter; daily range labels need extra side room.
+              margin={
+                isHourly
+                  ? { top: 8, right: 12, bottom: 0, left: 12 }
+                  : { top: 8, right: 22, bottom: 0, left: 22 }
+              }
             >
               {metric === 'cost' ? (
                 <defs>
@@ -127,9 +131,9 @@ export function TrayTrendChart({
                 axisLine={false}
                 dataKey="label"
                 interval={xAxisInterval}
+                tick={{ fontSize: isHourly ? 13 : 11 }}
                 tickLine={false}
                 tickMargin={8}
-                tick={{ fontSize: 13 }}
               />
               <YAxis allowDataOverflow hide />
               <ChartTooltip
@@ -246,12 +250,9 @@ function buildTrendPoints({
     const value = metric === 'tokens'
       ? totalTokens
       : bucket.reduce((total, row) => total + row.costUsd, 0);
-    const firstLabel = formatDate(first.date);
-    const lastLabel = formatDate(last.date);
-    const label = first.date === last.date ? firstLabel : `${firstLabel}–${lastLabel}`;
     points.push({
-      label,
-      tooltipLabel: label,
+      label: formatBucketLabel(first.date, last.date),
+      tooltipLabel: formatBucketTooltip(first.date, last.date),
       value,
       ...tokenBreakdown({ totalTokens, inputTokens, cachedInputTokens, outputTokens }),
     });
@@ -400,4 +401,21 @@ function TokenTooltipRow({
 function formatDate(date: string): string {
   const [, month = '', day = ''] = date.slice(0, 10).split('-');
   return `${Number(month)}/${Number(day)}`;
+}
+
+/** Compact axis label: `8/10–11` when the bucket stays in the same month. */
+function formatBucketLabel(firstDate: string, lastDate: string): string {
+  const firstLabel = formatDate(firstDate);
+  const lastLabel = formatDate(lastDate);
+  if (firstDate === lastDate) return firstLabel;
+  const [firstMonth] = firstLabel.split('/');
+  const [lastMonth, lastDay = ''] = lastLabel.split('/');
+  if (firstMonth === lastMonth) return `${firstLabel}–${lastDay}`;
+  return `${firstLabel}–${lastLabel}`;
+}
+
+function formatBucketTooltip(firstDate: string, lastDate: string): string {
+  const firstLabel = formatDate(firstDate);
+  const lastLabel = formatDate(lastDate);
+  return firstDate === lastDate ? firstLabel : `${firstLabel}–${lastLabel}`;
 }


### PR DESCRIPTION
### 🏷️ 变动类型

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [x] Desktop
- [ ] CLI
- [ ] Web

仅 macOS 系统托盘用量弹窗里的趋势图。`TrayTrendChart` 只存在于 Desktop，Dashboard 无同名副本。

### 🔗 关联 Issue

#100 修了「今天」最左侧 `0h` 被裁切。30 天 / 90 天范围下，每日趋势图仍会裁切，并且相邻日期会叠在一起。

### 💡 改动说明

原来 30 / 90 天大约展示 5 个横坐标（例如 `8/10-8/11`、`8/14-8/15` …）。托盘只有约 420px 宽，完整写成 `8/10–8/11` 时第一个和最后一个会被卡片裁掉，中间的也会挤成 `8/10-8/118/14-8/15`。

刻度数量保持原来的约 5 个，不抽稀。同月的区间在轴上写成 `8/10–11`，跨月仍写 `8/29–9/2`；悬停 tooltip 仍显示完整区间。日维度字号改为 11，并给左右多留一点边距。

「今天」和 7 天的刻度数量、内容不变。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 修复 macOS 系统托盘用量弹窗在 30 天 / 90 天范围下，每日趋势图横坐标被裁切或互相重叠的问题。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [ ] `pnpm build` 通过