### PR TITLE
fix(desktop): Token 趋势图改用真实的输入/输出/缓存用量，不再按固定比例推算

### DIFF
--- a/.changeset/daily-token-breakdown.md
+++ b/.changeset/daily-token-breakdown.md
@@ -1,0 +1,7 @@
+---
+'@juejin-opensource/jusage-core': patch
+'@juejin-opensource/jusage-dashboard': patch
+'@juejin-opensource/jusage-desktop': patch
+---
+
+Token 趋势图的「输入 / 输出 / 缓存」改用真实用量：日视图此前按固定比例（总量 × 0.78 等）推算构成，小时视图则把缓存读取截断到未缓存输入之内，缓存几乎显示不出来。现在日粒度接口直接给出这三项，两个视图口径一致；「总 Token」曲线也改用该行真实总量。数据源未提供明细时（目前只有线上用量页会遇到）图表会注明「构成为估算值」，不再当作实测值展示。

--- a/apps/desktop/src/renderer/components/TokenUsageTrendCard.tsx
+++ b/apps/desktop/src/renderer/components/TokenUsageTrendCard.tsx
@@ -52,25 +52,32 @@ export const TokenUsageTrendCard = memo(function TokenUsageTrendCard({
   const [trendView, setTrendView] = useState<TokenTrendView>('all');
 
   const rows = useMemo(() => {
-    const source = hourly
+    // `total` is the row's own total, not the sum of the three series: cache
+    // writes and reasoning tokens count toward usage but have no series here,
+    // so adding the series up would under-report the headline number.
+    return hourly
       ? [...hourlyRows].sort((a, b) => a.hour - b.hour).map((row) => ({
           label: `${row.hour}h`,
           input: Math.max(0, row.inputTokens - row.cachedInputTokens),
           output: row.outputTokens,
           cache: row.cachedInputTokens,
+          total: row.totalTokens,
         }))
       : dailyRows.map((row) => ({
           label: row.date,
           input: row.uncachedInputTokens,
           output: row.outputTokens,
           cache: row.cachedInputTokens,
+          total: row.totalTokens,
         }));
-
-    return source.map((row) => ({
-      ...row,
-      total: row.input + row.output + row.cache,
-    }));
   }, [dailyRows, hourly, hourlyRows]);
+
+  // Only the daily path can lack a reported split (a remote payload without
+  // the fields); say so rather than letting a derived shape read as measured.
+  const breakdownEstimated = useMemo(
+    () => !hourly && dailyRows.some((row) => row.tokenBreakdownEstimated),
+    [dailyRows, hourly],
+  );
 
   const title = hourly
     ? dayScoped
@@ -80,7 +87,9 @@ export const TokenUsageTrendCard = memo(function TokenUsageTrendCard({
   const description =
     trendView === 'all'
       ? '总 Token 用量趋势'
-      : '输入、输出与缓存 Token 趋势';
+      : breakdownEstimated
+        ? '输入、输出与缓存 Token 趋势（构成为估算值，数据源未提供明细）'
+        : '输入、输出与缓存 Token 趋势';
 
   return (
     <Card className="h-full min-w-0 overflow-hidden rounded-2xl">

--- a/apps/desktop/src/renderer/components/TrayTrendChart.tsx
+++ b/apps/desktop/src/renderer/components/TrayTrendChart.tsx
@@ -227,7 +227,9 @@ function buildTrendPoints({
         value: metric === 'tokens' ? row.totalTokens : row.costUsd,
         ...tokenBreakdown({
           totalTokens: row.totalTokens,
-          inputTokens: row.inputTokens,
+          // Hourly rows carry input *including* cache, same as daily; the
+          // stack wants the two apart.
+          inputTokens: Math.max(0, row.inputTokens - row.cachedInputTokens),
           cachedInputTokens: row.cachedInputTokens,
           outputTokens: row.outputTokens,
         }),

--- a/apps/desktop/src/renderer/lib/api.ts
+++ b/apps/desktop/src/renderer/lib/api.ts
@@ -136,6 +136,14 @@ export interface DailyUsageRow {
   costUsd: number;
   models: Record<string, number>;
   projects?: DailyProjectUsage[];
+  /**
+   * Same split `HourlyUsageRow` carries: uncached input, output, cache reads.
+   * Optional because a remote daily payload may predate them — absent means
+   * "unknown", never "zero", and must not be replaced with a guess.
+   */
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
 }
 
 export interface DailyUsageResponse {

--- a/apps/desktop/src/renderer/lib/dashboard-data.ts
+++ b/apps/desktop/src/renderer/lib/dashboard-data.ts
@@ -241,9 +241,16 @@ export function buildFilledHourlyForDate(
     const hourLabel = DASHBOARD_HOURS[hour] ?? String(hour).padStart(2, '0');
     if (!api) return emptyHourlyRow(day, hour, hourLabel);
 
-    const inputTokens = api.inputTokens;
-    const outputTokens = api.outputTokens;
-    const cachedInputTokens = Math.min(inputTokens, api.cachedInputTokens);
+    // `HourlyUsageRow.inputTokens` from the API is *uncached* input, and
+    // `cachedInputTokens` is a separate dimension — clamping one to the other
+    // threw away almost every cache read, since a cached turn reports a few
+    // fresh input tokens against thousands of cached ones. This model's
+    // `inputTokens` means input including cache, matching the daily row, so
+    // consumers can derive the uncached part by subtraction.
+    const uncachedInputTokens = Math.max(0, api.inputTokens);
+    const cachedInputTokens = Math.max(0, api.cachedInputTokens);
+    const inputTokens = uncachedInputTokens + cachedInputTokens;
+    const outputTokens = Math.max(0, api.outputTokens);
     return {
       day,
       hour,
@@ -454,31 +461,67 @@ function buildProjectRowsFromDaily(
     .sort((a, b) => b.tokens - a.tokens);
 }
 
+/**
+ * Reported split, or `null` when the payload has none.
+ *
+ * `DailyUsageRow.inputTokens` is *uncached* input (same meaning as on
+ * `HourlyUsageRow`), while this dashboard model's `inputTokens` counts cache
+ * reads too — hence the addition here.
+ */
+function reportedDailySplit(row: DailyUsageRow): {
+  inputTokens: number;
+  cachedInputTokens: number;
+  uncachedInputTokens: number;
+  outputTokens: number;
+} | null {
+  if (
+    row.inputTokens == null ||
+    row.outputTokens == null ||
+    row.cachedInputTokens == null
+  ) {
+    return null;
+  }
+  const uncachedInputTokens = Math.max(0, row.inputTokens);
+  const cachedInputTokens = Math.max(0, row.cachedInputTokens);
+  return {
+    inputTokens: uncachedInputTokens + cachedInputTokens,
+    cachedInputTokens,
+    uncachedInputTokens,
+    outputTokens: Math.max(0, row.outputTokens),
+  };
+}
+
 function normalizeDailyRow(
   row: DailyUsageRow,
   _index?: number,
 ): DashboardDailyUsageRow {
-  const inputRatio = 0.78;
-  const cacheRatio = 0.2;
-  const inputTokens = Math.round(row.tokens * inputRatio);
-  const outputTokens = Math.max(0, row.tokens - inputTokens);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.round(inputTokens * cacheRatio),
-  );
-  const durationMinutes = 0;
+  // Desktop always talks to the local API, which reports the split. The
+  // fallback only covers a daily payload old enough to predate it, and says so
+  // rather than passing a fixed ratio off as measurement.
+  const reported = reportedDailySplit(row);
+  const split = reported ?? estimateDailySplit(row.tokens);
 
   return {
     day: weekdayForDate(row.date),
     date: row.date,
     dateLabel: formatDateLabel(row.date),
+    ...split,
+    totalTokens: row.tokens,
+    costUsd: roundCurrency(row.costUsd),
+    durationMinutes: 0,
+    ...(reported ? {} : { tokenBreakdownEstimated: true }),
+  };
+}
+
+/** Last-resort shape for payloads without a split; never shown unlabelled. */
+function estimateDailySplit(tokens: number) {
+  const inputTokens = Math.round(tokens * 0.78);
+  const cachedInputTokens = Math.min(inputTokens, Math.round(inputTokens * 0.2));
+  return {
     inputTokens,
     cachedInputTokens,
     uncachedInputTokens: inputTokens - cachedInputTokens,
-    outputTokens,
-    totalTokens: row.tokens,
-    costUsd: roundCurrency(row.costUsd),
-    durationMinutes,
+    outputTokens: Math.max(0, tokens - inputTokens),
   };
 }
 

--- a/apps/desktop/src/renderer/lib/dashboard-mock-data.ts
+++ b/apps/desktop/src/renderer/lib/dashboard-mock-data.ts
@@ -32,6 +32,8 @@ export interface DashboardDailyUsageRow {
   totalTokens: number;
   costUsd: number;
   durationMinutes: number;
+  /** True when the input/output/cache split was derived, not reported. */
+  tokenBreakdownEstimated?: boolean;
 }
 
 export interface DashboardUsageSummary {

--- a/packages/core/src/aggregate-cache.ts
+++ b/packages/core/src/aggregate-cache.ts
@@ -31,7 +31,10 @@ import type {
 } from './types.js';
 
 /** Bump when sealed project keys change (v3: encoded cwd → folder name). */
-const CACHE_VERSION = 3;
+// 4: sealed daily rows carry the input/output/cache split. Entries sealed by an
+// older build lack it, so the whole file is dropped and rebuilt rather than
+// serving days whose split silently reads as undefined.
+const CACHE_VERSION = 4;
 /** Epoch lower bound so single-day aggregates are not clipped by statsSince. */
 const EPOCH_SINCE = '1970-01-01T00:00:00.000Z';
 
@@ -113,6 +116,9 @@ function buildSealedDay(
       date,
       tokens: 0,
       costUsd: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedInputTokens: 0,
       models: {},
       projects: [],
     },

--- a/packages/core/src/aggregate.ts
+++ b/packages/core/src/aggregate.ts
@@ -175,6 +175,9 @@ export function aggregateDaily(
     {
       tokens: number;
       costUsd: number;
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
       models: Map<string, number>;
       projects: Map<string, { tokens: number; models: Map<string, number> }>;
     }
@@ -191,11 +194,19 @@ export function aggregateDaily(
       {
         tokens: 0,
         costUsd: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedInputTokens: 0,
         models: new Map<string, number>(),
         projects: new Map(),
       };
     day.tokens += tokens;
     day.costUsd += cost;
+    // Same three dimensions aggregateHourly reports, so the daily and hourly
+    // views of one day describe the same split instead of the UI deriving it.
+    day.inputTokens += row.input_tokens || 0;
+    day.outputTokens += row.output_tokens || 0;
+    day.cachedInputTokens += row.cached_input_tokens || 0;
     const modelKey = dailyModelKey(row.source, row.model);
     day.models.set(modelKey, (day.models.get(modelKey) ?? 0) + tokens);
 
@@ -217,6 +228,9 @@ export function aggregateDaily(
       date,
       tokens: v.tokens,
       costUsd: roundCostUsd(v.costUsd),
+      inputTokens: v.inputTokens,
+      outputTokens: v.outputTokens,
+      cachedInputTokens: v.cachedInputTokens,
       models: Object.fromEntries(
         Array.from(v.models.entries()).sort((a, b) => b[1] - a[1]),
       ),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -463,6 +463,17 @@ export interface DailyUsageRow {
   models: Record<string, number>;
   /** Optional for backward compatibility with older daily payloads. */
   projects?: DailyProjectUsage[];
+  /**
+   * Same split `HourlyUsageRow` reports: uncached input, output and cache
+   * reads. Optional because remote daily payloads may not carry them — a
+   * client that gets `undefined` must not invent the split.
+   *
+   * These three do not add up to `tokens`: cache writes and reasoning tokens
+   * count toward the total but have no series of their own.
+   */
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
 }
 
 export interface DailyUsageResponse {

--- a/packages/core/test/aggregate-cache.test.ts
+++ b/packages/core/test/aggregate-cache.test.ts
@@ -70,7 +70,7 @@ test('AggregateCache seals history and serves daily without rescanning today-onl
     assert.equal(cache.sealedDayCount(), before);
 
     const raw = await readFile(join(dir, 'cache', 'daily-sealed.json'), 'utf8');
-    assert.ok(raw.includes('"version":3'));
+    assert.ok(raw.includes('"version":4'));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/core/test/aggregate.test.ts
+++ b/packages/core/test/aggregate.test.ts
@@ -307,3 +307,58 @@ test('aggregateDaily and todayTokens use Asia/Shanghai calendar day', () => {
     assert.equal(summary.todayTokens, 80);
   }
 });
+
+test('aggregateDaily reports the same token split as aggregateHourly', () => {
+  const hourStart = new Date().toISOString();
+  const split = (
+    input: number,
+    output: number,
+    cacheRead: number,
+    cacheWrite: number,
+  ): QueueBucket => ({
+    hour_start: hourStart,
+    source: 'claude',
+    model: 'claude-sonnet-4-6',
+    project: 'app',
+    input_tokens: input,
+    output_tokens: output,
+    cached_input_tokens: cacheRead,
+    cache_creation_input_tokens: cacheWrite,
+    reasoning_output_tokens: 0,
+    total_tokens: input + output + cacheRead + cacheWrite,
+    conversation_count: 1,
+  });
+  const rows = [split(100, 20, 5000, 300), split(40, 8, 1000, 0)];
+
+  const daily = aggregateDaily(rows, 1, '2020-01-01T00:00:00.000Z');
+  const hourly = aggregateHourly(rows, 1, '2020-01-01T00:00:00.000Z');
+  const day = daily.days[0]!;
+
+  assert.equal(day.inputTokens, 140);
+  assert.equal(day.outputTokens, 28);
+  assert.equal(day.cachedInputTokens, 6000);
+
+  // The point of the split living in core: both endpoints describe one day the
+  // same way, so the UI never has to derive it from ratios.
+  const hourTotals = hourly.hours.reduce(
+    (acc, h) => ({
+      inputTokens: acc.inputTokens + h.inputTokens,
+      outputTokens: acc.outputTokens + h.outputTokens,
+      cachedInputTokens: acc.cachedInputTokens + h.cachedInputTokens,
+    }),
+    { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0 },
+  );
+  assert.deepEqual(
+    {
+      inputTokens: day.inputTokens,
+      outputTokens: day.outputTokens,
+      cachedInputTokens: day.cachedInputTokens,
+    },
+    hourTotals,
+  );
+
+  // Cache writes count toward the total but have no series of their own, so
+  // the three dimensions are deliberately less than `tokens`.
+  assert.equal(day.tokens, 6468);
+  assert.equal(day.inputTokens + day.outputTokens + day.cachedInputTokens, 6168);
+});

--- a/packages/dashboard/src/components/TokenUsageTrendCard.tsx
+++ b/packages/dashboard/src/components/TokenUsageTrendCard.tsx
@@ -52,25 +52,32 @@ export function TokenUsageTrendCard({
   const [trendView, setTrendView] = useState<TokenTrendView>('all');
 
   const rows = useMemo(() => {
-    const source = hourly
+    // `total` is the row's own total, not the sum of the three series: cache
+    // writes and reasoning tokens count toward usage but have no series here,
+    // so adding the series up would under-report the headline number.
+    return hourly
       ? [...hourlyRows].sort((a, b) => a.hour - b.hour).map((row) => ({
           label: `${row.hour}h`,
           input: Math.max(0, row.inputTokens - row.cachedInputTokens),
           output: row.outputTokens,
           cache: row.cachedInputTokens,
+          total: row.totalTokens,
         }))
       : dailyRows.map((row) => ({
           label: row.date,
           input: row.uncachedInputTokens,
           output: row.outputTokens,
           cache: row.cachedInputTokens,
+          total: row.totalTokens,
         }));
-
-    return source.map((row) => ({
-      ...row,
-      total: row.input + row.output + row.cache,
-    }));
   }, [dailyRows, hourly, hourlyRows]);
+
+  // Only the daily path can lack a reported split (a remote payload without
+  // the fields); say so rather than letting a derived shape read as measured.
+  const breakdownEstimated = useMemo(
+    () => !hourly && dailyRows.some((row) => row.tokenBreakdownEstimated),
+    [dailyRows, hourly],
+  );
 
   const title = hourly
     ? dayScoped
@@ -80,7 +87,9 @@ export function TokenUsageTrendCard({
   const description =
     trendView === 'all'
       ? '总 Token 用量趋势'
-      : '输入、输出与缓存 Token 趋势';
+      : breakdownEstimated
+        ? '输入、输出与缓存 Token 趋势（构成为估算值，数据源未提供明细）'
+        : '输入、输出与缓存 Token 趋势';
 
   return (
     <Card className="h-full min-w-0 overflow-hidden rounded-2xl">

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -102,6 +102,14 @@ export interface DailyUsageRow {
   costUsd: number;
   models: Record<string, number>;
   projects?: DailyProjectUsage[];
+  /**
+   * Same split `HourlyUsageRow` carries: uncached input, output, cache reads.
+   * The local API fills them in; the hosted API does not yet, so absent means
+   * "unknown", never "zero", and must not be replaced with a guess.
+   */
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
 }
 
 export interface DailyUsageResponse {

--- a/packages/dashboard/src/lib/dashboard-data.test.ts
+++ b/packages/dashboard/src/lib/dashboard-data.test.ts
@@ -421,3 +421,71 @@ test('dashboard tool panel uses summed 8-decimal model costs then cents', () => 
   assert.equal(view.toolModelUsage[0]?.costUsd, 9.03);
   assert.notEqual(view.toolModelUsage[0]?.costUsd, 9.04);
 });
+
+test('daily rows use the reported token split instead of deriving one', () => {
+  const today = localDateNow();
+  const dataset = datasetWithDays([
+    {
+      date: today,
+      tokens: 10_000,
+      costUsd: 1,
+      models: { 'claude-sonnet-4-6': 10_000 },
+      inputTokens: 120,
+      outputTokens: 880,
+      cachedInputTokens: 8_000,
+    },
+  ]);
+
+  const row = buildDashboardDataFromDataset(dataset, 7).rangeDailyUsage[0]!;
+
+  assert.equal(row.uncachedInputTokens, 120);
+  assert.equal(row.cachedInputTokens, 8_000);
+  assert.equal(row.outputTokens, 880);
+  // Dashboard-model `inputTokens` counts cache reads; the API field does not.
+  assert.equal(row.inputTokens, 8_120);
+  assert.equal(row.totalTokens, 10_000);
+  assert.equal(row.tokenBreakdownEstimated, undefined);
+  // Cache writes have no series, so the split is deliberately below the total.
+  assert.equal(
+    row.uncachedInputTokens + row.cachedInputTokens + row.outputTokens,
+    9_000,
+  );
+});
+
+test('daily rows without a reported split are flagged as estimated', () => {
+  const today = localDateNow();
+  const dataset = datasetWithDays([
+    { date: today, tokens: 10_000, costUsd: 1, models: { 'gpt-4': 10_000 } },
+  ]);
+
+  const row = buildDashboardDataFromDataset(dataset, 7).rangeDailyUsage[0]!;
+
+  assert.equal(row.tokenBreakdownEstimated, true);
+  assert.equal(row.totalTokens, 10_000);
+});
+
+test('buildFilledHourlyForDate keeps cache reads that exceed uncached input', () => {
+  const rows = buildFilledHourlyForDate(
+    [
+      {
+        date: '2026-08-13',
+        hour: 10,
+        source: 'claude',
+        tokens: 20_400,
+        costUsd: 0.1,
+        // A cached turn: a handful of fresh input tokens against thousands of
+        // cached ones. Clamping cache to input used to collapse this to 4.
+        inputTokens: 4,
+        outputTokens: 400,
+        cachedInputTokens: 20_000,
+      },
+    ],
+    '2026-08-13',
+  );
+
+  const hour = rows[10]!;
+  assert.equal(hour.cachedInputTokens, 20_000);
+  assert.equal(hour.inputTokens, 20_004);
+  assert.equal(hour.inputTokens - hour.cachedInputTokens, 4);
+  assert.equal(hour.totalTokens, 20_400);
+});

--- a/packages/dashboard/src/lib/dashboard-data.ts
+++ b/packages/dashboard/src/lib/dashboard-data.ts
@@ -236,9 +236,16 @@ export function buildFilledHourlyForDate(
     const hourLabel = DASHBOARD_HOURS[hour] ?? String(hour).padStart(2, '0');
     if (!api) return emptyHourlyRow(day, hour, hourLabel);
 
-    const inputTokens = api.inputTokens;
-    const outputTokens = api.outputTokens;
-    const cachedInputTokens = Math.min(inputTokens, api.cachedInputTokens);
+    // `HourlyUsageRow.inputTokens` from the API is *uncached* input, and
+    // `cachedInputTokens` is a separate dimension — clamping one to the other
+    // threw away almost every cache read, since a cached turn reports a few
+    // fresh input tokens against thousands of cached ones. This model's
+    // `inputTokens` means input including cache, matching the daily row, so
+    // consumers can derive the uncached part by subtraction.
+    const uncachedInputTokens = Math.max(0, api.inputTokens);
+    const cachedInputTokens = Math.max(0, api.cachedInputTokens);
+    const inputTokens = uncachedInputTokens + cachedInputTokens;
+    const outputTokens = Math.max(0, api.outputTokens);
     return {
       day,
       hour,
@@ -430,28 +437,46 @@ function buildProjectRowsFromDaily(
     .sort((a, b) => b.tokens - a.tokens);
 }
 
+/**
+ * Reported split, or `null` when the payload has none.
+ *
+ * `DailyUsageRow.inputTokens` is *uncached* input (same meaning as on
+ * `HourlyUsageRow`), while this dashboard model's `inputTokens` counts cache
+ * reads too — hence the addition here.
+ */
+function reportedDailySplit(row: DailyUsageRow): {
+  inputTokens: number;
+  cachedInputTokens: number;
+  uncachedInputTokens: number;
+  outputTokens: number;
+} | null {
+  if (
+    row.inputTokens == null ||
+    row.outputTokens == null ||
+    row.cachedInputTokens == null
+  ) {
+    return null;
+  }
+  const uncachedInputTokens = Math.max(0, row.inputTokens);
+  const cachedInputTokens = Math.max(0, row.cachedInputTokens);
+  return {
+    inputTokens: uncachedInputTokens + cachedInputTokens,
+    cachedInputTokens,
+    uncachedInputTokens,
+    outputTokens: Math.max(0, row.outputTokens),
+  };
+}
+
 function normalizeDailyRow(
   row: DailyUsageRow,
   index: number,
 ): DashboardDailyUsageRow {
-  const template =
-    dashboardMockData.dailyUsage[index % dashboardMockData.dailyUsage.length];
-  const inputRatio = safeRatio(
-    template.inputTokens,
-    template.totalTokens,
-    0.78,
-  );
-  const cacheRatio = safeRatio(
-    template.cachedInputTokens,
-    template.inputTokens,
-    0.2,
-  );
-  const inputTokens = Math.round(row.tokens * inputRatio);
-  const outputTokens = Math.max(0, row.tokens - inputTokens);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.round(inputTokens * cacheRatio),
-  );
+  // The local API reports the split; the hosted API does not yet. When it is
+  // missing we still have to draw something, so the sample-derived ratios stay
+  // — but the row is flagged so the chart can say the split is an estimate
+  // instead of presenting it as measured usage.
+  const reported = reportedDailySplit(row);
+  const split = reported ?? estimateDailySplit(row.tokens, index);
   const durationMinutes = Math.round(
     row.tokens *
       safeRatio(
@@ -465,13 +490,34 @@ function normalizeDailyRow(
     day: weekdayForDate(row.date),
     date: row.date,
     dateLabel: formatDateLabel(row.date),
-    inputTokens,
-    cachedInputTokens,
-    uncachedInputTokens: inputTokens - cachedInputTokens,
-    outputTokens,
+    ...split,
     totalTokens: row.tokens,
     costUsd: roundCurrency(row.costUsd),
     durationMinutes,
+    ...(reported ? {} : { tokenBreakdownEstimated: true }),
+  };
+}
+
+/** Last-resort shape for payloads without a split; never shown unlabelled. */
+function estimateDailySplit(tokens: number, index: number) {
+  const template =
+    dashboardMockData.dailyUsage[index % dashboardMockData.dailyUsage.length];
+  const inputRatio = safeRatio(template.inputTokens, template.totalTokens, 0.78);
+  const cacheRatio = safeRatio(
+    template.cachedInputTokens,
+    template.inputTokens,
+    0.2,
+  );
+  const inputTokens = Math.round(tokens * inputRatio);
+  const cachedInputTokens = Math.min(
+    inputTokens,
+    Math.round(inputTokens * cacheRatio),
+  );
+  return {
+    inputTokens,
+    cachedInputTokens,
+    uncachedInputTokens: inputTokens - cachedInputTokens,
+    outputTokens: Math.max(0, tokens - inputTokens),
   };
 }
 

--- a/packages/dashboard/src/lib/dashboard-mock-data.ts
+++ b/packages/dashboard/src/lib/dashboard-mock-data.ts
@@ -137,6 +137,8 @@ export interface DashboardDailyUsageRow {
   totalTokens: number;
   costUsd: number;
   durationMinutes: number;
+  /** True when the input/output/cache split was derived, not reported. */
+  tokenBreakdownEstimated?: boolean;
 }
 
 export interface DashboardUsageSummary {


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [x] Web

### 🔗 关联 Issue

close #134

### 💡 改动说明

**1. 原来有什么问题**

Token 趋势图的「输入 / 输出 / 缓存」不是采集到的数字，是算出来的。

**日视图** —— 桌面端 `dashboard-data.ts:457-470` 两个写死的常数：

```ts
const inputRatio = 0.78;
const cacheRatio = 0.2;
const inputTokens = Math.round(row.tokens * inputRatio);
const outputTokens = Math.max(0, row.tokens - inputTokens);
const cachedInputTokens = Math.min(inputTokens, Math.round(inputTokens * cacheRatio));
```

每一天、每一个用户都是同一组比例。Web 端更隐蔽：比例从**打包进去的 mock 演示数据集**按下标轮着取（`dashboardMockData.dailyUsage[index % len]`），`durationMinutes` 也是拿 mock 的总时长/总 token 比例乘出来的。

拿我本机真实 `~/.ai-usage/queue` 实测，2026-09-09 那天：

| 维度 | 真实 | 面板画出来的 | 偏差 |
| --- | --- | --- | --- |
| 输入 | 17,105,844 | 569,108,714 | **33 倍** |
| 输出 | 3,200,808 | 200,647,303 | **63 倍** |
| 缓存 | 879,611,084 | 142,277,179 | 真实是显示值的 **6.2 倍** |

缓存占那天真实用量的 **96%**，面板把它画成 15.6%，把输入画成 62%。构成基本是反的。

**小时视图**方向相反 —— `buildFilledHourlyForDate` 里：

```ts
const cachedInputTokens = Math.min(inputTokens, api.cachedInputTokens);
```

`HourlyUsageRow.inputTokens` 是**未缓存**输入，`cachedInputTokens` 是另一个独立维度，两者没有包含关系。把缓存截断到未缓存输入之内，而一次命中缓存的对话通常是几个新增 token 配几千个缓存 token。卡片随后又减了一次（`input: Math.max(0, row.inputTokens - row.cachedInputTokens)`），截断后两值已相等，输入恒为 0。同一份 queue 实测：

```text
小时桶数: 382，其中缓存被截断的: 382 (100.0%)
缓存合计  旧: 489,182,668   新: 15,650,238,814   旧/新 = 3.1%
输入合计  旧: 0             新: 489,182,668
```

**382 个小时桶全部中招**，缓存只画出真实值的 3.1%，输入每个桶都是 0。

**2. 这版怎么改的**

数据本来就在，是聚合时被丢了。同一个 `aggregate.ts`、同一批 queue 行：`aggregateHourly` 累加并返回 input / output / cachedInput 三项，`aggregateDaily` 只给 `{date, tokens, costUsd, models, projects}`。前端拿不到明细，就自己编了一份。

- **core**：`aggregateDaily` 补齐这三项，口径与 `aggregateHourly` **完全一致**（未缓存 input / output / cache read）。`AggregateCache` 版本 3 → 4，让不带这三项的历史封存条目整体重建，而不是把 `undefined` 当 0 发出去。local API 直接透传聚合结果，无需改动。
- **两份面板**：`normalizeDailyRow` 改用真值。这里有个容易踩的口径差 —— API 的 `inputTokens` **不含**缓存，而面板模型的 `inputTokens` **含**缓存（`uncachedInputTokens` 才是不含的那个），所以映射时做了显式相加，并写了注释。
- **小时视图**：`buildFilledHourlyForDate` 不再截断，并让面板模型的小时 `inputTokens` 也统一成「含缓存」，和日行对齐。这样卡片里本来就在做的那次相减反而变正确了，三个卡片（`TokenUsageTrendCard` / `DailyUsageTrendCard` / `TrayTrendChart`）不用各改一遍。
- 顺带两处：趋势卡的「总 Token」曲线改用该行自己的 `totalTokens`，不再拿三条系列相加（缓存写入和 reasoning token 计入总量但没有独立系列，相加会低报）；托盘图的小时路径在堆叠前把输入和缓存拆开。

**3. 拿不到明细时怎么办**

线上用量页走 `api.juejin.cn`，服务端 daily 接口目前还没有这三个字段。那条路径**保留推算，但打上 `tokenBreakdownEstimated`**，图表描述显示「构成为估算值，数据源未提供明细」，不再当实测值展示。

我考虑过直接把构成视图藏掉，没这么做：对线上用户来说那等于砍掉一个现有功能，而标注估算既诚实又不减功能。**服务端 daily 接口补上这三个字段之后，这条推算路径就可以整个删掉** —— 这部分需要维护者那边配合，我这边改不到。

**4. 已知的遗留（本 PR 没动）**

- 构成视图三条系列之和**小于**总量线：缓存写入（`cache_creation_input_tokens`）和 reasoning token 计入总量但没有独立系列。这是小时视图本来就有的性质，不是本 PR 引入的。要不要加第四条「缓存写入」系列涉及配色和图例，想听维护者的意见再动。
- `usage-filter.ts` 的 `scaleDailyTrendRow` 在按渠道筛选时，是拿该渠道的 token 占比去**等比缩放**整天的构成，而不是用该渠道自己的真实构成。属于同一类问题，但要 daily 接口带上 per-source 明细才好修，单独立项更合适。

**5. 验证**

```text
$ pnpm -r build                                        # 四个包全过
$ pnpm --filter @juejin-opensource/jusage-desktop typecheck   # 过
$ pnpm --filter @juejin-opensource/jusage-core      test  → ℹ pass 288  ℹ fail 0
$ pnpm --filter @juejin-opensource/jusage           test  → ℹ pass 13   ℹ fail 0
$ pnpm --filter @juejin-opensource/jusage-dashboard test  → ℹ pass 74   ℹ fail 0
```

新增用例：

- core：`aggregateDaily reports the same token split as aggregateHourly` —— 断言同一批行在日/小时两个口径下三项完全相等，并显式断言三项之和小于 `tokens`（缓存写入没有系列）；
- dashboard：真值优先、无明细时打 `tokenBreakdownEstimated`、以及「缓存大于未缓存输入时不再被截断」（用 input 4 / cache 20,000 这种真实命中缓存的形状）。

`aggregate-cache.test.ts` 里断言缓存文件版本号的那行同步改成 4。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 日粒度用量接口补齐输入 / 输出 / 缓存明细 |
| `@juejin-opensource/jusage-desktop` | patch | Token 趋势图的输入 / 输出 / 缓存改用真实用量 |
| `@juejin-opensource/jusage-dashboard` | patch | 同上；数据源无明细时标注为估算 |

changeset 已随 PR 提交（`.changeset/daily-token-breakdown.md`）。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（`fix/desktop/daily-token-breakdown`）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：`packages/dashboard/src` 与 `apps/desktop/src/renderer` 两份**都改了**，逻辑保持一致（桌面端始终走本地 API，理论上不会命中估算分支，但仍保留了同一套兜底，避免两份代码分叉）
- [x] 已执行 `pnpm changeset`
- [x] `pnpm build` 通过

---

本分支基于 #124（`main` 目前编译不过，不带那一行修复就没法 `pnpm build`）。**#124 合了我 rebase 掉**，本 PR 只剩 `fix(desktop): ...` 这一个 commit。
