### PR TITLE
fix(cli): Windows 注册开机自启失败的引导与降级

### DIFF
--- a/.changeset/windows-autostart-permission.md
+++ b/.changeset/windows-autostart-permission.md
@@ -1,0 +1,7 @@
+---
+'@juejin-opensource/jusage': patch
+---
+
+- Windows 下 `jusage service start` 注册开机自启因缺少管理员权限失败（0x80070005）时，给出「以管理员身份运行终端」/「改用 `jusage start` 前台运行」的明确指引，不再只抛 PowerShell 原始报错。
+- 服务已在运行时补注册自启失败不再中断命令：降级为警告提示（服务运行不受影响）。
+- CLI.md 补充 Windows 需在管理员终端运行以注册开机自启的说明。

--- a/CLI.md
+++ b/CLI.md
@@ -37,6 +37,8 @@ jusage service start
 
 Linux 后台服务依赖 systemd 用户实例（`systemctl --user`）。无 systemd 时改用 `jusage start` 前台运行。
 
+Windows 注册开机自启需要管理员权限：建议在「以管理员身份运行」的终端中执行 `jusage service start`。普通终端执行时服务可正常启动，但会提示自启注册失败（仅自启不可用）。
+
 首次启动会写入数据目录 `~/.ai-usage/`，尝试注册 Claude / Codex Hook，并同步本地用量。
 
 常用管理：

--- a/packages/cli/src/service-windows.ts
+++ b/packages/cli/src/service-windows.ts
@@ -50,7 +50,13 @@ Start-ScheduledTask -TaskName $taskName
 
   const result = runPowerShell(script);
   if (!result.ok) {
-    throw new Error(`注册 Windows 自启失败: ${result.stderr || result.stdout || 'PowerShell 返回非零'}`);
+    const raw = result.stderr || result.stdout || 'PowerShell 返回非零';
+    if (/0x80070005|拒绝访问|Access is denied|PermissionDenied/i.test(raw)) {
+      throw new Error(
+        '注册 Windows 开机自启需要管理员权限:请右键「以管理员身份运行」终端后重新执行 `jusage service start`(服务已在运行时会自动补注册自启);或改用 `jusage start` 前台运行(无开机自启)',
+      );
+    }
+    throw new Error(`注册 Windows 开机自启失败: ${raw}`);
   }
 }
 

--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -75,6 +75,23 @@ async function unregisterAutostart(): Promise<void> {
   await unregisterLinuxAutostart();
 }
 
+/**
+ * Re-register autostart while the service is already running.
+ * On failure warn and continue (the running service is unaffected), so a
+ * non-elevated Windows terminal does not abort `service start`.
+ */
+async function registerAutostartOrWarn(cliBinPath: string, dataDir: string): Promise<boolean> {
+  try {
+    await registerAutostart(cliBinPath, dataDir);
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`  ⚠️ 开机自启注册失败: ${message}`);
+    console.warn('  服务运行不受影响;如需开机自启,请修复上述问题后重新执行 `jusage service start`。');
+    return false;
+  }
+}
+
 export async function cmdServiceStart(
   cliBinPath: string,
   daysAgo?: number,
@@ -114,9 +131,11 @@ async function cmdServiceStartBody(
     const who = runtimeKindLabel(existing.kind);
     const registered = await isAutostartRegistered();
     if (!registered) {
-      await registerAutostart(cliBinPath, dir);
+      const autostartRegistered = await registerAutostartOrWarn(cliBinPath, dir);
       console.log(
-        `服务已在运行（${who} pid ${existing.pid}），已补注册开机自启`,
+        autostartRegistered
+          ? `服务已在运行（${who} pid ${existing.pid}），已补注册开机自启`
+          : `服务已在运行（${who} pid ${existing.pid}，开机自启未注册）`,
       );
     } else {
       console.log(`服务已在运行（${who} pid ${existing.pid}）`);
@@ -129,7 +148,7 @@ async function cmdServiceStartBody(
     return;
   }
 
-  await registerAutostart(cliBinPath, dir);
+  const autostartRegistered = await registerAutostart(cliBinPath, dir);
   const port = config.serverPort || DEFAULT_PORT;
   const host = config.serverHost || DEFAULT_HOST;
   const ready = await waitForServiceReady(dir, port, host);


### PR DESCRIPTION
### 🏷️ 变动类型

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [ ] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [x] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [ ] Web

### 🔗 关联 Issue

Part of #106（Windows 普通终端 `jusage service start` 注册自启报 0x80070005、错误无引导、且服务已运行时被整体报错）。

未用 `close/fix` 是考虑到 #106 中"服务未运行时也能无管理员后台启动"的场景受架构限制（守护进程由 autostart 机制拉起）未在本 PR 覆盖，故不自动关闭该 issue。

### 💡 改动说明

**原问题（两个场景）**
1. Windows 普通（未提升）终端下 `Register-ScheduledTask` 必然因缺管理员权限失败，抛原始 PowerShell CimException（0x80070005），用户看不懂也不知道怎么办；
2. 服务**已在运行**时补注册开机自启失败，会让整个 `service start` 命令报错退出——误导用户以为服务挂了。

**这版怎么改**
1. `service-windows.ts`：失败命中权限错误（`0x80070005` / `拒绝访问` / `Access is denied` / `PermissionDenied`）时，错误信息直接引导「以管理员身份运行终端重试 `jusage service start`」或「改用 `jusage start` 前台运行（无开机自启）」；
2. `service.ts`：服务已在运行的分支改用新增的 `registerAutostartOrWarn()`，注册自启失败降级为警告并继续（运行中的服务不受影响）；
3. 服务**未运行**的启动分支保持抛错不降级：该分支的守护进程依赖自启机制（计划任务 / systemd / launchctl）拉起，降级会导致等待 15s 后误报"服务未启动"，故仅受益于第 1 条的可读错误信息；
4. `CLI.md` 补充 Windows 需在管理员终端运行以注册开机自启。

**被否掉的方案**：为普通用户增加"裸进程兜底启动 daemon"。需新增跨三平台的独立启动逻辑并改变"服务由系统托管"语义，改动与风险超出该 UX 修复范围。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | Windows 下 `jusage service start` 注册开机自启因缺管理员权限失败（0x80070005）时，给出「以管理员身份运行终端 / 改用 `jusage start` 前台运行」的明确指引；服务已在运行时补注册自启失败不再中断命令，降级为警告提示。 |
| `@juejin-opensource/jusage-core` | - | 未改动 |
| `@juejin-opensource/jusage-desktop` | - | 未改动 |
| `@juejin-opensource/jusage-dashboard` | - | 未改动 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（`fix/cli/windows-autostart-permission`）
- [ ] 已在受影响的端本地自测通过（本机网络受限未全量 `pnpm install`；已做 TypeScript 语法/类型校验；普通 vs 管理员终端的现象复现与对照见 #106，可据此在本机重测）
- [ ] 若改动了面板 UI：不适用（未改 dashboard / desktop renderer）
- [x] 已执行 `pnpm changeset`（已提交 `.changeset/windows-autostart-permission.md`）
- [ ] `pnpm build` 通过（依赖 CI 复核）
