### PR TITLE
fix(cli): 校验 --port 参数

### DIFF
--- a/.changeset/quiet-mice-check.md
+++ b/.changeset/quiet-mice-check.md
@@ -1,0 +1,5 @@
+---
+'@juejin-opensource/jusage': patch
+---
+
+CLI 现在会在启动前拒绝缺失、非整数或超出范围的 `--port`，不再静默回退或吞掉后续参数。

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -57,6 +57,14 @@ export function normalizeListenHost(raw: string): string {
   return host;
 }
 
+export function normalizeListenPort(raw: string): number {
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`无效的 --port: ${raw}，请输入 1 到 65535 之间的整数`);
+  }
+  return port;
+}
+
 function isFlagToken(value: string | undefined): boolean {
   return value != null && value.startsWith('-') && value !== '-';
 }
@@ -87,8 +95,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--port' && args[i + 1]) {
-      port = Number(args[i + 1]) || DEFAULT_PORT;
+    if (args[i] === '--port') {
+      if (isFlagToken(args[i + 1]) || args[i + 1] == null) {
+        throw new Error('--port 需要端口号，例如 8452');
+      }
+      port = normalizeListenPort(args[i + 1]);
       i += 1;
     } else if (args[i] === '--host') {
       if (isFlagToken(args[i + 1]) || args[i + 1] == null) {

--- a/packages/cli/test/args.test.js
+++ b/packages/cli/test/args.test.js
@@ -5,6 +5,7 @@ import {
   formatListenUrl,
   formatSyncSourceList,
   normalizeListenHost,
+  normalizeListenPort,
   parseArgs,
   resolveSyncSource,
 } from '../dist/args.js';
@@ -49,6 +50,21 @@ test('normalizeListenHost rejects empty or path-like values', () => {
 
 test('parseArgs throws when --host has no value', () => {
   assert.throws(() => parseArgs(['node', 'jusage', 'start', '--host']), /需要地址/);
+});
+
+test('normalizeListenPort accepts only valid TCP port integers', () => {
+  assert.equal(normalizeListenPort('8452'), 8452);
+  assert.throws(() => normalizeListenPort('abc'), /无效的 --port/);
+  assert.throws(() => normalizeListenPort('1.5'), /无效的 --port/);
+  assert.throws(() => normalizeListenPort('0'), /无效的 --port/);
+  assert.throws(() => normalizeListenPort('65536'), /无效的 --port/);
+});
+
+test('parseArgs rejects a missing --port value without consuming the next flag', () => {
+  assert.throws(
+    () => parseArgs(['node', 'jusage', 'start', '--port', '--host', '0.0.0.0']),
+    /--port 需要端口号/,
+  );
 });
 
 test('formatListenUrl maps wildcard bind to loopback', () => {


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [ ] Web

### 🔗 关联 Issue

Fixes #111

### 💡 改动说明

#### 问题与根因

`--port` 原来使用 `Number(value) || DEFAULT_PORT` 解析。非数字因此静默回退为 8452，超出 TCP 端口范围的数字没有被拒绝；缺失参数值时，下一个 flag 还会被当成值吞掉。

#### 修复

- 增加集中式端口校验，只接受 1–65535 范围内的整数；
- 在 `--port` 缺值或后续 token 是另一个 flag 时立即给出明确错误；
- 增加非法数字、小数、零、越界及缺值回归测试；
- 合法端口及现有 host 解析行为不变。

### 🧪 Before / after 与验证

修复前的最小行为验证：

- `--port abc` → 静默得到 8452；
- `--port 70000` → 解析器接受非法端口；
- `--port --host 0.0.0.0` → 吞掉 `--host` 并静默得到 8452。

修复后，相同输入均在启动前给出中文 `--port` 错误；`--port 9000 --host 0.0.0.0` 仍正确解析。

执行结果：

- `corepack pnpm --filter @juejin-opensource/jusage test`：15/15 通过；
- CLI 行为 harness：三类非法输入均被拒绝，合法组合保持正常；
- `corepack pnpm build:cli`：通过；
- `git diff --check`：通过。

### 🛡️ 风险与范围

改动仅位于 CLI 参数解析和对应单元测试，不涉及 Desktop、Web、数据格式、网络请求或迁移。行为变化只影响此前无效或歧义的 `--port` 输入。

### 🚫 未测试

- 未运行 Desktop/Web 的端到端测试；本改动不触及这些端。
- 未运行仓库全量 `pnpm build`；已运行受影响范围的 `build:cli`（包含 core、dashboard 和 CLI 构建）。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | CLI 现在会在启动前拒绝缺失、非整数或超出范围的 `--port`，不再静默回退或吞掉后续参数。 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端本地自测通过
- [x] 未改动面板 UI，无需同步两份 renderer
- [x] 已添加 changeset
- [ ] 已执行仓库全量 `pnpm build`（已通过 `pnpm build:cli`）
