### PR TITLE
fix(cli): 修掉 service.ts 未使用变量，恢复 main 的 pnpm build 与 CLI 测试

### DIFF
--- a/packages/cli/src/service.ts
+++ b/packages/cli/src/service.ts
@@ -148,7 +148,7 @@ async function cmdServiceStartBody(
     return;
   }
 
-  const autostartRegistered = await registerAutostart(cliBinPath, dir);
+  await registerAutostart(cliBinPath, dir);
   const port = config.serverPort || DEFAULT_PORT;
   const host = config.serverHost || DEFAULT_HOST;
   const ready = await waitForServiceReady(dir, port, host);


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复
- [ ] 📦 构建 / 打包 / 依赖

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [ ] Web

### 🔗 关联 Issue

close #123

### 💡 改动说明

**1. 原来有什么问题**

`main`（当前 `d69aafd`）编译不过：

```text
packages/cli build: src/service.ts(151,9): error TS6133: 'autostartRegistered' is declared but its value is never read.
[ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL] @juejin-opensource/jusage@0.1.9 build: `tsc -p tsconfig.json && node ./scripts/copy-dashboard.mjs`
```

从 `f0c7b9f`（2026-09-08，PR #108）起中断，到现在两天。连带打断三条链路：

- `pnpm build` / `pnpm build:cli` 失败；
- `packages/cli` 的 `test` 脚本是 `tsc -p tsconfig.json && node --test ...`，**CLI 测试当前一条都跑不起来**；
- `pnpm release` 里第一步就是 `pnpm build:cli`，下次发版前必须先修。

已发布的 v0.1.9 产物不受影响：版本号提交 `0d0b7f1` 在断点之前。

**2. 根因**

PR #108 把「服务已在运行」那一处的 `registerAutostart()` 换成了新的 `registerAutostartOrWarn()`（返回 `boolean`，用来区分「已补注册」和「注册失败」两句提示）。首次启动那一处也被顺手加上了 `const autostartRegistered =`，但调用的仍然是原来的 `registerAutostart()` —— 签名是 `Promise<void>`，返回值不存在，这个变量也从头到尾没被读过：下面打印的是写死的 `开机自启: 已注册`。

`tsconfig.base.json` 开了 `noUnusedLocals: true`，所以这是编译期硬错误，不是 lint 警告，任何 TS 5.x 都会报（本地 5.9.3 实测）。

**3. 这版怎么改的**

删掉那个绑定，恢复成 `await registerAutostart(cliBinPath, dir)`，一行。

考虑过另一种改法：把首次启动那一处也换成 `registerAutostartOrWarn()`，再用返回值把 `开机自启: 已注册` 改成条件文案。**没有这么做**，因为两处的语义本来就不同 —— 服务已在运行时注册失败可以只告警继续（PR #108 的原意），而首次启动路径下面紧跟着的错误分支写的是「自启已注册，但进程未在预期时间内启动」，整段逻辑依赖注册失败时直接抛错。把它降级成告警是行为变更，不该混在一个「修构建」的 PR 里。所以这里只做最小修复，行为零变化。

**验证**

```text
# 修复前（origin/main 原样）
$ npx tsc -p packages/cli/tsconfig.json
src/service.ts(151,9): error TS6133: 'autostartRegistered' is declared but its value is never read.

# 本分支
$ pnpm -r build
packages/cli build: Copied dashboard dist → .../packages/cli/dist/dashboard
packages/cli build: Done

$ pnpm --filter @juejin-opensource/jusage test
ℹ tests 13   ℹ pass 13   ℹ fail 0        # 修复前这条命令连 tsc 都过不去

$ pnpm --filter @juejin-opensource/jusage-core test
ℹ tests 287  ℹ pass 287  ℹ fail 0

$ pnpm --filter @juejin-opensource/jusage-dashboard test
ℹ tests 71   ℹ pass 71   ℹ fail 0
```

### 📝 Changelog

无需 changeset：只删掉一个没被读过的变量绑定，运行时行为零变化，且 v0.1.9 的已发布产物本来就不含这个错误，用户侧无可感知的变化。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（`fix/cli/service-start-build-break`）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：本次未改 UI
- [x] 已执行 `pnpm changeset`（本次按上面说明跳过）
- [x] `pnpm build` 通过

---

**顺带一提**：仓库 `.github/workflows/` 下目前只有 `sync-release.yml`（release published 时同步 Gitee 元数据），**没有任何 `pull_request` / `push` 触发的 build + test 门禁**。所以这次是合进 `main` 两天、靠本地手动 `pnpm build` 才发现的。我可以另开一个 PR 补一条最小 CI（`pnpm install` → `pnpm build` → core / cli / dashboard / desktop 四个包的 `test`），要不要做、跑哪些 OS，请维护者定个调子我再提。
