### PR TITLE
fix(core): scan both WorkBuddy edition homes for usage

### DIFF
--- a/.changeset/workbuddy-intl-home.md
+++ b/.changeset/workbuddy-intl-home.md
@@ -1,0 +1,8 @@
+---
+'@juejin-opensource/jusage-core': patch
+---
+
+Include WorkBuddy's international edition in the WorkBuddy source by scanning
+both the domestic `~/.workbuddy` and international `~/.workbuddy-ai` data
+directories. Usage produced by the international edition no longer shows up as
+missing in the dashboard.

--- a/.changeset/workbuddy-intl-home.md
+++ b/.changeset/workbuddy-intl-home.md
@@ -6,3 +6,8 @@ Include WorkBuddy's international edition in the WorkBuddy source by scanning
 both the domestic `~/.workbuddy` and international `~/.workbuddy-ai` data
 directories. Usage produced by the international edition no longer shows up as
 missing in the dashboard.
+
+`session_usage` rows for the same session id across the two edition DBs are
+merged before the incremental delta is computed (largest `used` wins), so a
+session mirrored in both homes is counted once and a lagging mirror cannot
+flip the sqlite cursor back and forth.

--- a/packages/core/src/parsers/workbuddy.ts
+++ b/packages/core/src/parsers/workbuddy.ts
@@ -334,6 +334,15 @@ export async function parseWorkbuddyIncremental(
   }
 
   // Older WorkBuddy DBs only have sessions/workspaces — skip when session_usage is absent.
