### PR TITLE
fix(dashboard): 修复 Token 趋势在缓存远大于输入时把输入画成 0

### DIFF
--- a/.changeset/token-trend-uncached-split.md
+++ b/.changeset/token-trend-uncached-split.md
@@ -1,0 +1,7 @@
+---
+'@juejin-opensource/jusage-core': patch
+'@juejin-opensource/jusage-dashboard': patch
+'@juejin-opensource/jusage-desktop': patch
+---
+
+修复 Token 趋势「详细」视图在缓存远大于未缓存输入时把输入画成 0 的问题；日/小时构成改用未缓存输入与独立缓存列，不再二次相减或截断。

--- a/apps/desktop/src/renderer/lib/dashboard-data.ts
+++ b/apps/desktop/src/renderer/lib/dashboard-data.ts
@@ -235,8 +235,9 @@ export function buildFilledHourlyForDate(
 
     const inputTokens = api.inputTokens;
     const outputTokens = api.outputTokens;
-    // Cache is a separate column; do not clamp as a subset of input (parsers
-    // like Cursor already store net input without cache).
+    // Cache is a separate column (uncached input ≠ superset of cache reads).
+    // Do not clamp cache to input, and do not fold cache into inputTokens —
+    // trend charts and metric cards both expect uncached input here.
     const cachedInputTokens = Math.max(0, api.cachedInputTokens);
     return {
       day,
@@ -463,11 +464,13 @@ function normalizeDailyRow(
   let cacheCreationInputTokens: number;
 
   if (hasRealBreakdown) {
+    // Local/daily API `inputTokens` is uncached input; cache read is separate.
     inputTokens = Math.max(0, row.inputTokens ?? 0);
     outputTokens = Math.max(0, row.outputTokens ?? 0);
     cachedInputTokens = Math.max(0, row.cachedInputTokens ?? 0);
     cacheCreationInputTokens = Math.max(0, row.cacheCreationInputTokens ?? 0);
   } else {
+    // Estimated `inputTokens` still means gross input (cache as a subset).
     const inputRatio = 0.78;
     const cacheRatio = 0.2;
     inputTokens = Math.round(row.tokens * inputRatio);
@@ -479,14 +482,18 @@ function normalizeDailyRow(
     cacheCreationInputTokens = 0;
   }
 
+  const uncachedInputTokens = hasRealBreakdown
+    ? inputTokens
+    : Math.max(0, inputTokens - cachedInputTokens);
+
   return {
     day: weekdayForDate(row.date),
     date: row.date,
     dateLabel: formatDateLabel(row.date),
-    inputTokens,
+    inputTokens: hasRealBreakdown ? inputTokens : uncachedInputTokens,
     cachedInputTokens,
     cacheCreationInputTokens,
-    uncachedInputTokens: Math.max(0, inputTokens - cachedInputTokens),
+    uncachedInputTokens,
     outputTokens,
     // 总 Token 用 API 五类之和；有真实 I/O 时输入/输出可小于总（cache 等不进两卡）。
     totalTokens: row.tokens,

--- a/apps/desktop/src/renderer/lib/usage-filter.ts
+++ b/apps/desktop/src/renderer/lib/usage-filter.ts
@@ -529,16 +529,13 @@ function scaleDailyTrendRow(
   }
 
   const inputTokens = Math.round(row.inputTokens * share);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.round(row.cachedInputTokens * share),
-  );
+  const cachedInputTokens = Math.round(row.cachedInputTokens * share);
   return {
     ...row,
     inputTokens,
     cachedInputTokens,
     cacheCreationInputTokens: Math.round(row.cacheCreationInputTokens * share),
-    uncachedInputTokens: Math.max(0, inputTokens - cachedInputTokens),
+    uncachedInputTokens: Math.round(row.uncachedInputTokens * share),
     outputTokens: Math.round(row.outputTokens * share),
     totalTokens: Math.round(row.totalTokens * share),
     costUsd: row.costUsd * share,
@@ -564,10 +561,7 @@ function scaleHourlyTrendRow(
   }
 
   const inputTokens = Math.round(row.inputTokens * share);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.round(row.cachedInputTokens * share),
-  );
+  const cachedInputTokens = Math.round(row.cachedInputTokens * share);
   return {
     ...row,
     inputTokens,

--- a/packages/core/src/dashboard-trend.ts
+++ b/packages/core/src/dashboard-trend.ts
@@ -17,6 +17,7 @@ export interface UsageTrendDailyBucket {
 
 export interface UsageTrendHourlyBucket {
   hour: number;
+  /** Uncached input only — same column as the local hourly API. */
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
@@ -84,8 +85,11 @@ export function buildUsageTrendChartRows({
         buildUsageTrendChartPoint({
           label: `${row.hour}h`,
           dateLabel: `${row.hour}h`,
-          inputTokens: Math.max(0, row.inputTokens - row.cachedInputTokens),
-          cachedInputTokens: row.cachedInputTokens,
+          // Hourly API / filled rows already store uncached input; cache is a
+          // separate column. Subtracting again zeros the 输入 series whenever
+          // cache reads exceed fresh input (the common cached-turn shape).
+          inputTokens: Math.max(0, row.inputTokens),
+          cachedInputTokens: Math.max(0, row.cachedInputTokens),
           outputTokens: row.outputTokens,
           totalTokens: row.totalTokens,
           costUsd: row.costUsd,

--- a/packages/core/test/dashboard-trend.test.ts
+++ b/packages/core/test/dashboard-trend.test.ts
@@ -34,7 +34,7 @@ test('preserves the authoritative daily total and exposes unallocated tokens', (
   });
 });
 
-test('sorts hourly buckets and derives uncached input without changing totals', () => {
+test('sorts hourly buckets and keeps uncached input without subtracting cache', () => {
   const rows = buildUsageTrendChartRows({
     hourly: true,
     dailyRows: [],
@@ -49,10 +49,11 @@ test('sorts hourly buckets and derives uncached input without changing totals', 
       },
       {
         hour: 3,
+        // Cache reads routinely exceed fresh input on a cached turn.
         inputTokens: 10,
-        cachedInputTokens: 12,
+        cachedInputTokens: 12_000,
         outputTokens: 8,
-        totalTokens: 20,
+        totalTokens: 12_018,
         costUsd: 0.1,
       },
     ],
@@ -62,20 +63,20 @@ test('sorts hourly buckets and derives uncached input without changing totals', 
     {
       label: '3h',
       dateLabel: '3h',
-      inputTokens: 0,
-      cachedInputTokens: 12,
+      inputTokens: 10,
+      cachedInputTokens: 12_000,
       outputTokens: 8,
       otherTokens: 0,
-      totalTokens: 20,
+      totalTokens: 12_018,
       costUsd: 0.1,
     },
     {
       label: '12h',
       dateLabel: '12h',
-      inputTokens: 35,
+      inputTokens: 50,
       cachedInputTokens: 15,
       outputTokens: 30,
-      otherTokens: 20,
+      otherTokens: 5,
       totalTokens: 100,
       costUsd: 0.8,
     },

--- a/packages/dashboard/src/lib/dashboard-data.test.ts
+++ b/packages/dashboard/src/lib/dashboard-data.test.ts
@@ -330,6 +330,56 @@ test('buildFilledHourlyForDate coerces hour strings', () => {
   assert.equal(rows[14]?.totalTokens, 200);
 });
 
+test('daily rows keep uncached input when cache reads dwarf fresh input', () => {
+  const today = localDateNow();
+  const dataset = datasetWithDays([
+    {
+      date: today,
+      tokens: 20_024,
+      costUsd: 0.5,
+      models: { 'claude-sonnet-4-6': 20_024 },
+      inputTokens: 4,
+      outputTokens: 20,
+      cachedInputTokens: 20_000,
+      cacheCreationInputTokens: 0,
+    },
+  ]);
+
+  const view = buildDashboardDataFromDataset(dataset, 1);
+  const row = view.rangeDailyUsage.find((entry) => entry.date === today);
+  assert.ok(row);
+  assert.equal(row.inputTokens, 4);
+  assert.equal(row.uncachedInputTokens, 4);
+  assert.equal(row.cachedInputTokens, 20_000);
+  assert.equal(row.outputTokens, 20);
+  assert.equal(view.summary.inputTokens, 4);
+  assert.equal(view.summary.cachedInputTokens, 20_000);
+});
+
+test('buildFilledHourlyForDate does not clamp cache reads to uncached input', () => {
+  const rows = buildFilledHourlyForDate(
+    [
+      {
+        date: '2026-08-13',
+        hour: 9,
+        source: 'claude',
+        tokens: 20_024,
+        costUsd: 0.5,
+        inputTokens: 4,
+        outputTokens: 20,
+        cachedInputTokens: 20_000,
+      },
+    ],
+    '2026-08-13',
+    9,
+  );
+
+  assert.equal(rows[9]?.inputTokens, 4);
+  assert.equal(rows[9]?.cachedInputTokens, 20_000);
+  assert.equal(rows[9]?.outputTokens, 20);
+  assert.equal(rows[9]?.totalTokens, 20_024);
+});
+
 test('projectDashboardForDate fills hourly from ISO date rows', () => {
   const today = localDateNow();
   const yesterday = addLocalDays(today, -1);

--- a/packages/dashboard/src/lib/dashboard-data.ts
+++ b/packages/dashboard/src/lib/dashboard-data.ts
@@ -245,8 +245,9 @@ export function buildFilledHourlyForDate(
 
     const inputTokens = api.inputTokens;
     const outputTokens = api.outputTokens;
-    // Cache is a separate column; do not clamp as a subset of input (parsers
-    // like Cursor already store net input without cache).
+    // Cache is a separate column (uncached input ≠ superset of cache reads).
+    // Do not clamp cache to input, and do not fold cache into inputTokens —
+    // trend charts and metric cards both expect uncached input here.
     const cachedInputTokens = Math.max(0, api.cachedInputTokens);
     return {
       day,
@@ -456,12 +457,14 @@ function normalizeDailyRow(
   let cacheCreationInputTokens: number;
 
   if (hasRealBreakdown) {
+    // Local/daily API `inputTokens` is uncached input; cache read is separate.
     inputTokens = Math.max(0, row.inputTokens ?? 0);
     outputTokens = Math.max(0, row.outputTokens ?? 0);
     cachedInputTokens = Math.max(0, row.cachedInputTokens ?? 0);
     cacheCreationInputTokens = Math.max(0, row.cacheCreationInputTokens ?? 0);
   } else {
     // Legacy payloads without I/O: keep a stable visual split from total only.
+    // Estimated `inputTokens` still means gross input (cache as a subset).
     const template =
       dashboardMockData.dailyUsage[index % dashboardMockData.dailyUsage.length];
     const inputRatio = safeRatio(
@@ -483,6 +486,10 @@ function normalizeDailyRow(
     cacheCreationInputTokens = 0;
   }
 
+  const uncachedInputTokens = hasRealBreakdown
+    ? inputTokens
+    : Math.max(0, inputTokens - cachedInputTokens);
+
   const durationMinutes = Math.round(
     (hasRealBreakdown ? inputTokens + outputTokens : row.tokens) *
       safeRatio(
@@ -496,10 +503,10 @@ function normalizeDailyRow(
     day: weekdayForDate(row.date),
     date: row.date,
     dateLabel: formatDateLabel(row.date),
-    inputTokens,
+    inputTokens: hasRealBreakdown ? inputTokens : uncachedInputTokens,
     cachedInputTokens,
     cacheCreationInputTokens,
-    uncachedInputTokens: Math.max(0, inputTokens - cachedInputTokens),
+    uncachedInputTokens,
     outputTokens,
     // 总 Token 用 API 五类之和；有真实 I/O 时输入/输出可小于总（cache 等不进两卡）。
     totalTokens: row.tokens,

--- a/packages/dashboard/src/lib/dashboard-mock-data.ts
+++ b/packages/dashboard/src/lib/dashboard-mock-data.ts
@@ -339,17 +339,19 @@ function buildUsageSamples(): DashboardUsageSample[] {
         (500 + intensity * 38_000) * profile.scale,
       );
       const inputRatio = 0.72 + wave * 0.12;
-      const inputTokens = Math.round(totalTokens * inputRatio);
-      const outputTokens = totalTokens - inputTokens;
+      const grossInputTokens = Math.round(totalTokens * inputRatio);
+      const outputTokens = totalTokens - grossInputTokens;
       const cachedInputRatio =
         profile.model.includes('MiniMax') ||
         profile.model.includes('fable')
           ? 0.42 + wave * 0.28
           : 0.08 + wave * 0.18;
       const cachedInputTokens = Math.min(
-        inputTokens,
-        Math.round(inputTokens * cachedInputRatio),
+        grossInputTokens,
+        Math.round(grossInputTokens * cachedInputRatio),
       );
+      // Match the local API: inputTokens is uncached; cache is separate.
+      const inputTokens = Math.max(0, grossInputTokens - cachedInputTokens);
       const costUsd = roundCurrency(
         inputTokens * 0.000004 + outputTokens * 0.000016,
       );
@@ -697,7 +699,7 @@ function aggregateDailyUsage(
       totalTokens: usage.totalTokens,
       cachedInputTokens,
       cacheCreationInputTokens: 0,
-      uncachedInputTokens: usage.inputTokens - cachedInputTokens,
+      uncachedInputTokens: usage.inputTokens,
       costUsd: usage.totalCostUsd,
       durationMinutes: usage.totalDurationMinutes,
     };

--- a/packages/dashboard/src/lib/usage-filter.ts
+++ b/packages/dashboard/src/lib/usage-filter.ts
@@ -529,16 +529,13 @@ function scaleDailyTrendRow(
   }
 
   const inputTokens = Math.round(row.inputTokens * share);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.round(row.cachedInputTokens * share),
-  );
+  const cachedInputTokens = Math.round(row.cachedInputTokens * share);
   return {
     ...row,
     inputTokens,
     cachedInputTokens,
     cacheCreationInputTokens: Math.round(row.cacheCreationInputTokens * share),
-    uncachedInputTokens: Math.max(0, inputTokens - cachedInputTokens),
+    uncachedInputTokens: Math.round(row.uncachedInputTokens * share),
     outputTokens: Math.round(row.outputTokens * share),
     totalTokens: Math.round(row.totalTokens * share),
     costUsd: row.costUsd * share,
@@ -564,10 +561,7 @@ function scaleHourlyTrendRow(
   }
 
   const inputTokens = Math.round(row.inputTokens * share);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.round(row.cachedInputTokens * share),
-  );
+  const cachedInputTokens = Math.round(row.cachedInputTokens * share);
   return {
     ...row,
     inputTokens,


### PR DESCRIPTION
## Summary
- API 的 `inputTokens` 本身已是未缓存输入；日行再做 `input - cache`、小时趋势再减一次，会在缓存命中场景把「输入」画成 0
- 渠道筛选缩放不再把 cache 截断到 input 内；Dashboard / Desktop 同构数据层一并修正
- 吸收自 #135（ChenCJ-io）的口径结论，在已合入的 #144 / #130 之上做语义补丁，避免与那两份冲突硬合

## Test plan
- [ ] Token 趋势「详细」：找一天缓存远大于未缓存输入的数据，确认输入 / 缓存 / 输出都非 0 且合理
- [ ] 1D 小时视图同上，输入不再恒为 0
- [ ] 概览总 Token 问号构成：输入仍为未缓存，与缓存读/写分开，合计仍对得上
- [ ] 按工具筛选后，构成不被等比截断成假数据
- [x] `pnpm --filter @juejin-opensource/jusage-dashboard exec node --experimental-strip-types --test src/lib/dashboard-data.test.ts src/lib/usage-filter.test.ts`
- [x] `packages/core` `dashboard-trend` 测试
- [x] `pnpm --filter @juejin-opensource/jusage-desktop typecheck`


Made with [Cursor](https://cursor.com)