### PR TITLE
fix(cli): Windows 注册开机自启失败的引导与降级

### DIFF
--- a/.changeset/windows-autostart-permission.md
+++ b/.changeset/windows-autostart-permission.md
@@ -1,0 +1,7 @@
+---
+'@juejin-opensource/jusage': patch
+---
+
+- Windows 下 `jusage service start` 注册开机自启因缺少管理员权限失败（0x80070005）时，给出「以管理员身份运行终端」/「改用 `jusage start` 前台运行」的明确指引，不再只抛 PowerShell 原始报错。
+- 服务已在运行时补注册自启失败不再中断命令：降级为警告提示（服务运行不受影响）。
+- CLI.md 补充 Windows 需在管理员终端运行以注册开机自启的说明。

--- a/CLI.md
+++ b/CLI.md
@@ -37,6 +37,8 @@ jusage service start
 
 Linux 后台服务依赖 systemd 用户实例（`systemctl --user`）。无 systemd 时改用 `jusage start` 前台运行。
 
+Windows 注册开机自启需要管理员权限：建议在「以管理员身份运行」的终端中执行 `jusage service start`。普通终端执行时服务可正常启动，但会提示自启注册失败（仅自启不可用）。
+
 首次启动会写入数据目录 `~/.ai-usage/`，尝试注册 Claude / Codex Hook，并同步本地用量。
 
 常用管理：

--- a/packages/cli/src/service-windows.ts
+++ b/packages/cli/src/service-windows.ts
@@ -50,7 +50,13 @@ Start-ScheduledTask -TaskName $taskName
 
   const result = runPowerShell(script);
   if (!result.ok) {
-    throw new Error(`注册 Windows 自启失败: ${result.stderr || result.stdout || 'PowerShell 返回非零'}`);
+    const raw = result.stderr || result.stdout || 'PowerShell 返回非零';
+    if (/0x80070005|拒绝访问|Access is denied|PermissionDenied/i.test(raw)) {
+      throw new Error(
+        '注册 Windows 开机自启需要管理员权限:请右键「以管理员身份运行」终端后重新执行 `jusage service start`(服务已在运行时会自动补注册自启);或改用 `jusage start` 前台运行(无开机自启)',
+      );
+    }
+    throw new Error(`注册 Windows 开机自启失败: ${raw}`);
   }
 }
 

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -75,6 +75,23 @@ async function unregisterAutostart(): Promise<void> {
   await unregisterLinuxAutostart();
 }
 
+/**
+ * Re-register autostart while the service is already running.
+ * On failure warn and continue (the running service is unaffected), so a
+ * non-elevated Windows terminal does not abort `service start`.
+ */
+async function registerAutostartOrWarn(cliBinPath: string, dataDir: string): Promise<boolean> {
+  try {
+    await registerAutostart(cliBinPath, dataDir);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`  ⚠️ 开机自启注册失败: ${message}`);
+    console.warn('  服务运行不受影响;如需开机自启,请修复上述问题后重新执行 `jusage service start`。');
+    return false;
+  }
+}
+
 export async function cmdServiceStart(
   cliBinPath: string,
   daysAgo?: number,
@@ -114,9 +131,11 @@ async function cmdServiceStartBody(
     const who = runtimeKindLabel(existing.kind);
     const registered = await isAutostartRegistered();
     if (!registered) {
-      await registerAutostart(cliBinPath, dir);
+      const autostartRegistered = await registerAutostartOrWarn(cliBinPath, dir);
       console.log(
-        `服务已在运行（${who} pid ${existing.pid}），已补注册开机自启`,
+        autostartRegistered
+          ? `服务已在运行（${who} pid ${existing.pid}），已补注册开机自启`
+          : `服务已在运行（${who} pid ${existing.pid}，开机自启未注册）`,
       );
     } else {
       console.log(`服务已在运行（${who} pid ${existing.pid}）`);
@@ -129,7 +148,7 @@ async function cmdServiceStartBody(
     return;
   }
 
-  await registerAutostart(cliBinPath, dir);
+  const autostartRegistered = await registerAutostart(cliBinPath, dir);
   const port = config.serverPort || DEFAULT_PORT;
   const host = config.serverHost || DEFAULT_HOST;
   const ready = await waitForServiceReady(dir, port, host);


### PR DESCRIPTION
### 关联 Issue
Related to #106(Windows 普通终端 `jusage service start` 注册自启报 0x80070005,错误无引导)。

### 改动说明
1. `packages/cli/src/service-windows.ts`:注册 Windows 开机自启失败且命中权限错误(`0x80070005` / `拒绝访问` / `Access is denied` / `PermissionDenied`)时,错误信息直接指引「以管理员身份运行终端重试 `jusage service start`」或「改用 `jusage start` 前台运行」,不再只抛 PowerShell 原始 CimException。
2. `packages/cli/src/service.ts`:服务**已在运行**时补注册自启失败不再中断命令——新增 `registerAutostartOrWarn()`,降级为警告并继续打印运行状态(运行中的服务不受影响)。首次从停止状态启动的路径保持不变:该路径依赖 autostart 机制(计划任务/systemd/launchctl)拉起守护进程,失败仍需明确报错引导,避免用户误以为服务已后台运行。
3. `CLI.md`:补充 Windows 需在管理员终端运行以注册开机自启的说明。
4. 新增 changeset(patch)。

### 测试
- [x] TypeScript 语法/局部类型校验通过(`tsc --noEmit`,仅剩跨包模块解析告警,依赖仓库安装)
- [ ] 全量 `pnpm build` 与 Windows 真机验证依赖 CI(本地网络受限未全量安装依赖;复现与管理员对照验证见 #106)

### 影响面
仅 CLI(`packages/cli`)与根文档,不涉及 Desktop / Web / Dashboard。
