### PR TITLE
fix(core): support session.v3 format and reasoning tokens for DSH

### DIFF
--- a/.changeset/dsh-session-v3-support.md
+++ b/.changeset/dsh-session-v3-support.md
@@ -1,0 +1,6 @@
+---
+'@juejin-opensource/jusage-core': patch
+'@juejin-opensource/jusage': patch
+---
+
+修复 DeepSeek Harness（dsh）用量采集：兼容带版本的会话文件（`session.v3.jsonl.zstd` 等），并支持采集思考模型 Token（`reasoningTokens`）。

--- a/packages/core/src/parsers/dsh.ts
+++ b/packages/core/src/parsers/dsh.ts
@@ -53,54 +53,104 @@ export function dshHome(env: NodeJS.ProcessEnv = process.env): string {
   return join(homedir(), '.dsh');
 }
 
+/** DSH 会话文件名匹配模式（支持 session.v3.jsonl.zstd、session.jsonl 等格式）。 */
+export const DSH_SESSION_FILE_RE = /^session(?:\.v(\d+))?\.jsonl(?:\.zstd)?$/i;
+
+interface DshFileCandidate {
+  path: string;
+  version: number;
+  isZstd: boolean;
+  mtimeMs: number;
+}
+
+function parseSessionCandidate(dir: string, filename: string): DshFileCandidate | null {
+  const match = DSH_SESSION_FILE_RE.exec(filename);
+  if (!match) return null;
+  const version = match[1] !== undefined ? Number.parseInt(match[1], 10) : 0;
+  const isZstd = filename.endsWith('.zstd');
+  const fullPath = join(dir, filename);
+  let mtimeMs = 0;
+  try {
+    mtimeMs = statSync(fullPath).mtimeMs;
+  } catch {
+    // ignore
+  }
+  return { path: fullPath, version, isZstd, mtimeMs };
+}
+
+function pickBestSessionFile(candidates: DshFileCandidate[]): string | null {
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0]!.path;
+  const sorted = [...candidates].sort((a, b) => {
+    if (a.version !== b.version) return b.version - a.version;
+    const zstdA = a.isZstd ? 1 : 0;
+    const zstdB = b.isZstd ? 1 : 0;
+    if (zstdA !== zstdB) return zstdB - zstdA;
+    return b.mtimeMs - a.mtimeMs;
+  });
+  return sorted[0]!.path;
+}
+
+function collectSessionFilesFromDir(dir: string, currentDepth: number, maxDepth: number): string[] {
+  if (currentDepth > maxDepth) return [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates: DshFileCandidate[] = [];
+  const subdirs: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.isFile()) {
+      const candidate = parseSessionCandidate(dir, entry.name);
+      if (candidate) candidates.push(candidate);
+    } else if (entry.isDirectory()) {
+      subdirs.push(join(dir, entry.name));
+    }
+  }
+
+  if (candidates.length > 0) {
+    const best = pickBestSessionFile(candidates);
+    return best ? [best] : [];
+  }
+
+  const results: string[] = [];
+  for (const subdir of subdirs.sort()) {
+    results.push(...collectSessionFilesFromDir(subdir, currentDepth + 1, maxDepth));
+  }
+  return results;
+}
+
 /** DSH 会话根目录（workspace 目录的父目录）。 */
 function dshSessionsDir(home = dshHome()): string {
   return join(home, 'sessions');
 }
 
-/** 收集所有会话文件（按路径排序，稳定）。 */
+/** 收集所有会话文件（递归支持多层/单层目录，同会话目录优先选最高版本与 zstd，按路径排序）。 */
 export function listDshSessionFiles(home = dshHome()): string[] {
   const sessionsDir = dshSessionsDir(home);
-  const results: string[] = [];
-
-  let workspaces: string[];
-  try {
-    workspaces = readdirSync(sessionsDir, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => join(sessionsDir, e.name))
-      .sort();
-  } catch {
-    return results;
-  }
-
-  for (const ws of workspaces) {
-    try {
-      const entries = readdirSync(ws, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const compressedFile = join(ws, entry.name, 'session.jsonl.zstd');
-        const plainFile = join(ws, entry.name, 'session.jsonl');
-        if (existsSync(compressedFile)) results.push(compressedFile);
-        else if (existsSync(plainFile)) results.push(plainFile);
-      }
-    } catch {
-      // 跳过不可读的 workspace 目录
-    }
-  }
-  return results;
+  if (!existsSync(sessionsDir)) return [];
+  return collectSessionFilesFromDir(sessionsDir, 0, 4).sort();
 }
 
