### PR TITLE
ci: 补 PR / main 的构建与测试门禁（build + typecheck + 四个包的测试）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: ✅ CI
+
+# PR 与 main 的构建 / 测试门禁。
+# 只跑 CONTRIBUTING.md 已经要求本地跑的那几条命令，不新增工具链。
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# 同一分支上新推的 commit 取消上一次还在跑的 CI；main 上的不取消，保留完整历史。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: 构建与测试
+    # 暂时跑 macOS：packages/core 有 6 个用例的 fixture 写死了 macOS 的
+    # ~/Library/Application Support 布局（Claude Desktop / Qoder IDE / Trae），
+    # 在 Linux、Windows 上必红。等那几个用例改成跟着平台走，这里就能换成
+    # ubuntu-latest 或 [ubuntu-latest, macos-latest, windows-latest] 矩阵。
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # 版本取自根 package.json 的 packageManager 字段，不在这里重复写死。
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          # packages/dashboard 的测试用 node --experimental-strip-types 直接跑 .ts，
+          # 需要 >= 22.6；仓库 engines 声明的 >=20 是给已发布产物的运行时用的。
+          node-version: 22
+          cache: pnpm
+
+      # 不要设 ELECTRON_SKIP_BINARY_DOWNLOAD：electron/install.js 只判断变量存不存在
+      # （连 =0 都算跳过），而 apps/desktop 的测试要 require('electron') 拿到真实路径。
+      - name: 安装依赖
+        run: pnpm install --frozen-lockfile
+
+      - name: 构建全部包
+        run: pnpm build
+
+      # electron-vite 走 esbuild，只剥类型不做类型检查，桌面端的 tsc 要单独跑。
+      - name: 类型检查（desktop）
+        run: pnpm --filter @juejin-opensource/jusage-desktop typecheck
+
+      # 四个包分开跑，红的时候一眼能看出是哪个包。
+      - name: 测试 core
+        run: pnpm --filter @juejin-opensource/jusage-core test
+
+      - name: 测试 cli
+        run: pnpm --filter @juejin-opensource/jusage test
+
+      - name: 测试 dashboard
+        run: pnpm --filter @juejin-opensource/jusage-dashboard test
+
+      - name: 测试 desktop
+        run: pnpm --filter @juejin-opensource/jusage-desktop test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,9 @@ PR 会自动带出模板，按模板填完即可。几个容易踩的点：
 - **带上 changeset。** 影响用户的改动都要跑 `pnpm changeset`，并把生成的文件一起提交；纯文档 / CI 改动可跳过。描述写「对用户的影响」而非实现方式，详见 [发版与里程碑规范](./RELEASE.md#changeset-怎么写)。
 - **改了面板 UI 要看两处。** `packages/dashboard/src` 与 `apps/desktop/src/renderer` 是同构但独立的两份代码，改一处时确认另一处是否需要同步。
 - **跨端改动**在 PR 正文写清影响范围。
-- 合并前确保 `pnpm build` 通过。
+- 合并前确保 `pnpm build` 和 `pnpm test` 通过。`pnpm test` 会先构建再跑四个包的测试；只想跑单个包时用 `pnpm --filter @juejin-opensource/jusage-core test`（把包名换成 `jusage` / `jusage-dashboard` / `jusage-desktop` 即可）。
+
+PR 推上来后 CI（`.github/workflows/ci.yml`）会在 Ubuntu + Node 22 上跑同一套命令：`pnpm build` → 桌面端 `typecheck` → 四个包的测试。CI 红了先看是哪个包哪一步挂的，本地用上面对应的 `--filter` 命令复现。
 
 ## 按端启动
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "pnpm -r build",
     "build:packages": "pnpm --filter \"./packages/**\" -r build",
     "build:cli": "pnpm --filter @juejin-opensource/jusage... build",
+    "test": "pnpm build && pnpm -r --if-present test",
     "start": "pnpm start:cli",
     "start:cli": "pnpm build:cli && pnpm --filter @juejin-opensource/jusage start",
     "dev:cli": "pnpm build:cli && node scripts/run-parallel.mjs dev:cli:api dev:cli:ui",


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] ⏩ 工作流 / CI

### 🖥️ 影响范围

- [ ] Desktop
- [ ] CLI
- [ ] Web

（不改运行时代码，只加 CI + 一个根 `test` 脚本 + CONTRIBUTING 两行。）

### 🔗 关联 Issue

关联 #123 / #124。

`.github/workflows/` 下目前只有 `sync-release.yml`（release published 时同步 Gitee 元数据），**没有任何 `pull_request` / `push` 触发的门禁**，所以合进 `main` 的东西没有任何自动信号。#123 就是这么来的：`packages/cli` 从 2026-09-08 起编译不过，`pnpm build`、`pnpm build:cli`、CLI 的 `test` 脚本、`pnpm release` 一起挂，两天没人发现，最后是本地手跑 `pnpm build` 才撞出来的。

### 💡 改动说明

**1. 加了什么**

`.github/workflows/ci.yml`，在 `pull_request → main`、`push → main` 和手动 `workflow_dispatch` 时跑：

