### PR TITLE
fix(core): use cwdPath as fallback when opencode rootPath resolves to unknown

### DIFF
--- a/.changeset/chilly-bears-peel.md
+++ b/.changeset/chilly-bears-peel.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-core": patch
+---
+
+修复 opencode 会话项目名全部显示为 unknown 的问题

--- a/packages/core/src/parsers/opencode.ts
+++ b/packages/core/src/parsers/opencode.ts
@@ -60,9 +60,13 @@ function coerceEpochMs(value: unknown): number | null {
   return null;
 }
 
-function projectFromRoot(rootPath: unknown): string {
-  if (typeof rootPath !== 'string' || !rootPath.trim()) return 'unknown';
-  return resolveProjectName(rootPath);
+function projectFromRoot(...rootPaths: unknown[]): string {
+  for (const rootPath of rootPaths) {
+    if (typeof rootPath !== 'string' || !rootPath.trim()) continue;
+    const name = resolveProjectName(rootPath);
+    if (name !== 'unknown') return name;
+  }
+  return 'unknown';
 }
 
 function ingestMessage(
@@ -171,7 +175,7 @@ function parseFromSqlite(
       (typeof row.model === 'string' && row.model) ||
       (typeof row.modelId === 'string' && row.modelId) ||
       'unknown';
-    const project = projectFromRoot(row.rootPath ?? row.cwdPath);
+    const project = projectFromRoot(row.rootPath, row.cwdPath);
     const timestampMs =
       coerceEpochMs(row.completed) || coerceEpochMs(row.created);
 
@@ -252,7 +256,7 @@ function parseFromJson(
       (typeof data.modelId === 'string' && data.modelId) ||
       'unknown';
     const pathObj = data.path as { root?: string; cwd?: string } | undefined;
-    const project = projectFromRoot(pathObj?.root ?? pathObj?.cwd);
+    const project = projectFromRoot(pathObj?.root, pathObj?.cwd);
     const time = data.time as { created?: unknown; completed?: unknown } | undefined;
     const timestampMs = coerceEpochMs(time?.completed) || coerceEpochMs(time?.created);
 


### PR DESCRIPTION
  ### 🏷️ 变动类型
  - [x] 🐞 Bug 修复

  ### 🖥️ 影响范围
  - [x] Desktop
  - [x] CLI

  ### 🔗 关联 Issue
  无对应 issue，本地测试发现。

  ### 💡 改动说明
  opencode 在 SQLite 数据库的 \`message\` 表中，\`path.root\` 字段存储的是
  \`/\`（文件系统根目录）而非 \`null\`。原来的代码用 \`rootPath ?? cwdPath\`，但 \`/\` 不是
  \`null\`，所以 fallback 永远不会触发。\`resolveProjectName('/')\`
  将斜杠处理后得到空字符串，最终返回 \`'unknown'\`，导致所有 opencode 会话的项目统计都归入
  \`unknown\`。

  **修复方式**：将 \`projectFromRoot\` 改为接受可变数量的路径候选，按顺序尝试，跳过解析结果为
  \`unknown\` 的项，取第一个有效结果。SQLite 和 JSON 两条解析路径均已同步更新，传入 \`(rootPath,
  cwdPath)\` 让真实工作目录作为 fallback。

  本地验证：清除 opencode cursor 并重新同步后，项目名正确显示为 \`vidu-code\`、\`Default Project\`
  等，不再全部归入 \`unknown\`。

  ### 📝 Changelog

  | 包 | 版本类型 | 变更描述（面向用户） |
  | --- | --- | --- |
  | \`@juejin-opensource/jusage-core\` | patch | 修复 opencode 会话项目名全部显示为 unknown 的问题 |

  ### ☑️ 自查清单
  - [x] 分支命名符合 \`fix/cli/opencode-project-name\`
  - [x] 已在本地 Desktop 验证修复有效
  - [x] 已执行 \`pnpm changeset\`
  - [x] \`pnpm build\` 通过