+  // Rows for the same session id across edition DBs are merged first (largest `used`
+  // wins, ties break on the newer `updated_at`): the cursor key is the bare session id
+  // so a session mirrored in both homes is counted once, and merging keeps a lagging
+  // mirror from flipping the cursor back and forth (which would re-emit a delta,
+  // or trip the reset heuristic, on every run).
+  const mergedDbRows = new Map<
+    string,
+    { used: number; updatedAt: number; model: string }
+  >();
   for (const dbPath of dbPaths) {
     if (!sqliteTableExists(dbPath, 'session_usage')) continue;
 
@@ -367,61 +376,76 @@ export async function parseWorkbuddyIncremental(
         const rawModel = typeof row.model === 'string' ? row.model.trim() : '';
         if (usedNow <= 0 || updatedAtRaw <= 0) continue;
 
-        const prev = sqliteSessions[sessionId] ?? { used: 0 };
-        const prevUsed = toNonNeg(prev.used);
-        const isReset = usedNow > 0 && prevUsed > 0 && usedNow < prevUsed;
-        const inputDelta = isReset ? usedNow : Math.max(0, usedNow - prevUsed);
-        if (inputDelta === 0) {
-          sqliteSessions[sessionId] = {
-            ...prev,
-            used: usedNow,
-            updatedAt: updatedAtRaw,
-            model: rawModel || prev.model || fallbackModel,
-          };
-          continue;
+        const current = mergedDbRows.get(sessionId);
+        if (
+          !current ||
+          usedNow > current.used ||
+          (usedNow === current.used && updatedAtRaw > current.updatedAt)
+        ) {
+          mergedDbRows.set(sessionId, { used: usedNow, updatedAt: updatedAtRaw, model: rawModel });
         }
-
-        const tsMs = updatedAtRaw > 10_000_000_000 ? updatedAtRaw : updatedAtRaw * 1000;
-        const hourStart = toUtcHalfHourStart(new Date(tsMs).toISOString());
-        if (!hourStart || new Date(hourStart).getTime() < sinceMs) {
-          sqliteSessions[sessionId] = {
-            used: usedNow,
-            updatedAt: updatedAtRaw,
-            model: normalizeModel(rawModel) || fallbackModel,
-          };
-          continue;
-        }
-
-        const model = normalizeModel(rawModel) || fallbackModel;
-        const delta: TokenTotals = {
-          input_tokens: inputDelta,
-          cached_input_tokens: 0,
-          cache_creation_input_tokens: 0,
-          output_tokens: 0,
-          reasoning_output_tokens: 0,
-          total_tokens: inputDelta,
-          conversation_count: prevUsed === 0 || isReset ? 1 : 0,
-        };
-
-        accumulateBucket(
-          bucketState,
-          'workbuddy',
-          model,
-          'unknown',
-          hourStart,
-          delta,
-          WORKBUDDY_COLLECTOR,
-        );
-        sqliteSessions[sessionId] = {
-          used: usedNow,
-          updatedAt: updatedAtRaw,
-          model,
-        };
-        eventsParsed += 1;
       }
     } catch {
       // SQLite fallback is best effort; detailed JSONL remains authoritative.
     }
+  }
+
+  for (const [sessionId, row] of mergedDbRows) {
+    const usedNow = row.used;
+    const updatedAtRaw = row.updatedAt;
+    const rawModel = row.model;
+
+    const prev = sqliteSessions[sessionId] ?? { used: 0 };
+    const prevUsed = toNonNeg(prev.used);
+    const isReset = usedNow > 0 && prevUsed > 0 && usedNow < prevUsed;
+    const inputDelta = isReset ? usedNow : Math.max(0, usedNow - prevUsed);
+    if (inputDelta === 0) {
+      sqliteSessions[sessionId] = {
+        ...prev,
+        used: usedNow,
+        updatedAt: updatedAtRaw,
+        model: rawModel || prev.model || fallbackModel,
+      };
+      continue;
+    }
+
+    const tsMs = updatedAtRaw > 10_000_000_000 ? updatedAtRaw : updatedAtRaw * 1000;
+    const hourStart = toUtcHalfHourStart(new Date(tsMs).toISOString());
+    if (!hourStart || new Date(hourStart).getTime() < sinceMs) {
+      sqliteSessions[sessionId] = {
+        used: usedNow,
+        updatedAt: updatedAtRaw,
+        model: normalizeModel(rawModel) || fallbackModel,
+      };
+      continue;
+    }
+
+    const model = normalizeModel(rawModel) || fallbackModel;
+    const delta: TokenTotals = {
+      input_tokens: inputDelta,
+      cached_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      output_tokens: 0,
+      reasoning_output_tokens: 0,
+      total_tokens: inputDelta,
+      conversation_count: prevUsed === 0 || isReset ? 1 : 0,
+    };
+
+    accumulateBucket(
+      bucketState,
+      'workbuddy',
+      model,
+      'unknown',
+      hourStart,
+      delta,
+      WORKBUDDY_COLLECTOR,
+    );
+    sqliteSessions[sessionId] = {
+      used: usedNow,
+      updatedAt: updatedAtRaw,
+      model,
+    };
+    eventsParsed += 1;
   }
 
   ext.workbuddy.seenIds = Array.from(seenIds).slice(-10_000);

--- a/packages/core/src/parsers/workbuddy.ts
+++ b/packages/core/src/parsers/workbuddy.ts
@@ -1,7 +1,10 @@
 /**
  * WorkBuddy passive reader (source `workbuddy`, collector `workbuddy`).
  *
- * Recursively scans ~/.workbuddy/projects/ for .jsonl files (including subagents/).
+ * Recursively scans `<workbuddy-home>/projects/` for .jsonl files (including
+ * subagents/). WorkBuddy ships two editions that keep separate homes: the
+ * domestic `~/.workbuddy` and the international `~/.workbuddy-ai`. Both are
+ * scanned by default — see workbuddyHomeCandidates().
  * Token math differs from CodeBuddy — see normalizeWorkbuddyUsage().
  * SQLite fallback reads workbuddy.db session_usage when a session has no JSONL detail.
  */
@@ -39,21 +42,53 @@ function expandHome(p: string): string {
   return p.startsWith('~') ? join(homedir(), p.slice(1)) : p;
 }
 