-/** 解析 JSONL 首行的 cwd。 */
+/** 解析 JSONL 前 10 行的 cwd。 */
 function readSessionCwd(text: string): string | null {
-  const newline = text.indexOf('\n');
-  const firstLine = newline >= 0 ? text.slice(0, newline) : text;
-  if (!firstLine.includes('"cwd"')) return null;
-  try {
-    const obj = JSON.parse(firstLine) as { cwd?: unknown };
-    return typeof obj.cwd === 'string' && obj.cwd.trim() ? obj.cwd.trim() : null;
-  } catch {
-    return null;
+  const lines = text.split('\n', 10);
+  for (const line of lines) {
+    if (!line.includes('"cwd"')) continue;
+    try {
+      const obj = JSON.parse(line) as { cwd?: unknown };
+      if (typeof obj.cwd === 'string' && obj.cwd.trim()) {
+        return obj.cwd.trim();
+      }
+    } catch {
+      // 忽略无效行
+    }
   }
+  return null;
 }
 
 /** 解压单帧 zstd，返回 (解压内容, 消费的压缩字节数)。 */
@@ -291,13 +341,17 @@ export async function parseDshIncremental(
       const output = toNonNeg(usage.outputTokens);
       const cacheRead = toNonNeg(usage.cacheReadTokens);
       const cacheWrite = toNonNeg(usage.cacheWriteTokens);
+      const reasoning = toNonNeg(usage.reasoningTokens);
+      const reportedTotal = toNonNeg(usage.totalTokens);
+      const computedTotal = input + output + cacheRead + cacheWrite;
+      const total = Math.max(reportedTotal, computedTotal);
       const totals: DshMessageTotals = {
         input_tokens: input,
         output_tokens: output,
         cached_input_tokens: cacheRead,
         cache_creation_input_tokens: cacheWrite,
-        reasoning_output_tokens: 0,
-        total_tokens: input + output + cacheRead + cacheWrite,
+        reasoning_output_tokens: reasoning,
+        total_tokens: total,
       };
       if (totals.total_tokens === 0) continue;
 

--- a/packages/core/test/dsh.test.ts
+++ b/packages/core/test/dsh.test.ts
@@ -33,6 +33,7 @@ function writeSession(
     output: number;
     cacheRead: number;
     cacheWrite?: number;
+    reasoning?: number;
     id: string;
     time: number;
   }>,
@@ -41,12 +42,14 @@ function writeSession(
     plain?: boolean;
     requestModel?: string;
     omitMessageModel?: boolean;
+    version?: number;
+    filename?: string;
   } = {},
 ): string {
-  const dir = join(home, 'sessions', workspace, sessionId);
+  const dir = workspace ? join(home, 'sessions', workspace, sessionId) : join(home, 'sessions', sessionId);
   mkdirSync(dir, { recursive: true });
   const lines: unknown[] = [
-    { type: 'session', version: 0, id: sessionId, createdAt: 1787830821841, cwd },
+    { type: 'session', version: opts.version ?? 0, id: sessionId, createdAt: 1787830821841, cwd },
   ];
   if (opts.requestModel) {
     lines.push({
@@ -63,6 +66,7 @@ function writeSession(
       outputTokens: m.output,
       cacheReadTokens: m.cacheRead,
       cacheWriteTokens: m.cacheWrite ?? 0,
+      ...(m.reasoning !== undefined ? { reasoningTokens: m.reasoning } : {}),
     };
     lines.push({
       type: 'assistant/chunk',
@@ -98,12 +102,17 @@ function writeSession(
     time: 1787830861600,
     data: { usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 1 } },
   });
-  const file = join(dir, opts.plain ? 'session.jsonl' : 'session.jsonl.zstd');
-  const contents = opts.plain
-    ? Buffer.from(lines.map((line) => JSON.stringify(line)).join('\n') + '\n')
-    : opts.multiFrame
+  const defaultName = opts.version !== undefined
+    ? `session.v${opts.version}.jsonl${opts.plain ? '' : '.zstd'}`
+    : opts.plain
+      ? 'session.jsonl'
+      : 'session.jsonl.zstd';
+  const file = join(dir, opts.filename ?? defaultName);
+  const contents = file.endsWith('.zstd')
+    ? opts.multiFrame
       ? zstdJsonlMultiFrame(lines)
-      : zstdJsonl(lines);
+      : zstdJsonl(lines)
+    : Buffer.from(lines.map((line) => JSON.stringify(line)).join('\n') + '\n');
   writeFileSync(file, contents);
   return file;
 }
@@ -292,3 +301,72 @@ test('parseDshIncremental decodes multi-frame zstd (streamed session files)', as
     else process.env.DSH_HOME = prev;
   }
 });
+
+test('listDshSessionFiles supports session.v3.jsonl.zstd and picks higher version', () => {
+  const home = mkdtempSync(join(tmpdir(), 'tud-dsh-v3-'));
+  try {
+    // 真实 DSH 目录结构：sessions/<workspace>/<sessionId>/session.v3.jsonl.zstd
+    writeSession(home, '--workspace-sample--', 'session-s1', '/tmp/proj/sample', [], { version: 3 });
+    // 单层目录结构：sessions/<sessionId>/session.v3.jsonl.zstd
+    writeSession(home, '', 'session-single', '/tmp/proj/single', [], { version: 3 });
+    // 同一目录存在 v2 和 v3，应选更高版本的 v3
+    writeSession(home, 'ws-multi', 'session-multi', '/tmp/proj/multi', [], { filename: 'session.v2.jsonl.zstd' });
+    writeSession(home, 'ws-multi', 'session-multi', '/tmp/proj/multi', [], { filename: 'session.v3.jsonl.zstd' });
+
+    const files = listDshSessionFiles(home);
+    assert.equal(files.length, 3);
+    assert.ok(files.some((f) => f.includes('session-s1') && f.endsWith('session.v3.jsonl.zstd')));
+    assert.ok(files.some((f) => f.includes('session-single') && f.endsWith('session.v3.jsonl.zstd')));
+    assert.ok(files.some((f) => f.includes('session-multi') && f.endsWith('session.v3.jsonl.zstd')));
+  } finally {
+    // cleanup
+  }
+});
+
+test('parseDshIncremental parses session.v3.jsonl.zstd with reasoning tokens', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'tud-dsh-v3-parse-'));
+  const prev = process.env.DSH_HOME;
+  process.env.DSH_HOME = home;
+  try {
+    writeSession(
+      home,
+      '--workspace-demo--',
+      'session-demo-7b06',
+      '/demo/workspace/sample-app',
+      [
+        {
+          model: 'deepseek-flash',
+          input: 8693,
+          output: 189,
+          cacheRead: 500,
+          cacheWrite: 20,
+          reasoning: 74,
+          id: 'm-flash-1',
+          time: 1789026072131,
+        },
+      ],
+      { version: 3, multiFrame: true },
+    );
+
+    const { result } = await parseDshIncremental(emptyCursors(), SINCE);
+    assert.equal(result.eventsParsed, 1);
+    assert.equal(result.filesProcessed, 1);
+    assert.equal(result.buckets.length, 1);
+
+    const b = result.buckets[0]!;
+    assert.equal(b.source, 'dsh');
+    assert.equal(b.model, 'deepseek-flash');
+    assert.equal(b.project, 'sample-app');
+    assert.equal(b.input_tokens, 8693);
+    assert.equal(b.output_tokens, 189);
+    assert.equal(b.cached_input_tokens, 500);
+    assert.equal(b.cache_creation_input_tokens, 20);
+    assert.equal(b.reasoning_output_tokens, 74);
+    assert.equal(b.total_tokens, 8693 + 189 + 500 + 20);
+    assert.equal(b.conversation_count, 1);
+  } finally {
+    if (prev === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = prev;
+  }
+});
+


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🔌 新增 / 修复数据源解析器（parser）
- [x] 🐞 Bug 修复
- [x] ✅ 测试用例

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI

