### PR TITLE
test(core): 修掉只在 macOS 通过的 fixture + 给两条整轮 sync 用例上沙箱（CI 转双平台矩阵，套件 64s → 1.4s）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,15 @@ permissions:
 
 jobs:
   build-and-test:
-    name: 构建与测试
-    # 暂时跑 macOS：packages/core 有 6 个用例的 fixture 写死了 macOS 的
-    # ~/Library/Application Support 布局（Claude Desktop / Qoder IDE / Trae），
-    # 在 Linux、Windows 上必红。等那几个用例改成跟着平台走，这里就能换成
-    # ubuntu-latest 或 [ubuntu-latest, macos-latest, windows-latest] 矩阵。
-    runs-on: macos-latest
+    name: 构建与测试 (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # windows-latest 还进不来：core 另有 7 个与本仓库路径无关的用例在 Windows 上
+        # 挂（config 原子写 rename EPERM、kilocode/roocode 的 roots、runtime-pid 一组），
+        # 已单独记 issue。修完再往这里加一行。
+        os: [ubuntu-latest, macos-latest]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: ✅ CI
+
+# PR 与 main 的构建 / 测试门禁。
+# 只跑 CONTRIBUTING.md 已经要求本地跑的那几条命令，不新增工具链。
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# 同一分支上新推的 commit 取消上一次还在跑的 CI；main 上的不取消，保留完整历史。
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: 构建与测试
+    # 暂时跑 macOS：packages/core 有 6 个用例的 fixture 写死了 macOS 的
+    # ~/Library/Application Support 布局（Claude Desktop / Qoder IDE / Trae），
+    # 在 Linux、Windows 上必红。等那几个用例改成跟着平台走，这里就能换成
+    # ubuntu-latest 或 [ubuntu-latest, macos-latest, windows-latest] 矩阵。
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # 版本取自根 package.json 的 packageManager 字段，不在这里重复写死。
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          # packages/dashboard 的测试用 node --experimental-strip-types 直接跑 .ts，
+          # 需要 >= 22.6；仓库 engines 声明的 >=20 是给已发布产物的运行时用的。
+          node-version: 22
+          cache: pnpm
+
+      # 不要设 ELECTRON_SKIP_BINARY_DOWNLOAD：electron/install.js 只判断变量存不存在
+      # （连 =0 都算跳过），而 apps/desktop 的测试要 require('electron') 拿到真实路径。
+      - name: 安装依赖
+        run: pnpm install --frozen-lockfile
+
+      - name: 构建全部包
+        run: pnpm build
+
+      # electron-vite 走 esbuild，只剥类型不做类型检查，桌面端的 tsc 要单独跑。
+      - name: 类型检查（desktop）
+        run: pnpm --filter @juejin-opensource/jusage-desktop typecheck
+
+      # 四个包分开跑，红的时候一眼能看出是哪个包。
+      - name: 测试 core
+        run: pnpm --filter @juejin-opensource/jusage-core test
+
+      - name: 测试 cli
+        run: pnpm --filter @juejin-opensource/jusage test
+
+      - name: 测试 dashboard
+        run: pnpm --filter @juejin-opensource/jusage-dashboard test
+
+      - name: 测试 desktop
+        run: pnpm --filter @juejin-opensource/jusage-desktop test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,9 @@ PR 会自动带出模板，按模板填完即可。几个容易踩的点：
 - **带上 changeset。** 影响用户的改动都要跑 `pnpm changeset`，并把生成的文件一起提交；纯文档 / CI 改动可跳过。描述写「对用户的影响」而非实现方式，详见 [发版与里程碑规范](./RELEASE.md#changeset-怎么写)。
 - **改了面板 UI 要看两处。** `packages/dashboard/src` 与 `apps/desktop/src/renderer` 是同构但独立的两份代码，改一处时确认另一处是否需要同步。
 - **跨端改动**在 PR 正文写清影响范围。
-- 合并前确保 `pnpm build` 通过。
+- 合并前确保 `pnpm build` 和 `pnpm test` 通过。`pnpm test` 会先构建再跑四个包的测试；只想跑单个包时用 `pnpm --filter @juejin-opensource/jusage-core test`（把包名换成 `jusage` / `jusage-dashboard` / `jusage-desktop` 即可）。
+
+PR 推上来后 CI（`.github/workflows/ci.yml`）会在 Ubuntu + Node 22 上跑同一套命令：`pnpm build` → 桌面端 `typecheck` → 四个包的测试。CI 红了先看是哪个包哪一步挂的，本地用上面对应的 `--filter` 命令复现。
 
 ## 按端启动
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "pnpm -r build",
     "build:packages": "pnpm --filter \"./packages/**\" -r build",
     "build:cli": "pnpm --filter @juejin-opensource/jusage... build",
+    "test": "pnpm build && pnpm -r --if-present test",
     "start": "pnpm start:cli",
     "start:cli": "pnpm build:cli && pnpm --filter @juejin-opensource/jusage start",
     "dev:cli": "pnpm build:cli && node scripts/run-parallel.mjs dev:cli:api dev:cli:ui",

--- a/packages/core/test/claude-desktop.test.ts
+++ b/packages/core/test/claude-desktop.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../src/paths.js';
 import { listClaudeProjectFiles, parseClaudeIncremental } from '../src/parsers/claude.js';
 import { resetProjectNameCache } from '../src/project-name.js';
+import { appSupportDir, pinHomeEnv } from './platform-fixtures.js';
 
 function hasGit(): boolean {
   try {
@@ -51,10 +52,7 @@ test('claudeCliProjectsDirs includes ~/.claude/projects', () => {
 test('claudeDesktopProjectsDirs finds local-agent .claude/projects', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-claude-desktop-'));
   const projectFolder = join(
-    tempHome,
-    'Library',
-    'Application Support',
-    'Claude-3p',
+    appSupportDir(tempHome, 'Claude-3p'),
     'local-agent-mode-sessions',
     'acct',
     'workspace',
@@ -67,10 +65,7 @@ test('claudeDesktopProjectsDirs finds local-agent .claude/projects', async () =>
   await mkdir(projectFolder, { recursive: true });
   await writeFile(join(projectFolder, 'session.jsonl'), `${ASSISTANT_LINE}\n`, 'utf8');
 
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
-  process.env.HOME = tempHome;
-  process.env.USERPROFILE = tempHome;
+  const restoreEnv = pinHomeEnv(tempHome);
 
   try {
     const desktopDirs = claudeDesktopProjectsDirs();
@@ -82,20 +77,14 @@ test('claudeDesktopProjectsDirs finds local-agent .claude/projects', async () =>
     const all = claudeProjectsDirs();
     assert.ok(all.includes(projectsDir));
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
+    restoreEnv();
   }
 });
 
 test('parseClaudeIncremental reads Desktop local-agent JSONL', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-claude-parse-'));
   const projectFolder = join(
-    tempHome,
-    'Library',
-    'Application Support',
-    'Claude-3p',
+    appSupportDir(tempHome, 'Claude-3p'),
     'local-agent-mode-sessions',
     'acct',
     'workspace',
@@ -108,11 +97,8 @@ test('parseClaudeIncremental reads Desktop local-agent JSONL', async () => {
   await writeFile(join(projectFolder, 'session.jsonl'), `${ASSISTANT_LINE}\n`, 'utf8');
   await mkdir(join(tempHome, '.claude', 'projects'), { recursive: true });
 
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
+  const restoreEnv = pinHomeEnv(tempHome);
   const prevClaudeConfig = process.env.CLAUDE_CONFIG_DIR;
-  process.env.HOME = tempHome;
-  process.env.USERPROFILE = tempHome;
   delete process.env.CLAUDE_CONFIG_DIR;
 
   try {
@@ -132,10 +118,7 @@ test('parseClaudeIncremental reads Desktop local-agent JSONL', async () => {
     assert.equal(result.buckets[0]?.output_tokens, 20);
     assert.equal(result.buckets[0]?.cached_input_tokens, 50);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
+    restoreEnv();
     if (prevClaudeConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
     else process.env.CLAUDE_CONFIG_DIR = prevClaudeConfig;
   }
@@ -197,11 +180,8 @@ test(
       'utf8',
     );
 
-    const prevHome = process.env.HOME;
-    const prevUserProfile = process.env.USERPROFILE;
+    const restoreEnv = pinHomeEnv(tempHome);
     const prevClaudeConfig = process.env.CLAUDE_CONFIG_DIR;
-    process.env.HOME = tempHome;
-    process.env.USERPROFILE = tempHome;
     delete process.env.CLAUDE_CONFIG_DIR;
 
     try {
@@ -209,10 +189,7 @@ test(
       assert.equal(result.eventsParsed, 1);
       assert.equal(result.buckets[0]?.project, 'ai-usage');
     } finally {
-      if (prevHome === undefined) delete process.env.HOME;
-      else process.env.HOME = prevHome;
-      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-      else process.env.USERPROFILE = prevUserProfile;
+      restoreEnv();
       if (prevClaudeConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
       else process.env.CLAUDE_CONFIG_DIR = prevClaudeConfig;
       rmSync(tempRoot, { recursive: true, force: true });
@@ -252,11 +229,8 @@ test('parseClaudeIncremental reuses cached project for grown files without re-pe
   const firstLine = makeAssistantLine('projcache_1', '2026-05-02T09:24:36.000Z');
   await writeFile(filePath, `${cwdLine}\n${firstLine}\n`, 'utf8');
 
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
+  const restoreEnv = pinHomeEnv(tempHome);
   const prevClaudeConfig = process.env.CLAUDE_CONFIG_DIR;
-  process.env.HOME = tempHome;
-  process.env.USERPROFILE = tempHome;
   delete process.env.CLAUDE_CONFIG_DIR;
 
   try {
@@ -281,10 +255,7 @@ test('parseClaudeIncremental reuses cached project for grown files without re-pe
     assert.equal(second.result.eventsParsed, 1);
     assert.equal(second.result.buckets[0]?.project, 'first-app');
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
+    restoreEnv();
     if (prevClaudeConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
     else process.env.CLAUDE_CONFIG_DIR = prevClaudeConfig;
     rmSync(tempHome, { recursive: true, force: true });
@@ -302,11 +273,8 @@ test('parseClaudeIncremental falls back to encoded path when no cwd', async () =
   await mkdir(projectFolder, { recursive: true });
   await writeFile(join(projectFolder, 'session.jsonl'), `${ASSISTANT_LINE}\n`, 'utf8');
 
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
+  const restoreEnv = pinHomeEnv(tempHome);
   const prevClaudeConfig = process.env.CLAUDE_CONFIG_DIR;
-  process.env.HOME = tempHome;
-  process.env.USERPROFILE = tempHome;
   delete process.env.CLAUDE_CONFIG_DIR;
 
   try {
@@ -315,10 +283,7 @@ test('parseClaudeIncremental falls back to encoded path when no cwd', async () =
     // Heuristic: last `-` segment of encoded folder name
     assert.equal(result.buckets[0]?.project, 'app');
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
+    restoreEnv();
     if (prevClaudeConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
     else process.env.CLAUDE_CONFIG_DIR = prevClaudeConfig;
     rmSync(tempHome, { recursive: true, force: true });
@@ -358,19 +323,13 @@ function makeAssistantLine(opts: {
 
 async function withTempClaudeHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
   const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-claude-home-'));
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
+  const restoreEnv = pinHomeEnv(tempHome);
   const prevClaudeConfig = process.env.CLAUDE_CONFIG_DIR;
-  process.env.HOME = tempHome;
-  process.env.USERPROFILE = tempHome;
   delete process.env.CLAUDE_CONFIG_DIR;
   try {
     return await fn(tempHome);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
+    restoreEnv();
     if (prevClaudeConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
     else process.env.CLAUDE_CONFIG_DIR = prevClaudeConfig;
     rmSync(tempHome, { recursive: true, force: true });
@@ -488,10 +447,7 @@ test('claudeCliProjectsDirs includes XDG and ~/.claude-* profiles', async () => 
 test('claudeDesktopProjectsDirs finds claude-code-sessions projects', async () => {
   await withTempClaudeHome(async (home) => {
     const projectFolder = join(
-      home,
-      'Library',
-      'Application Support',
-      'Claude',
+      appSupportDir(home, 'Claude'),
       'claude-code-sessions',
       'acct',
       'workspace',

--- a/packages/core/test/platform-fixtures.ts
+++ b/packages/core/test/platform-fixtures.ts
@@ -1,0 +1,49 @@
+import { join } from 'node:path';
+
+/**
+ * Where an Electron app keeps its data under `home`, per platform.
+ *
+ * Mirrors `appSupportBase()` / `claudeDesktopAppSupportRoots()` in
+ * `src/paths.ts`. Fixtures that hard-code the macOS
+ * `~/Library/Application Support` layout only ever exercise the darwin branch,
+ * so they fail on Linux and Windows even though the parser is fine there.
+ */
+export function appSupportDir(home: string, ...segments: string[]): string {
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', ...segments);
+  }
+  if (process.platform === 'win32') {
+    return join(home, 'AppData', 'Roaming', ...segments);
+  }
+  return join(home, '.config', ...segments);
+}
+
+/**
+ * Point every home-derived lookup in `src/paths.ts` at `home`, and return a
+ * function that restores the previous environment.
+ *
+ * `HOME` / `USERPROFILE` cover `os.homedir()`. `APPDATA` and `XDG_CONFIG_HOME`
+ * matter too: `appSupportBase()` and `claudeDesktopAppSupportRoots()` read them
+ * *before* falling back to the home directory, so without pinning them a
+ * fixture still resolves to the real user profile on Windows, and on any Linux
+ * box that exports `XDG_CONFIG_HOME`.
+ */
+export function pinHomeEnv(home: string): () => void {
+  const pinned: Record<string, string> = {
+    HOME: home,
+    USERPROFILE: home,
+    APPDATA: join(home, 'AppData', 'Roaming'),
+    XDG_CONFIG_HOME: join(home, '.config'),
+  };
+  const previous = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(pinned)) {
+    previous.set(name, process.env[name]);
+    process.env[name] = value;
+  }
+  return () => {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  };
+}

--- a/packages/core/test/platform-fixtures.ts
+++ b/packages/core/test/platform-fixtures.ts
@@ -1,3 +1,4 @@
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 /**
@@ -22,11 +23,11 @@ export function appSupportDir(home: string, ...segments: string[]): string {
  * Point every home-derived lookup in `src/paths.ts` at `home`, and return a
  * function that restores the previous environment.
  *
- * `HOME` / `USERPROFILE` cover `os.homedir()`. `APPDATA` and `XDG_CONFIG_HOME`
- * matter too: `appSupportBase()` and `claudeDesktopAppSupportRoots()` read them
- * *before* falling back to the home directory, so without pinning them a
- * fixture still resolves to the real user profile on Windows, and on any Linux
- * box that exports `XDG_CONFIG_HOME`.
+ * `HOME` / `USERPROFILE` cover `os.homedir()`. The XDG and `APPDATA` bases
+ * matter too: `appSupportBase()`, `claudeDesktopAppSupportRoots()` and the
+ * `~/.local/share` lookups read them *before* falling back to the home
+ * directory, so without pinning them a fixture still resolves to the real user
+ * profile on Windows, and on any Linux box that exports them.
  */
 export function pinHomeEnv(home: string): () => void {
   const pinned: Record<string, string> = {
@@ -34,6 +35,7 @@ export function pinHomeEnv(home: string): () => void {
     USERPROFILE: home,
     APPDATA: join(home, 'AppData', 'Roaming'),
     XDG_CONFIG_HOME: join(home, '.config'),
+    XDG_DATA_HOME: join(home, '.local', 'share'),
   };
   const previous = new Map<string, string | undefined>();
   for (const [name, value] of Object.entries(pinned)) {
@@ -46,4 +48,141 @@ export function pinHomeEnv(home: string): () => void {
       else process.env[name] = value;
     }
   };
+}
+
+/**
+ * Per-agent path overrides in `src/paths.ts` and `src/parsers/*`. Each one wins
+ * over the home directory, so a developer who exports any of them would have
+ * their real transcripts scanned by a test that only pinned `HOME`.
+ *
+ * Add new entries here when a parser gains its own override.
+ */
+const AGENT_PATH_OVERRIDE_ENV = [
+  'AI_USAGE_CLINE_ROOTS',
+  'AI_USAGE_EVERY_CODE_HOME',
+  'AI_USAGE_KILOCODE_ROOTS',
+  'AI_USAGE_OMP_AGENT_DIR',
+  'AI_USAGE_VSCODE_ROOTS',
+  'AMP_DATA_DIR',
+  'CLAUDE_CONFIG_DIR',
+  'CODEX_HOME',
+  'CODE_HOME',
+  'COPILOT_HOME',
+  'CURSOR_STATE_DB_PATH',
+  'DROID_SESSIONS_DIR',
+  'FACTORY_DIR',
+  'GEMINI_HOME',
+  'HERMES_HOME',
+  'KILO_CLI_DB',
+  'KILO_HOME',
+  'KIMI_CODE_HOME',
+  'KIMI_HOME',
+  'KIRO_CLI_DB_PATH',
+  'KIRO_CLI_SESSIONS_DIR',
+  'KIRO_HOME',
+  'MIMO_DB_PATH',
+  'MIMO_HOME',
+  'OMP_HOME',
+  'OPENCLAW_STATE_DIR',
+  'OPENCODE_HOME',
+  'PI_CODING_AGENT_DIR',
+  'QWEN_TMP_DIR',
+  'ZCODE_HOME',
+] as const;
+
+/**
+ * Sandbox a whole sync round: `pinHomeEnv(home)` plus every per-agent override
+ * cleared, so the only agent data reachable is what the test seeded under
+ * `home`.
+ *
+ * Tests that drive `syncAll` / `syncAllStaggered` need this. Without it they
+ * walk the developer's real `~/.claude`, `~/.codex`, … — slow (a 500 MB
+ * transcript tree takes ~60 s), non-deterministic (the result depends on which
+ * agents that machine has installed) and, once Cursor's `state.vscdb` is
+ * present, the cursor channel will read its access token and hit cursor.com for
+ * real, because the fetch throttle only kicks in once `lastSyncAt` exists and a
+ * fresh temp dataDir has none.
+ */
+export function isolateAgentHome(home: string): () => void {
+  const restoreHome = pinHomeEnv(home);
+  const previous = new Map<string, string | undefined>();
+  for (const name of AGENT_PATH_OVERRIDE_ENV) {
+    previous.set(name, process.env[name]);
+    delete process.env[name];
+  }
+  return () => {
+    for (const [name, value] of previous) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    restoreHome();
+  };
+}
+
+/** One assistant turn in a Claude Code CLI transcript under `home`. */
+export const SEEDED_CLAUDE = {
+  model: 'claude-sonnet-4-6',
+  project: 'app',
+  inputTokens: 100,
+  outputTokens: 20,
+  events: 1,
+};
+
+export async function seedClaudeSession(home: string): Promise<void> {
+  const projectDir = join(home, '.claude', 'projects', '-Users-dev-app');
+  await mkdir(projectDir, { recursive: true });
+  const line = JSON.stringify({
+    type: 'assistant',
+    timestamp: '2026-06-09T20:46:30.000Z',
+    requestId: 'req_seed_claude',
+    message: {
+      id: 'msg_seed_claude',
+      model: SEEDED_CLAUDE.model,
+      usage: {
+        input_tokens: SEEDED_CLAUDE.inputTokens,
+        output_tokens: SEEDED_CLAUDE.outputTokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  });
+  await writeFile(join(projectDir, 'session.jsonl'), `${line}\n`, 'utf8');
+}
+
+/** One token_count event in a Codex rollout under `home`. */
+export const SEEDED_CODEX = {
+  model: 'gpt-5.4',
+  inputTokens: 50,
+  outputTokens: 10,
+  events: 1,
+};
+
+export async function seedCodexSession(home: string): Promise<void> {
+  const sessionsDir = join(home, '.codex', 'sessions', '2026', '06', '09');
+  await mkdir(sessionsDir, { recursive: true });
+  const lines = [
+    JSON.stringify({
+      type: 'session_meta',
+      timestamp: '2026-06-09T20:46:00.000Z',
+      payload: { id: 'seed-codex-1', cwd: '/Users/dev/app' },
+    }),
+    JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-06-09T20:46:30.000Z',
+      payload: {
+        type: 'token_count',
+        info: {
+          last_token_usage: {
+            input_tokens: SEEDED_CODEX.inputTokens,
+            cached_input_tokens: 0,
+            output_tokens: SEEDED_CODEX.outputTokens,
+            reasoning_output_tokens: 0,
+            total_tokens: SEEDED_CODEX.inputTokens + SEEDED_CODEX.outputTokens,
+          },
+          model: SEEDED_CODEX.model,
+        },
+      },
+    }),
+  ];
+  await writeFile(join(sessionsDir, 'rollout-seed.jsonl'), `${lines.join('\n')}\n`, 'utf8');
 }

--- a/packages/core/test/qoder-trae-collectors.test.ts
+++ b/packages/core/test/qoder-trae-collectors.test.ts
@@ -23,6 +23,7 @@ import { bucketToIngestEvent } from '../src/upload/events.js';
 import { aggregateForIngest } from '../src/aggregate.js';
 import { bucketKey, ingestBucketKey } from '../src/queue/keys.js';
 import type { QueueBucket } from '../src/types.js';
+import { appSupportDir, pinHomeEnv } from './platform-fixtures.js';
 
 const PAGE_SIZE = 4096;
 const RESERVE_SIZE = 80;
@@ -109,10 +110,7 @@ test('parseClaudeIncremental tags cli vs desktop collectors', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-claude-collectors-'));
   const cliProjects = join(tempHome, '.claude', 'projects', 'proj-cli');
   const desktopProjects = join(
-    tempHome,
-    'Library',
-    'Application Support',
-    'Claude',
+    appSupportDir(tempHome, 'Claude'),
     'local-agent-mode-sessions',
     'sess1',
     '.claude',
@@ -155,10 +153,7 @@ test('parseClaudeIncremental tags cli vs desktop collectors', async () => {
   await writeFile(join(cliProjects, 'a.jsonl'), `${cliLine}\n`);
   await writeFile(join(desktopProjects, 'b.jsonl'), `${deskLine}\n`);
 
-  const prevHome = process.env.HOME;
-  const prevUserProfile = process.env.USERPROFILE;
-  process.env.HOME = tempHome;
-  process.env.USERPROFILE = tempHome;
+  const restoreEnv = pinHomeEnv(tempHome);
   try {
     const { result } = await parseClaudeIncremental({}, '2026-01-01T00:00:00.000Z');
     assert.equal(result.eventsParsed, 2);
@@ -166,29 +161,20 @@ test('parseClaudeIncremental tags cli vs desktop collectors', async () => {
     assert.equal(byCollector.get(CLAUDE_COLLECTOR_CLI)?.input_tokens, 10);
     assert.equal(byCollector.get(CLAUDE_COLLECTOR_DESKTOP)?.input_tokens, 20);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevUserProfile;
+    restoreEnv();
   }
 });
 
 test('parseQoderIncremental reads IDE local.db with collector split', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-qoder-'));
   const cnDbDir = join(
-    tempHome,
-    'Library',
-    'Application Support',
-    'QoderCN',
+    appSupportDir(tempHome, 'QoderCN'),
     'SharedClientCache',
     'cache',
     'db',
   );
   const intlDbDir = join(
-    tempHome,
-    'Library',
-    'Application Support',
-    'Qoder',
+    appSupportDir(tempHome, 'Qoder'),
     'SharedClientCache',
     'cache',
     'db',
@@ -238,8 +224,7 @@ test('parseQoderIncremental reads IDE local.db with collector split', async () =
   seedDb(join(cnDbDir, 'local.db'), 'msg-cn', 1100);
   seedDb(join(intlDbDir, 'local.db'), 'msg-intl', 2100);
 
-  const prevHome = process.env.HOME;
-  process.env.HOME = tempHome;
+  const restoreEnv = pinHomeEnv(tempHome);
   try {
     const { result } = await parseQoderIncremental({}, '2020-01-01T00:00:00.000Z');
     assert.equal(result.eventsParsed, 2);
@@ -250,8 +235,7 @@ test('parseQoderIncremental reads IDE local.db with collector split', async () =
     assert.equal(byCollector.get('qoder-ide')?.input_tokens, 2000);
     assert.equal(result.buckets.every((b) => b.source === 'qoder'), true);
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreEnv();
   }
 });
 
@@ -310,8 +294,7 @@ test('trae decrypt + parseTraeIncremental via env decrypted db', async () => {
   db.close();
 
   process.env.TRAE_DECRYPTED_DB_TRAE_CN_IDE = plainPath;
-  const prevHome = process.env.HOME;
-  process.env.HOME = temp; // no encrypted DBs under fake home
+  const restoreEnv = pinHomeEnv(temp); // no encrypted DBs under fake home
   try {
     const { result } = await parseTraeIncremental({}, '2020-01-01T00:00:00.000Z', {
       dataDir: temp,
@@ -327,27 +310,18 @@ test('trae decrypt + parseTraeIncremental via env decrypted db', async () => {
     assert.equal(bucket.output_tokens, 312);
   } finally {
     delete process.env.TRAE_DECRYPTED_DB_TRAE_CN_IDE;
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreEnv();
   }
 });
 
 test('parseTraeIncremental skips when encrypted DB exists but key missing', async () => {
   const tempHome = await mkdtemp(join(tmpdir(), 'ai-usage-trae-nokey-'));
-  const dbDir = join(
-    tempHome,
-    'Library',
-    'Application Support',
-    'Trae CN',
-    'ModularData',
-    'ai-agent',
-  );
+  const dbDir = join(appSupportDir(tempHome, 'Trae CN'), 'ModularData', 'ai-agent');
   await mkdir(dbDir, { recursive: true });
   // Not a real SQLCipher DB — existence alone triggers key-required skip.
   await writeFile(join(dbDir, 'database.db'), Buffer.alloc(PAGE_SIZE));
 
-  const prevHome = process.env.HOME;
-  process.env.HOME = tempHome;
+  const restoreEnv = pinHomeEnv(tempHome);
   try {
     const dataDir = join(tempHome, '.ai-usage');
     await mkdir(dataDir, { recursive: true });
@@ -357,8 +331,7 @@ test('parseTraeIncremental skips when encrypted DB exists but key missing', asyn
     assert.equal(result.skipped, true);
     assert.ok(result.error?.includes('trae-cn-ide'));
   } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
+    restoreEnv();
   }
 });
 

--- a/packages/core/test/sync-on-signal.test.ts
+++ b/packages/core/test/sync-on-signal.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import test from 'node:test';
@@ -11,6 +11,13 @@ import {
 } from '../src/server/sync-on-signal.js';
 import { syncAll } from '../src/sync/index.js';
 import type { TudConfig } from '../src/types.js';
+import {
+  isolateAgentHome,
+  SEEDED_CLAUDE,
+  SEEDED_CODEX,
+  seedClaudeSession,
+  seedCodexSession,
+} from './platform-fixtures.js';
 
 function baseConfig(dataDir: string): TudConfig {
   return {
@@ -120,18 +127,34 @@ test('createSyncRunner notify.signal respects source from payload', async () => 
 test('syncAll with source=claude|codex only runs that channel', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'ai-usage-sync-all-'));
   const config = baseConfig(dir);
+  // Same sandbox as sync-staggered: without it this case parsed the real
+  // ~/.claude and ~/.codex (~55s here) just to assert which channel ran.
+  const home = await mkdtemp(join(tmpdir(), 'ai-usage-sync-all-home-'));
+  const restoreEnv = isolateAgentHome(home);
+  try {
+    await seedClaudeSession(home);
+    await seedCodexSession(home);
 
-  const claudeOnly = await syncAll(dir, config, 'claude');
-  assert.deepEqual(
-    claudeOnly.map((r) => r.source),
-    ['claude'],
-  );
+    const claudeOnly = await syncAll(dir, config, 'claude');
+    assert.deepEqual(
+      claudeOnly.map((r) => r.source),
+      ['claude'],
+    );
+    // Filtering to one channel must still collect that channel's data — the
+    // old assertion passed even when the round parsed nothing at all.
+    assert.equal(claudeOnly[0]?.eventsParsed, SEEDED_CLAUDE.events);
 
-  const codexOnly = await syncAll(dir, config, 'codex');
-  assert.deepEqual(
-    codexOnly.map((r) => r.source),
-    ['codex'],
-  );
+    const codexOnly = await syncAll(dir, config, 'codex');
+    assert.deepEqual(
+      codexOnly.map((r) => r.source),
+      ['codex'],
+    );
+    assert.equal(codexOnly[0]?.eventsParsed, SEEDED_CODEX.events);
+  } finally {
+    restoreEnv();
+    await rm(dir, { recursive: true, force: true });
+    await rm(home, { recursive: true, force: true });
+  }
 });
 
 test('createSyncRunner coalesces overlapping poll and notify', async () => {

--- a/packages/core/test/sync-staggered.test.ts
+++ b/packages/core/test/sync-staggered.test.ts
@@ -6,6 +6,13 @@ import test from 'node:test';
 
 import { SYNC_SOURCE_IDS, syncAllStaggered } from '../src/sync/index.js';
 import type { TudConfig } from '../src/types.js';
+import {
+  isolateAgentHome,
+  SEEDED_CLAUDE,
+  SEEDED_CODEX,
+  seedClaudeSession,
+  seedCodexSession,
+} from './platform-fixtures.js';
 
 function baseConfig(dataDir: string): TudConfig {
   return {
@@ -26,7 +33,16 @@ function baseConfig(dataDir: string): TudConfig {
 
 test('syncAllStaggered visits sources with gaps and skips missing installs', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'tud-stagger-'));
+  // Sandboxed home: only the two sources seeded below exist. Without this the
+  // round walks the developer's real ~/.claude, ~/.codex, … — which made this
+  // one case ~58s on a 500MB transcript tree, and left "how many sources were
+  // skipped" a property of that machine rather than of the code under test.
+  const home = await mkdtemp(join(tmpdir(), 'tud-stagger-home-'));
+  const restoreEnv = isolateAgentHome(home);
   try {
+    await seedClaudeSession(home);
+    await seedCodexSession(home);
+
     const seen: string[] = [];
     const ticks: Array<{ skipped: boolean; t: number }> = [];
 
@@ -44,8 +60,21 @@ test('syncAllStaggered visits sources with gaps and skips missing installs', asy
       seen,
       SYNC_SOURCE_IDS.map((id) => id),
     );
-    // At least claude always runs (not skipped via presence); skipped count is environment-dependent.
-    assert.ok(results.some((r) => r.source === 'claude'));
+
+    const bySource = new Map(results.map((r) => [r.source, r]));
+    assert.equal(bySource.get('claude')?.eventsParsed, SEEDED_CLAUDE.events);
+    assert.equal(bySource.get('codex')?.eventsParsed, SEEDED_CODEX.events);
+
+    // Everything else has nothing to read under the sandboxed home, so no
+    // channel may invent events. This is what actually guards the round.
+    const unexpected = results.filter(
+      (r) => r.source !== 'claude' && r.source !== 'codex' && r.eventsParsed > 0,
+    );
+    assert.deepEqual(
+      unexpected.map((r) => `${r.source}:${r.eventsParsed}`),
+      [],
+      'only the seeded sources may report events',
+    );
 
     // Skipped channels must not insert the stagger gap.
     const skippedGaps: number[] = [];
@@ -54,13 +83,14 @@ test('syncAllStaggered visits sources with gaps and skips missing installs', asy
         skippedGaps.push(ticks[i]!.t - ticks[i - 1]!.t);
       }
     }
-    if (skippedGaps.length > 0) {
-      assert.ok(
-        skippedGaps.every((g) => g < 25),
-        `skipped source gaps should be << 40ms, got ${skippedGaps.join(',')}`,
-      );
-    }
+    assert.ok(skippedGaps.length > 0, 'sandboxed home must leave some source skipped');
+    assert.ok(
+      skippedGaps.every((g) => g < 25),
+      `skipped source gaps should be << 40ms, got ${skippedGaps.join(',')}`,
+    );
   } finally {
+    restoreEnv();
     await rm(dir, { recursive: true, force: true });
+    await rm(home, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] ✅ 测试用例
- [x] ⏩ 工作流 / CI

### 🖥️ 影响范围

- [ ] Desktop
- [x] CLI
- [ ] Web

（**不动任何产品代码**，只改 `packages/core/test/` 和 CI 矩阵。勾 CLI 是因为受影响的是 core 的测试。）

### 🔗 关联 Issue

接 #125。两件事都是 #125 装门禁时被卡出来的：矩阵只能跑 macOS（第一部分），以及门禁上最大的一个空洞（第二部分）。Windows 上另发现的一组问题记在 #128。

### 💡 改动说明

两个 commit，都只碰测试。

---

## 一、`test(core): build app-support fixtures for the running platform`

**问题**

`packages/core` 有 6 个用例把 macOS 的 `~/Library/Application Support` 布局写死进了 fixture：

```ts
const projectFolder = join(
  tempHome, 'Library', 'Application Support', 'Claude-3p',
  'local-agent-mode-sessions', ...
);
```

而产品代码本身是分平台的 —— `paths.ts` 里 `appSupportBase()`、`claudeDesktopAppSupportRoots()` 都有 darwin / win32 / linux 三个分支。所以这些用例只覆盖到 darwin 那一支，**在 Linux 和 Windows 上必红**：

```text
not ok 29  - claudeDesktopProjectsDirs finds local-agent .claude/projects
not ok 30  - parseClaudeIncremental reads Desktop local-agent JSONL
not ok 38  - claudeDesktopProjectsDirs finds claude-code-sessions projects
not ok 177 - parseClaudeIncremental tags cli vs desktop collectors
not ok 178 - parseQoderIncremental reads IDE local.db with collector split
not ok 180 - parseTraeIncremental skips when encrypted DB exists but key missing
```

后果：**非 macOS 的贡献者在干净 checkout 上跑 `pnpm test` 开箱就是 6 条红的**，还分不清是自己改坏了还是本来就红。CI 也因此只能跑 macOS 一个平台。

**改法**

新增 `packages/core/test/platform-fixtures.ts`：

- `appSupportDir(home, ...segments)` —— 按 `process.platform` 返回 `Library/Application Support` / `AppData/Roaming` / `.config`，和 `paths.ts` 的实现对齐；
- `pinHomeEnv(home)` —— 返回 restore 函数，一次钉住 `HOME`、`USERPROFILE`、`APPDATA`、`XDG_CONFIG_HOME`、`XDG_DATA_HOME`。

  第二个不是顺手加的：**只设 `HOME` / `USERPROFILE` 不够**。`appSupportBase()` 这类是**先读 XDG / `APPDATA`，读不到才回落 home**，所以在 Windows 上、以及任何 export 了 `XDG_CONFIG_HOME` 的 Linux 机器上，被测 parser 仍能走出临时 home 去扫开发者真实目录。

顺带把这两个文件里 4 份几乎一样的手写 env 存取还原换成同一个 helper。

CI `runs-on` 从 `macos-latest` 换成 `[ubuntu-latest, macos-latest]` 矩阵，`fail-fast: false`。

---

## 二、`test(core): sandbox the two whole-round sync cases`

**问题**

`syncAllStaggered visits sources with gaps` 和 `syncAll with source=claude|codex` 这两条都是**跑一整轮真实 sync**，扫的是开发者本机的 home。我这台 `~/.claude/projects` 是 548 MB / 340 个 jsonl，实测：

| 用例 | 耗时 |
| --- | --- |
| `syncAllStaggered visits sources with gaps and skips missing installs` | **57,963 ms** |
| `syncAll with source=claude\|codex only runs that channel` | **55,333 ms** |

core 套件本地一共 64 秒，基本就是这两条（文件级并行才没叠成 113 秒）。

但**慢只是症状**。真正的问题是这两条几乎没断言任何东西：CI runner 的 home 是空的，所有 source 全部走 `skipped`，`syncAllStaggered` 的断言退化成「结果数组长度等于 `SYNC_SOURCE_IDS` 长度」。用例自己的注释就写着：

```ts
// At least claude always runs (not skipped via presence); skipped count is environment-dependent.
```

也就是：**在开发者机器上慢且不确定，在 CI 上快但空转**。#125 刚装上的门禁，几乎任何 parser 挂掉它都会绿着放过去 —— 这是门禁上最大的一个洞。

**改法**

`platform-fixtures.ts` 里加 `isolateAgentHome(home)` = `pinHomeEnv()` + 清掉约 30 个 per-agent 路径覆写（`CODEX_HOME`、`CLAUDE_CONFIG_DIR`、`AI_USAGE_*_ROOTS`、`CURSOR_STATE_DB_PATH` …）—— 这些每一个都**优先于 home**，只钉 `HOME` 挡不住。然后在沙箱 home 里播一个 Claude 会话 + 一个 Codex rollout，断言改成：

- claude / codex 各自解析出预期的 event 数；
- **其余 30 个 source 一个 event 都不许有**（这条才是真正守住这一轮的断言）；
- skipped 的 channel 不插 stagger gap（原来这条只在「碰巧有连续 skip」时才生效，现在沙箱下必然成立，改成硬断言）。

**顺带堵掉一条没人想要的路径**：cursor 通道的抓取节流只在 `cursors.json` 已有 `lastSyncAt` 时才生效，而这两条用例用的是全新临时 dataDir，所以只要本机存在 `state.vscdb`，这一轮就会去读真实的 Cursor access token、拼 session cookie、向 `cursor.com/api/dashboard/export-usage-events-csv` 发实网请求。

> 我把 `CURSOR_WEB_BASE_URL` 指到本地探针实测过一轮：**我这台没有请求打出来**，说明我的 token 没读成可用 cookie。所以这条我只能说「代码路径是通的、节流在新 dataDir 上确实不生效」，**不能说「跑测试就一定会把凭证发出去」** —— 取决于开发者有没有登录 Cursor。沙箱之后 `state.vscdb` 在假 home 下不存在，通道按 presence 直接 skip，这条路径就断了。

**效果**

| | 改前 | 改后 |
| --- | --- | --- |
| `syncAllStaggered ...` | 57,963 ms | **112 ms** |
| `syncAll with source=...` | 55,333 ms | **25 ms** |
| core 套件 | 64,132 ms | **1,363 ms** |
| 通过数 | 287/287 | **287/287** |

`pnpm --filter @juejin-opensource/jusage-core test` 的墙上时间 66 s → 3.3 s。

---

### 验证（都是真跑的，不是推演）

| 平台 | 结果 |
| --- | --- |
| 本地 macOS | core 287/287、cli 13/13、dashboard 71/71 |
| CI `ubuntu-latest` | 全绿 |
| CI `macos-latest` | 全绿 |
| CI `windows-latest`（第一部分做完时试探跑过一轮） | 那 6 条**在 Windows 上也全过了**（`ok 29 / 30 / 38 / 177 / 178 / 180`） |

- 最终 run（含两个 commit）：<https://github.com/ChenCJ-io/juejin-usage/actions/runs/34463763764>
- 三平台试探 run：<https://github.com/ChenCJ-io/juejin-usage/actions/runs/34443402076>

### 为什么矩阵里暂时没有 `windows-latest`

三平台试探跑出来，Windows 上另有 **7 条**用例挂，和本 PR 修的两类**都没有关系**（本 PR 的 6 条在 Windows 上已经变绿）：

```text
not ok 57  - concurrent settings, sync and upload writers ...   # config.json 原子写 rename EPERM
not ok 118 - parseKilocodeIncremental reads ui_messages ...     # eventsParsed 0 !== 1
not ok 148 - parseRoocodeIncremental reads ui_messages ...      # eventsParsed 0 !== 1
not ok 191 - claimRuntimeOwner becomes owner when no pid        # runtime-pid 一组
not ok 192 - claimRuntimeOwner returns observer with owner kind
not ok 196 - startedAt mismatch is treated as PID reuse
not ok 197 - releaseRuntimeOwner only clears own pid
```

其中至少 `config.json` 那条**可能不只是测试问题**：`saveConfig()` 走 `.tmp` + `rename` 覆盖，POSIX 上是原子替换，Windows 上只要目标文件还被别的句柄开着就 EPERM，而这个用例模拟的正是「设置页 / sync / upload 三个写者并发」这个真实场景。我手边没有 Windows 机器，只有 CI 日志，所以没在这个 PR 里顺手动 —— 已记在 #128。修完把矩阵加一行就行，`ci.yml` 里写了注释说明。

### 关于本 PR 前面的 commit

本分支基于 #124 + #125，因此带了它们的 commit。**前面的合了我就 rebase 掉**，本 PR 只剩上面那两个 `test(core): ...`。

### 📝 Changelog

无需 changeset：只改测试和 CI，不碰产品代码，对已发布产物零影响。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（`test/core-cross-platform-fixtures`）
- [x] 已在受影响的端本地自测通过，并在 CI 上跑过 ubuntu / macOS / Windows 三个平台
- [x] 若改动了面板 UI：本次未改 UI
- [x] 已执行 `pnpm changeset`（纯测试 / CI 改动按 CONTRIBUTING 跳过）
- [x] `pnpm build` 通过