-export function resolveWorkbuddyHome(env: NodeJS.ProcessEnv = process.env): string {
+/** Domestic-edition data directory (historically the only home we scanned). */
+const WORKBUDDY_HOME_DIRNAME = '.workbuddy';
+/** International-edition data directory (`WorkBuddy AI`). */
+const WORKBUDDY_INTL_HOME_DIRNAME = '.workbuddy-ai';
+
+/**
+ * WorkBuddy homes that can hold project JSONL and the SQLite usage DB.
+ *
+ * WorkBuddy's domestic and international editions are separate installs with
+ * separate data directories, so scanning only `~/.workbuddy` silently drops all
+ * international-edition usage. `WORKBUDDY_HOME` stays a full override: when it
+ * is set we scan that directory alone, keeping custom installs and tests
+ * isolated from the developer's real homes.
+ */
+export function workbuddyHomeCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+  const roots: string[] = [];
+  const add = (value: string): void => {
+    const home = expandHome(value);
+    if (home && !roots.includes(home)) roots.push(home);
+  };
+
   const override = env.WORKBUDDY_HOME?.trim();
-  if (override) return expandHome(override);
-  return join(homedir(), '.workbuddy');
+  if (override) {
+    add(override);
+    return roots;
+  }
+
+  add(join(homedir(), WORKBUDDY_HOME_DIRNAME));
+  add(join(homedir(), WORKBUDDY_INTL_HOME_DIRNAME));
+  return roots;
+}
+
+/** Primary WorkBuddy home (first candidate); `WORKBUDDY_HOME` wins when set. */
+export function resolveWorkbuddyHome(env: NodeJS.ProcessEnv = process.env): string {
+  return workbuddyHomeCandidates(env)[0] ?? join(homedir(), WORKBUDDY_HOME_DIRNAME);
 }
 
 export function resolveWorkbuddyDefaultModel(env: NodeJS.ProcessEnv = process.env): string {
   const fallback = 'auto';
-  try {
-    const home = resolveWorkbuddyHome(env);
-    const raw = readFileSync(join(home, 'settings.json'), 'utf-8');
-    const parsed = JSON.parse(raw) as { model?: unknown };
-    if (typeof parsed.model === 'string' && parsed.model.trim()) return parsed.model.trim();
-  } catch {
-    // settings missing or malformed
+  for (const home of workbuddyHomeCandidates(env)) {
+    try {
+      const raw = readFileSync(join(home, 'settings.json'), 'utf-8');
+      const parsed = JSON.parse(raw) as { model?: unknown };
+      if (typeof parsed.model === 'string' && parsed.model.trim()) return parsed.model.trim();
+    } catch {
+      // settings missing or malformed for this home — try the next candidate
+    }
   }
   return fallback;
 }
@@ -84,10 +119,19 @@ function walkJsonlFiles(dir: string, out: string[]): void {
 }
 
 export function resolveWorkbuddyProjectFiles(env: NodeJS.ProcessEnv = process.env): string[] {
-  const home = resolveWorkbuddyHome(env);
   const files: string[] = [];
-  const projectsDir = join(home, 'projects');
-  if (existsSync(projectsDir)) walkJsonlFiles(projectsDir, files);
+  const seen = new Set<string>();
+  for (const home of workbuddyHomeCandidates(env)) {
+    const projectsDir = join(home, 'projects');
+    if (!existsSync(projectsDir)) continue;
+    const discovered: string[] = [];
+    walkJsonlFiles(projectsDir, discovered);
+    for (const file of discovered) {
+      if (seen.has(file)) continue;
+      seen.add(file);
+      files.push(file);
+    }
+  }
   files.sort((a, b) => a.localeCompare(b));
   return files;
 }
@@ -183,9 +227,10 @@ export async function parseWorkbuddyIncremental(
   const bucketState: BucketAccumulator = new Map();
   const fallbackModel = opts?.defaultModel ?? resolveWorkbuddyDefaultModel(env);
   const files = opts?.projectFiles ?? resolveWorkbuddyProjectFiles(env);
-  const workbuddyHome = resolveWorkbuddyHome(env);
-  const dbPath = join(workbuddyHome, 'workbuddy.db');
-  const dbExists = existsSync(dbPath);
+  // Each edition home owns its own workbuddy.db; fall back to every candidate.
+  const dbPaths = workbuddyHomeCandidates(env)
+    .map((home) => join(home, 'workbuddy.db'))
+    .filter((path) => existsSync(path));
 
   let eventsParsed = 0;
   let filesProcessed = 0;
@@ -289,7 +334,9 @@ export async function parseWorkbuddyIncremental(
   }
 
   // Older WorkBuddy DBs only have sessions/workspaces — skip when session_usage is absent.
-  if (dbExists && sqliteTableExists(dbPath, 'session_usage')) {
+  for (const dbPath of dbPaths) {
+    if (!sqliteTableExists(dbPath, 'session_usage')) continue;
+
     const query = `
       SELECT
         su.session_id,

--- a/packages/core/src/server/state.ts
+++ b/packages/core/src/server/state.ts
@@ -215,7 +215,7 @@ export function buildSyncStatus(
       ),
       workbuddy: poll(
         'workbuddy',
-        'WorkBuddy 读取 ~/.workbuddy/projects JSONL / SQLite，定时轮询同步',
+        'WorkBuddy 读取 ~/.workbuddy 与 ~/.workbuddy-ai 的 projects JSONL / SQLite，定时轮询同步',
         countWorkbuddyRows(rows),
       ),
       grok: poll(

--- a/packages/core/src/sync/source-presence.ts
+++ b/packages/core/src/sync/source-presence.ts
@@ -17,7 +17,7 @@ import { ompAgentDirCollidesWithPi, ompSessionsDir } from '../parsers/omp.js';
 import { openclawRoots } from '../parsers/openclaw.js';
 import { piSessionsDir } from '../parsers/pi.js';
 import { qwenTmpDir } from '../parsers/qwen.js';
-import { resolveWorkbuddyHome } from '../parsers/workbuddy.js';
+import { workbuddyHomeCandidates } from '../parsers/workbuddy.js';
 import { zcodeDbPath } from '../parsers/zcode.js';
 import { dshHome } from '../parsers/dsh.js';
 import { zedDbPath } from '../parsers/zed.js';
@@ -141,11 +141,10 @@ export function isSyncSourcePresent(source: string): boolean {
         join(resolveCodebuddyHome(), 'projects'),
       ]);
     case 'workbuddy':
-      return anyExists([
-        resolveWorkbuddyHome(),
-        join(resolveWorkbuddyHome(), 'projects'),
-        join(resolveWorkbuddyHome(), 'workbuddy.db'),
-      ]);
+      // Domestic and international editions use separate homes; either is enough.
+      return workbuddyHomeCandidates().some((home) =>
+        anyExists([home, join(home, 'projects'), join(home, 'workbuddy.db')]),
+      );
     case 'grok':
       return anyExists([
         resolveGrokBuildHome(),

--- a/packages/core/test/p2-parsers.test.ts
+++ b/packages/core/test/p2-parsers.test.ts
@@ -9,7 +9,11 @@ import { parseClineIncremental } from '../src/parsers/cline.js';
 import { parseAmpIncremental } from '../src/parsers/amp.js';
 import { parseQwenIncremental } from '../src/parsers/qwen.js';
 import { parseCodebuddyIncremental } from '../src/parsers/codebuddy.js';
-import { parseWorkbuddyIncremental } from '../src/parsers/workbuddy.js';
+import {
+  parseWorkbuddyIncremental,
+  resolveWorkbuddyHome,
+  workbuddyHomeCandidates,
+} from '../src/parsers/workbuddy.js';
 import { parseGrokBuildIncremental } from '../src/parsers/grok.js';
 import { parseMimoIncremental } from '../src/parsers/mimo.js';
 import { parseEveryCodeIncremental } from '../src/parsers/every-code.js';
@@ -174,6 +178,195 @@ test('parseWorkbuddyIncremental subtracts cacheRead and cacheCreate from prompt'
   } finally {
     if (prev === undefined) delete process.env.WORKBUDDY_HOME;
     else process.env.WORKBUDDY_HOME = prev;
+  }
+});
+
+const WORKBUDDY_ENV_KEYS = ['HOME', 'USERPROFILE', 'WORKBUDDY_HOME'] as const;
+
+type WorkbuddyEnvSnapshot = Record<(typeof WORKBUDDY_ENV_KEYS)[number], string | undefined>;
+
+function snapshotWorkbuddyEnv(): WorkbuddyEnvSnapshot {
+  return {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    WORKBUDDY_HOME: process.env.WORKBUDDY_HOME,
+  };
+}
+
+function restoreWorkbuddyEnv(snapshot: WorkbuddyEnvSnapshot): void {
+  for (const key of WORKBUDDY_ENV_KEYS) {
+    if (snapshot[key] === undefined) delete process.env[key];
+    else process.env[key] = snapshot[key];
+  }
+}
+
+/** Pin HOME to a temp tree so home discovery cannot see the developer's real homes. */
+function pinWorkbuddyHome(tempHome: string): void {
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  delete process.env.WORKBUDDY_HOME;
+}
+
+function workbuddyUsageLine(opts: {
+  sessionId: string;
+  messageId: string;
+  model?: string;
+  timestamp?: string;
+  promptTokens?: number;
+  completionTokens?: number;
+  cacheRead?: number;
+}): string {
+  return JSON.stringify({
+    sessionId: opts.sessionId,
+    id: opts.messageId,
+    timestamp: Date.parse(opts.timestamp ?? '2026-07-24T11:00:00.000Z'),
+    providerData: {
+      model: opts.model ?? 'wb-model',
+      rawUsage: {
+        prompt_tokens: opts.promptTokens ?? 100,
+        completion_tokens: opts.completionTokens ?? 40,
+        cache_read_input_tokens: opts.cacheRead ?? 20,
+      },
+    },
+  });
+}
+
+test('workbuddyHomeCandidates covers both editions and honours the override', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-home-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    assert.deepEqual(workbuddyHomeCandidates(), [
+      join(tempHome, '.workbuddy'),
+      join(tempHome, '.workbuddy-ai'),
+    ]);
+
+    process.env.WORKBUDDY_HOME = '~/custom-workbuddy';
+    assert.deepEqual(workbuddyHomeCandidates(), [join(tempHome, 'custom-workbuddy')]);
+    assert.equal(resolveWorkbuddyHome(), join(tempHome, 'custom-workbuddy'));
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
+  }
+});
+
+test('parseWorkbuddyIncremental reads the international ~/.workbuddy-ai home', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-intl-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    const intlProjects = join(tempHome, '.workbuddy-ai', 'projects');
+    await mkdir(intlProjects, { recursive: true });
+    await writeFile(
+      join(intlProjects, 'sess-intl.jsonl'),
+      workbuddyUsageLine({
+        sessionId: 'sess-intl',
+        messageId: 'm-intl',
+        model: 'wb-intl-model',
+      }) + '\n',
+    );
+
+    const { result } = await parseWorkbuddyIncremental({}, SINCE);
+    assert.equal(result.eventsParsed, 1);
+    assert.equal(result.buckets[0]!.source, 'workbuddy');
+    assert.equal(result.buckets[0]!.model, 'wb-intl-model');
+    assert.equal(result.buckets[0]!.input_tokens, 80);
+    assert.equal(result.buckets[0]!.cached_input_tokens, 20);
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
+  }
+});
+
+test('parseWorkbuddyIncremental aggregates both homes without double counting', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-both-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    const domProjects = join(tempHome, '.workbuddy', 'projects');
+    const intlProjects = join(tempHome, '.workbuddy-ai', 'projects');
+    await mkdir(domProjects, { recursive: true });
+    await mkdir(intlProjects, { recursive: true });
+
+    const shared = workbuddyUsageLine({ sessionId: 'sess-shared', messageId: 'm-shared' });
+    await writeFile(join(domProjects, 'sess-shared.jsonl'), `${shared}\n`);
+    await writeFile(join(intlProjects, 'sess-shared.jsonl'), `${shared}\n`);
+    await writeFile(
+      join(intlProjects, 'sess-intl-only.jsonl'),
+      workbuddyUsageLine({ sessionId: 'sess-intl-only', messageId: 'm-intl-only' }) + '\n',
+    );
+
+    const { result } = await parseWorkbuddyIncremental({}, SINCE);
+    assert.equal(result.eventsParsed, 2);
+    const totalInput = result.buckets.reduce((sum, b) => sum + b.input_tokens, 0);
+    assert.equal(totalInput, 160);
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
+  }
+});
+
+test('parseWorkbuddyIncremental keeps WORKBUDDY_HOME a full override', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-override-'));
+  const customHome = await mkdtemp(join(tmpdir(), 'tud-wb-custom-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    const intlProjects = join(tempHome, '.workbuddy-ai', 'projects');
+    await mkdir(intlProjects, { recursive: true });
+    await writeFile(
+      join(intlProjects, 'sess-intl.jsonl'),
+      workbuddyUsageLine({ sessionId: 'sess-intl', messageId: 'm-intl' }) + '\n',
+    );
+
+    const customProjects = join(customHome, 'projects');
+    await mkdir(customProjects, { recursive: true });
+    await writeFile(
+      join(customProjects, 'sess-custom.jsonl'),
+      workbuddyUsageLine({
+        sessionId: 'sess-custom',
+        messageId: 'm-custom',
+        model: 'wb-custom-model',
+      }) + '\n',
+    );
+
+    process.env.WORKBUDDY_HOME = customHome;
+    const { result } = await parseWorkbuddyIncremental({}, SINCE);
+    assert.equal(result.eventsParsed, 1);
+    assert.equal(result.buckets[0]!.model, 'wb-custom-model');
+    assert.equal(result.buckets[0]!.input_tokens, 80);
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
+  }
+});
+
+test('parseWorkbuddyIncremental falls back to session_usage in the intl DB', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-intl-db-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    const intlHome = join(tempHome, '.workbuddy-ai');
+    await mkdir(intlHome, { recursive: true });
+    const dbPath = join(intlHome, 'workbuddy.db');
+    const db = new DatabaseSync(dbPath);
+    db.exec('CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT, cwd TEXT)');
+    db.exec(`CREATE TABLE session_usage (
+      session_id TEXT PRIMARY KEY,
+      used INTEGER,
+      updated_at INTEGER
+    )`);
+    db.prepare('INSERT INTO sessions VALUES (?, ?, ?)').run('sess-db', 'wb-db-model', '/tmp/app');
+    db.prepare('INSERT INTO session_usage VALUES (?, ?, ?)').run(
+      'sess-db',
+      120,
+      Date.parse('2026-07-24T11:00:00.000Z'),
+    );
+    db.close();
+
+    const { result } = await parseWorkbuddyIncremental({}, SINCE);
+    assert.equal(result.eventsParsed, 1);
+    assert.equal(result.buckets[0]!.source, 'workbuddy');
+    assert.equal(result.buckets[0]!.model, 'wb-db-model');
+    assert.equal(result.buckets[0]!.input_tokens, 120);
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
   }
 });
 

--- a/packages/core/test/p2-parsers.test.ts
+++ b/packages/core/test/p2-parsers.test.ts
@@ -370,6 +370,71 @@ test('parseWorkbuddyIncremental falls back to session_usage in the intl DB', asy
   }
 });
 
+async function createWorkbuddyUsageDb(
+  homeDir: string,
+  sessionId: string,
+  used: number,
+  updatedAt: number,
+): Promise<void> {
+  await mkdir(homeDir, { recursive: true });
+  const db = new DatabaseSync(join(homeDir, 'workbuddy.db'));
+  db.exec('CREATE TABLE sessions (id TEXT PRIMARY KEY, model TEXT, cwd TEXT)');
+  db.exec(`CREATE TABLE session_usage (
+    session_id TEXT PRIMARY KEY,
+    used INTEGER,
+    updated_at INTEGER
+  )`);
+  db.prepare('INSERT INTO sessions VALUES (?, ?, ?)').run(sessionId, 'wb-db-model', '/tmp/app');
+  db.prepare('INSERT INTO session_usage VALUES (?, ?, ?)').run(sessionId, used, updatedAt);
+  db.close();
+}
+
+test('parseWorkbuddyIncremental counts a sqlite session mirrored in both homes once', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-db-mirror-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    const updatedAt = Date.parse('2026-07-24T11:00:00.000Z');
+    // Same session id recorded by both editions with the same counter.
+    await createWorkbuddyUsageDb(join(tempHome, '.workbuddy'), 'sess-mirror', 120, updatedAt);
+    await createWorkbuddyUsageDb(join(tempHome, '.workbuddy-ai'), 'sess-mirror', 120, updatedAt);
+
+    const { result, cursors } = await parseWorkbuddyIncremental({}, SINCE);
+    assert.equal(result.eventsParsed, 1);
+    const totalInput = result.buckets.reduce((sum, b) => sum + b.input_tokens, 0);
+    assert.equal(totalInput, 120);
+    const ext = cursors as { workbuddy?: { sqliteSessions?: Record<string, { used: number }> } };
+    assert.equal(ext.workbuddy?.sqliteSessions?.['sess-mirror']?.used, 120);
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
+  }
+});
+
+test('parseWorkbuddyIncremental keeps the sqlite cursor stable when a mirrored session lags', async () => {
+  const tempHome = await mkdtemp(join(tmpdir(), 'tud-wb-db-lag-'));
+  const snapshot = snapshotWorkbuddyEnv();
+  try {
+    pinWorkbuddyHome(tempHome);
+    const updatedAt = Date.parse('2026-07-24T11:00:00.000Z');
+    // Same session id, but the intl counter lags behind the CN one.
+    await createWorkbuddyUsageDb(join(tempHome, '.workbuddy'), 'sess-lag', 120, updatedAt);
+    await createWorkbuddyUsageDb(join(tempHome, '.workbuddy-ai'), 'sess-lag', 80, updatedAt);
+
+    const first = await parseWorkbuddyIncremental({}, SINCE);
+    assert.equal(first.result.eventsParsed, 1);
+    const firstInput = first.result.buckets.reduce((sum, b) => sum + b.input_tokens, 0);
+    assert.equal(firstInput, 120);
+
+    // A lagging mirror must not flip the cursor: later runs emit nothing.
+    const second = await parseWorkbuddyIncremental(first.cursors, SINCE);
+    assert.equal(second.result.eventsParsed, 0);
+    const secondInput = second.result.buckets.reduce((sum, b) => sum + b.input_tokens, 0);
+    assert.equal(secondInput, 0);
+  } finally {
+    restoreWorkbuddyEnv(snapshot);
+  }
+});
+
 test('parseCodebuddyIncremental subtracts cached tokens from prompt', async () => {
   const home = await mkdtemp(join(tmpdir(), 'tud-cb-'));
   const prev = process.env.CODEBUDDY_HOME;


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🔌 新增 / 修复数据源解析器（parser）

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [ ] Web

<!-- 改动落在 packages/core，Desktop 与 CLI 共用同一份采集逻辑；Web 面板不读本地目录。 -->

### 🔗 关联 Issue

没有对应的 issue。起因是本机同时装了国内版和国际版 WorkBuddy，面板里只统计到国内版的用量，排查后确认是采集器只扫了一个数据目录。

### 💡 改动说明

**1. 原来有什么问题**

`packages/core/src/parsers/workbuddy.ts` 的 `resolveWorkbuddyHome()` 只解析出**一个** home：`WORKBUDDY_HOME`，否则 `~/.workbuddy`。

WorkBuddy 国内版和国际版是两个独立安装、各自一个数据目录：国内版 `~/.workbuddy`，国际版 `~/.workbuddy-ai`。因此只装（或主要使用）国际版时，`projects/*.jsonl` 和 `workbuddy.db` 全在 `~/.workbuddy-ai`，采集器一个都看不到，WorkBuddy 这一行的用量会长期为空或明显偏少——而且不报错，只是静默漏采。

在同时装了两个版本的机器上实测：

| | 发现的 JSONL | 事件数 | 总 token |
| --- | --- | --- | --- |
| 修复前（只扫 `~/.workbuddy`） | 6 | 376 | 40,106,677 |
| 修复后（两个 home 都扫） | 17 | 1611 | 257,929,005 |

修复前国际版专属的模型完全没有出现在 bucket 里，修复后正常出现。

**2. 这版怎么改的**

- 新增 `workbuddyHomeCandidates()`，默认返回 `~/.workbuddy` 和 `~/.workbuddy-ai`。JSONL 发现（`resolveWorkbuddyProjectFiles`）、`settings.json` 回退模型、`workbuddy.db` 的 `session_usage` 兜底三处都改为遍历全部候选目录，并对发现的路径去重。
- 去重沿用原有的游标键 `seenIds`（messageId）与 `sqliteSessions`（sessionId），**没有改动 `cursors.json` 的结构**：一是老用户的游标继续有效，不会因为键变化把历史会话重算一遍；二是同一个 session 在两个 home 都有镜像时只会记一次，不会翻倍。
- `WORKBUDDY_HOME` 保持「完全覆盖」语义：设了就只扫它。自定义安装位置的行为不变，测试也能和开发者本机的真实目录隔离（做法对齐 `codexHomeCandidates()`）。
- 同步更新 `isSyncSourcePresent('workbuddy')`（任一 home 存在即视为存在）与面板里这一行的数据源说明文案。
- `resolveWorkbuddyHome()` 继续保留并导出，内部改为返回首个候选，避免破坏公开 API。

**3. 没有动 UI / 交互**，无需对比图。

被否掉的备选方案：把默认值从 `~/.workbuddy` 直接改成 `~/.workbuddy-ai`。这样只是把漏采从一边换到另一边，两个版本都装的用户仍然只能看到一半。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-core` | patch | 同时读取 WorkBuddy 国内版 `~/.workbuddy` 与国际版 `~/.workbuddy-ai` 的数据目录，国际版的 token 用量不再漏统计。 |

changeset 文件 `.changeset/workbuddy-intl-home.md` 已一并提交，描述与上表一致。

### ☑️ 自查清单

- [x] 分支命名符合 `<type>/<end>/<short-desc>`（`fix/desktop/workbuddy-intl-home`）
- [x] 已在受影响的端本地自测通过（core 单测 + 本机真实目录跑通）
- [x] 未改动面板 UI，无需核对 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 两份同构代码
- [x] 已执行 changeset 并提交
- [ ] `pnpm build` 通过 —— 见下方说明

补充说明：

- 新增 5 个单测：两个 home 的发现 / 聚合 / 跨目录去重、`WORKBUDDY_HOME` 覆盖语义、国际版 DB 兜底。**全部使用合成数据，不含任何真实会话内容、凭据或原始使用记录。**
- `packages/core` 测试共 288 项，其中 5 项失败均为既有的 `runtime-pid` 用例（依赖 `ps` 读取进程启动时间，在受限沙箱环境下必失败），与本次改动无关。
- 本机只跑通了 `pnpm --filter @juejin-opensource/jusage-core build`。完整 `pnpm build` 需要构建 Electron 桌面端，当前环境拉不到 electron 二进制，没能跑通，麻烦 CI 帮忙确认。