### 🔗 关联 Issue

修复本地 DeepSeek Harness（dsh）无法被自动识别和采集用量的问题。

### 💡 改动说明

1. **会话文件名正则化匹配**：
   - 原代码仅硬编码匹配 `session.jsonl.zstd` 与 `session.jsonl`，而当前官方 DeepSeek Harness 默认持久化文件为 `session.v3.jsonl.zstd`，导致扫描结果为空。
   - 使用正则 `DSH_SESSION_FILE_RE = /^session(?:\.v(\d+))?\.jsonl(?:\.zstd)?$/i` 支持版本化文件名匹配与多层/单层目录遍历，同会话目录下优先选取最高版本与 `.zstd` 压缩文件。
2. **CWD 项目名提取鲁棒性**：
   - 扫描会话前 10 行以兼容非首行的初始化事件，避免误回退到 `unknown` 项目。
3. **思考模型 Token 采集**：
   - 提取 DSH 事件中的 `usage.reasoningTokens` 并记入 `reasoning_output_tokens`，修正 `total_tokens` 聚合。
4. **CLI 参数帮助补齐**：
   - 在 `jusage --help` 的 `--source` 可选列表补充 `dsh`。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage`（CLI） | patch | `--source` 数据源帮助信息中补充 `dsh` |
| `@juejin-opensource/jusage-core` | patch | 修复 DeepSeek Harness（dsh）用量采集：兼容 `session.v3.jsonl.zstd` 文件并支持思考模型 Token 采集 |

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`
- [x] 已在受影响的端（CLI / Desktop）本地自测通过
- [x] 已执行 `pnpm changeset` 并随代码一同提交
- [x] `pnpm build` 及相关单元测试通过