```text
pnpm install --frozen-lockfile
pnpm build                                  # 四个包，含 apps/desktop
pnpm --filter ...jusage-desktop typecheck   # electron-vite 走 esbuild 只剥类型，不做类型检查
pnpm --filter ...jusage-core      test
pnpm --filter ...jusage           test
pnpm --filter ...jusage-dashboard test
pnpm --filter ...jusage-desktop   test
```

全是 CONTRIBUTING.md 已经要求本地跑的命令，**没有引入任何新工具链**（不加 lint、不加覆盖率、不加 action 之外的第三方依赖）。四个包分开成四个 step，红的时候在 Actions 列表里一眼能看出是哪个包挂的。

顺带加了根 `pnpm test`（`pnpm build && pnpm -r --if-present test`），CONTRIBUTING 里补了两行说明 —— 之前没有「一条命令跑完所有测试」的入口，新人也不知道 CI 会跑什么。

**2. 几个当时踩到的点，写在这里省得后面再踩**

- **`runs-on` 暂时用 `macos-latest`，不是 ubuntu。** 我第一版写的是 `ubuntu-latest`，实测 `packages/core` 有 6 个用例必红：

  ```text
  not ok 29  - claudeDesktopProjectsDirs finds local-agent .claude/projects
  not ok 30  - parseClaudeIncremental reads Desktop local-agent JSONL
  not ok 38  - claudeDesktopProjectsDirs finds claude-code-sessions projects
  not ok 177 - parseClaudeIncremental tags cli vs desktop collectors
  not ok 178 - parseQoderIncremental reads IDE local.db with collector split
  not ok 180 - parseTraeIncremental skips when encrypted DB exists but key missing
  ```

  产品代码本身是分平台的（`paths.ts` 里 `claudeDesktopAppSupportRoots()` / `cursorAppDir()` / `appSupportBase()` 都有 darwin / win32 / linux 三个分支），**是这几个用例的 fixture 把 macOS 的 `~/Library/Application Support` 布局写死了**，所以只覆盖到 darwin 分支，在 Linux / Windows 上找不到文件。

  换句话说：**现在 Linux / Windows 上的贡献者本地跑 `pnpm test` 就是红的**，而且分不清是自己改坏了还是本来就红。这是个独立问题，我另开 issue + PR 把那几个 fixture 改成跟着平台走，修完这里就能换成 `ubuntu-latest`（更快更省）或者 `[ubuntu, macos, windows]` 矩阵。这版先保证门禁能立刻绿、立刻起作用。

- **Node 用 22。** `packages/dashboard` 的 `test` 脚本是 `node --experimental-strip-types` 直接跑 `.ts`，需要 >= 22.6。`engines.node: >=20` 说的是已发布产物的运行时，不是测试工具链，两回事。

- **不要设 `ELECTRON_SKIP_BINARY_DOWNLOAD`。** `electron/install.js` 是 `if (process.env.ELECTRON_SKIP_BINARY_DOWNLOAD)`，**只判断变量存不存在**，写 `=0` 一样跳过下载；而 `apps/desktop` 的测试要 `require('electron')` 拿真实路径（`dist-test/main/auto-update.test.js` 靠替换 `require.cache` 打桩），跳过下载就直接抛 `Electron failed to install correctly`。已在文件里写了注释，免得后面有人「优化」掉。

- action 都用了 Node 24 的大版本（`checkout@v7` / `setup-node@v7` / `pnpm/action-setup@v6`）。第一版用 v4 时 Actions 会报 `Node.js 20 is deprecated` 的 annotation。pnpm 版本从根 `package.json` 的 `packageManager` 字段读，不在 workflow 里重复写死。

**3. 已实测**

在我 fork 上开 PR 真跑过（不是纸上推演）：<https://github.com/ChenCJ-io/juejin-usage/actions/runs/34433926047>

```text
✓ 构建与测试 in 2m23s
  ✓ 安装依赖   ✓ 构建全部包   ✓ 类型检查（desktop）
  ✓ 测试 core  ✓ 测试 cli     ✓ 测试 dashboard   ✓ 测试 desktop
```

core 287 项、cli 13 项、dashboard 71 项、desktop 14 项全过，无 annotation。

**4. 关于本 PR 的第一个 commit**

本分支基于 #124。因为 `pull_request` 事件跑的是 head 合进 base 的结果，而 `main` 现在编译不过，不带上那一行修复的话本 PR 自己的 CI 就是红的（这也算是个现场演示）。**#124 先合的话我 rebase 掉那个 commit，本 PR 就只剩 CI 这一个 commit。**

### 📝 Changelog

无需 changeset：纯 CI / 文档改动，不影响任何已发布产物。

### ☑️ 自查清单

- [x] 分支命名符合规范（`chore/ci-build-test-gate`）
- [x] 已在受影响的端本地自测通过（并在 fork 上真跑了一遍 Actions）
- [x] 若改动了面板 UI：本次未改 UI
- [x] 已执行 `pnpm changeset`（纯 CI 改动按 CONTRIBUTING 跳过）
- [x] `pnpm build` 通过

---

如果对形态有别的想法（比如想先只跑 build 不跑 test、想加 lint、想换 self-hosted、或者干脆想要矩阵），说一声我改，这版是按「最小、立刻能绿、不引入新工具链」的口径写的。
