### PR TITLE
fix(desktop): 未勾选的复选框在深色模式下不可见，补一条可见边框（Desktop / CLI / Web 同步）

### DIFF
--- a/.changeset/checkbox-unselected-contrast.md
+++ b/.changeset/checkbox-unselected-contrast.md
@@ -1,0 +1,6 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+"@juejin-opensource/jusage-dashboard": patch
+---
+
+修复设置面板中未勾选的复选框在深色模式下与背景融为一体、几乎不可见的问题：现在未选中状态有清晰的边框轮廓，深浅两种主题下均可辨识。

--- a/apps/desktop/src/renderer/index.css
+++ b/apps/desktop/src/renderer/index.css
@@ -208,3 +208,18 @@
     font: inherit;
   }
 }
+
+@layer components {
+  /* HeroUI's default theme leaves the unselected checkbox invisible: the
+   * control background (--field-background) equals the settings overlay
+   * background in dark mode (oklch 21%, 1.00:1), --field-border is
+   * transparent, and --field-shadow is transparent in dark mode. Give
+   * unselected controls a visible 1px border (--muted is >= 3:1 against both
+   * themes, WCAG 1.4.11). Selector mirrors the library's own unselected-state
+   * rule so selected / indeterminate / hover states keep their styles. */
+  .checkbox:not([aria-checked="true"]):not([data-selected="true"]):not([data-indeterminate="true"])
+    .checkbox__control {
+    border-color: var(--muted);
+    border-width: 1px;
+  }
+}

--- a/packages/dashboard/src/index.css
+++ b/packages/dashboard/src/index.css
@@ -185,3 +185,18 @@
     font: inherit;
   }
 }
+
+@layer components {
+  /* HeroUI's default theme leaves the unselected checkbox invisible: the
+   * control background (--field-background) equals the settings overlay
+   * background in dark mode (oklch 21%, 1.00:1), --field-border is
+   * transparent, and --field-shadow is transparent in dark mode. Give
+   * unselected controls a visible 1px border (--muted is >= 3:1 against both
+   * themes, WCAG 1.4.11). Selector mirrors the library's own unselected-state
+   * rule so selected / indeterminate / hover states keep their styles. */
+  .checkbox:not([aria-checked="true"]):not([data-selected="true"]):not([data-indeterminate="true"])
+    .checkbox__control {
+    border-color: var(--muted);
+    border-width: 1px;
+  }
+}


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🐞 Bug 修复
- [x] 💄 样式与交互改进

### 🖥️ 影响范围

- [x] Desktop
- [x] CLI
- [x] Web

Desktop / CLI / Web 共用同一套 HeroUI Checkbox 样式：`apps/desktop/src/renderer`（桌面端设置窗口）与 `packages/dashboard`（CLI 面板 + juejin.cn 网页统计页）各有一份 CSS 入口，本次两处同步修改。

### 🔗 关联 Issue

fix #142

### 💡 改动说明

**原来有什么问题**：未勾选的 checkbox 在深色模式下与弹窗背景完全融为一体，用户无法分辨控件位置。根因是 HeroUI 3.2.4 默认主题在未选中态的三个视觉线索同时失效：

1. 控件底色 `bg-field`（`--field-background`）在深色主题下的值与设置弹窗背景 `--overlay` 是同一个值 `oklch(21% 0.0059 285.89)`，对比度 1.00:1；
2. 边框色 `border-field-border` 解析为 `--field-border: transparent`；且 `checkbox.css` 引用的边框宽度变量 `--border-width-field` 在主题中**从未定义**（主题定义的是 `--field-border-width: 0px`，变量名不匹配），声明失效后回退到 initial 值 `medium`——即一个 3px 的透明边框；
3. `--field-shadow` 在深色主题下为 `0 0 0 0 transparent`。

浅色模式仅靠 alpha 0.04~0.06 的微弱阴影区分，同样偏弱。

**怎么改的**：在两个 CSS 入口（`apps/desktop/src/renderer/index.css`、`packages/dashboard/src/index.css`）的 `@layer components` 中给未选中控件补一条 1px 可见边框，颜色用 `--muted`（深色 6.7:1、浅色 4.8:1，满足 WCAG 1.4.11 ≥ 3:1）。选择器复刻组件库自身「非选中态」的负向写法，因此选中/半选/hover/focus 态样式不受影响；不动主题 token，避免波及 Input/Select 等其他表单控件的无边框设计。

**验证**：用构建产物 CSS 搭了最小复现页（`.dark`/`.light` 两块 `--overlay` 背景各放未选中+选中两个 checkbox），computed style 确认未选中控件为 `border-width: 1px; border-color: var(--muted)`；截图对比确认修复前深色下不可见、修复后两种主题轮廓清晰。选中态蓝色填充外观无变化。

（环境无截图上传通道，对比图未能附在 PR 里；复现方式如上，两分钟可重建。）

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-desktop` | patch | 修复设置面板中未勾选的复选框在深色模式下与背景融为一体、几乎不可见的问题：现在未选中状态有清晰的边框轮廓，深浅两种主题下均可辨识。 |
| `@juejin-opensource/jusage-dashboard` | patch | 同上（CLI 面板与网页统计页共用）。 |

### ✅ 验证

- `pnpm build`：通过
- `pnpm test`：四个包全部通过
- 构建产物 CSS 中确认规则位于 `@layer components`，未选中控件 computed style 为 `border-width: 1px; border-color: var(--muted)`

### ☑️ 自查清单

- [x] 分支命名符合规范（`fix/desktop/checkbox-unselected-contrast`，跨端改动取影响最大的一端）
- [x] Dashboard 与 Desktop renderer 两份同构代码已同步修改
- [x] 已添加 changeset
- [x] `pnpm build` 通过
