### PR TITLE
fix(core): stop splitting Windows drive-letter colons in ROOTS path l…

### DIFF
--- a/.changeset/windows-roots-separator.md
+++ b/.changeset/windows-roots-separator.md
@@ -1,0 +1,5 @@
+---
+'@juejin-opensource/jusage-core': patch
+---
+
+修复 Windows 下 `AI_USAGE_VSCODE_ROOTS` / `AI_USAGE_KILOCODE_ROOTS` 路径列表被盘符冒号（`C:`）劈碎的问题，Kilo Code / Roo Code 等 VS Code 系数据源在 Windows 恢复正常采集。Windows 上多个根目录请用 `;` 或 `,` 分隔；其他平台 `:` 分隔符保持兼容。

--- a/packages/core/src/parsers/kilocode.ts
+++ b/packages/core/src/parsers/kilocode.ts
@@ -14,6 +14,7 @@ import {
   accumulateBucket,
   bucketsFromState,
   computeTotalTokens,
+  splitRootsList,
   type BucketAccumulator,
 } from './shared.js';
 import { vscodeHostRoots } from './roocode.js';
@@ -38,11 +39,7 @@ function kilocodeHostRoots(): string[] {
     process.env.AI_USAGE_KILOCODE_ROOTS?.trim() ||
     process.env.AI_USAGE_VSCODE_ROOTS?.trim();
   if (override) {
-    return override
-      .split(/[:;,]/)
-      .map((p) => p.trim())
-      .filter(Boolean)
-      .map((p) => expandHome(p));
+    return splitRootsList(override).map((p) => expandHome(p));
   }
   return vscodeHostRoots();
 }

--- a/packages/core/src/parsers/roocode.ts
+++ b/packages/core/src/parsers/roocode.ts
@@ -17,6 +17,7 @@ import {
   accumulateBucket,
   bucketsFromState,
   computeTotalTokens,
+  splitRootsList,
   type BucketAccumulator,
 } from './shared.js';
 
@@ -43,11 +44,9 @@ function appSupportBase(): string {
 export function vscodeHostRoots(): string[] {
   const override = process.env.AI_USAGE_VSCODE_ROOTS?.trim();
   if (override) {
-    return override
-      .split(/[:;,]/)
-      .map((p) => p.trim())
-      .filter(Boolean)
-      .map((p) => (p.startsWith('~') ? join(homedir(), p.slice(1)) : p));
+    return splitRootsList(override).map((p) =>
+      p.startsWith('~') ? join(homedir(), p.slice(1)) : p,
+    );
   }
   const base = appSupportBase();
   const names = [

--- a/packages/core/src/parsers/shared.ts
+++ b/packages/core/src/parsers/shared.ts
@@ -1,10 +1,27 @@
 import { readdir, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
+import { platform } from 'node:os';
 import { join } from 'node:path';
 
 import type { QueueBucket, TokenTotals } from '../types.js';
 import { normalizeProjectName } from '../project-label.js';
 import { alignUnknownIntoDominant } from '../queue/align-unknown.js';
+
+/**
+ * Split a path-list env override (`AI_USAGE_*_ROOTS`).
+ *
+ * Windows absolute paths start with a drive-letter colon (`C:\…`), so `:`
+ * cannot be a separator there — splitting on it shreds every root into a
+ * bare drive letter and a tail. Use `[,;]` on win32; keep the historical
+ * `[:;,]` separator set on other platforms.
+ */
+export function splitRootsList(
+  raw: string,
+  plat: NodeJS.Platform = platform(),
+): string[] {
+  const sep = plat === 'win32' ? /[,;]/ : /[:;,]/;
+  return raw.split(sep).map((p) => p.trim()).filter(Boolean);
+}
 
 export type BucketAccumulator = Map<
   string,

--- a/packages/core/test/split-roots-list.test.ts
+++ b/packages/core/test/split-roots-list.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { splitRootsList } from '../src/parsers/shared.js';
+import { vscodeHostRoots } from '../src/parsers/roocode.js';
+
+test('splitRootsList keeps Windows drive-letter colons intact', () => {
+  assert.deepEqual(splitRootsList('C:\\Users\\dev\\.vscode', 'win32'), [
+    'C:\\Users\\dev\\.vscode',
+  ]);
+  assert.deepEqual(splitRootsList('C:\\r1;C:\\r2', 'win32'), [
+    'C:\\r1',
+    'C:\\r2',
+  ]);
+  assert.deepEqual(splitRootsList('C:\\r1,C:\\r2', 'win32'), [
+    'C:\\r1',
+    'C:\\r2',
+  ]);
+});
+
+test('splitRootsList splits on the historical separator set off win32', () => {
+  assert.deepEqual(splitRootsList('/r1:/r2', 'linux'), ['/r1', '/r2']);
+  assert.deepEqual(splitRootsList('/r1;/r2,/r3', 'darwin'), [
+    '/r1',
+    '/r2',
+    '/r3',
+  ]);
+});
+
+test('splitRootsList trims and drops empty segments', () => {
+  assert.deepEqual(splitRootsList(' /r1 ; ; /r2 ', 'linux'), ['/r1', '/r2']);
+  assert.deepEqual(splitRootsList('C:\\r1 ; ; C:\\r2', 'win32'), [
+    'C:\\r1',
+    'C:\\r2',
+  ]);
+});
+
+test('vscodeHostRoots splits AI_USAGE_VSCODE_ROOTS on ; on every platform', () => {
+  // `;` separates on every platform; `:` only off win32 (drive letters).
+  const prev = process.env.AI_USAGE_VSCODE_ROOTS;
+  process.env.AI_USAGE_VSCODE_ROOTS = '/vscode/a;/vscode/b';
+  try {
+    assert.deepEqual(vscodeHostRoots(), ['/vscode/a', '/vscode/b']);
+  } finally {
+    if (prev === undefined) delete process.env.AI_USAGE_VSCODE_ROOTS;
+    else process.env.AI_USAGE_VSCODE_ROOTS = prev;
+  }
+});


### PR DESCRIPTION
🏷️ 变动类型
🐞 Bug 修复
🖥️ 影响范围
Desktop
CLI
（core 解析器被两端共用，Roo Code / Cline / Kilo Code 数据采集同步修复）

🔗 关联 Issue
Partially addresses #128（本 PR 只修 ② 组 Kilocode / Roo Code；① EPERM 与 ④ 测试修正后续 PR 跟进）

💡 改动说明
原来的问题：AI_USAGE_VSCODE_ROOTS / AI_USAGE_KILOCODE_ROOTS 路径列表用 .split(/[:;,]/) 切分。Windows 绝对路径都带盘符冒号（C:\Users\...），整条路径被劈成 C + \Users\... 两个不存在的路径——Windows 上 Kilo Code / Roo Code 数据源完全采不到数据，CI 的 windows-latest 上 2 条测试因此失败（#128 ② 组）。

怎么改的：parsers/shared.ts 新增 splitRootsList(raw, plat?)，win32 用 [,;] 切分，其他平台保持历史 [:;,] 集合（零行为变化）；vscodeHostRoots() 与 kilocodeHostRoots() 改为共用该助手。plat 作为测试注入口，win32 行为可在任意平台单测。

备选方案：考虑过沿用 codex 的 node:path delimiter 先例（14e6a87），但 strict delimiter 会丢掉现有用户在 env 里用 , 分隔的兼容性，故采用平台条件正则。

验证：Windows 11 + Node v24 实机，pnpm --filter @juejin-opensource/jusage-core test 287 条，#128 ② 组 2 条转绿，新增 4 条用例（win32 盘符保护 / POSIX 兼容 / trim / env 集成）；pnpm build 全量通过。

📝 Changelog
包	版本类型	变更描述（面向用户）
@juejin-opensource/jusage-core	patch	修复 Windows 下 AI_USAGE_VSCODE_ROOTS / AI_USAGE_KILOCODE_ROOTS 路径列表被盘符冒号（C:）劈碎的问题，Kilo Code / Roo Code 等 VS Code 系数据源在 Windows 恢复正常采集。Windows 上多个根目录请用 ; 或 , 分隔；其他平台 : 分隔符保持兼容。
☑️ 自查清单
分支命名符合
<type>/<end>/<short-desc>
：
fix/cli/windows-roots-separator
已在受影响的端本地自测通过（Windows 实机 core 全量测试）
未改动面板 UI，不涉及 dashboard / desktop renderer 同步
已执行
pnpm changeset

pnpm build
通过