### PR TITLE
fix(web): keep inline SVG provider icons visible on light badges in dark mode

### DIFF
--- a/.changeset/dsh-icon-on-light-bg.md
+++ b/.changeset/dsh-icon-on-light-bg.md
@@ -1,0 +1,6 @@
+---
+"@juejin-opensource/jusage-desktop": patch
+"@juejin-opensource/jusage-dashboard": patch
+---
+
+修复「工具与模型用量」等白底徽章上的 DeepSeek Harness（及同类内联 SVG）渠道图标在深色模式下变成空白方块的问题：浅色底上强制使用深色填充，与 Cursor / ZCode 等单色图标一致。Desktop renderer 已同步。

--- a/apps/desktop/src/renderer/components/ProviderIcon.tsx
+++ b/apps/desktop/src/renderer/components/ProviderIcon.tsx
@@ -164,6 +164,9 @@ export function ProviderIcon({
 }: ProviderIconProps) {
   const key = normalizeProviderKey(provider);
   const asset = PROVIDER_ICON_MAP[key];
+  // Inline SVGs use currentColor. On light badges (e.g. bg-white in the tool
+  // usage card) force a dark fill so dark-mode foreground does not wash out.
+  const svgColor = color ?? (onLightBackground ? '#111827' : undefined);
 
   if (asset) {
     return (
@@ -192,7 +195,7 @@ export function ProviderIcon({
       <DroidIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -202,7 +205,7 @@ export function ProviderIcon({
       <OmpIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -212,7 +215,7 @@ export function ProviderIcon({
       <ZedIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -222,7 +225,7 @@ export function ProviderIcon({
       <WarpIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -232,12 +235,12 @@ export function ProviderIcon({
       <DeepSeekHarnessIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
 
-  return <PlaceholderIcon className={className} size={size} style={{ color }} />;
+  return <PlaceholderIcon className={className} size={size} style={{ color: svgColor }} />;
 }
 
 function OmpIcon({

--- a/packages/dashboard/src/components/ProviderIcon.tsx
+++ b/packages/dashboard/src/components/ProviderIcon.tsx
@@ -164,6 +164,9 @@ export function ProviderIcon({
 }: ProviderIconProps) {
   const key = normalizeProviderKey(provider);
   const asset = PROVIDER_ICON_MAP[key];
+  // Inline SVGs use currentColor. On light badges (e.g. bg-white in the tool
+  // usage card) force a dark fill so dark-mode foreground does not wash out.
+  const svgColor = color ?? (onLightBackground ? '#111827' : undefined);
 
   if (asset) {
     return (
@@ -192,7 +195,7 @@ export function ProviderIcon({
       <DroidIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -202,7 +205,7 @@ export function ProviderIcon({
       <OmpIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -212,7 +215,7 @@ export function ProviderIcon({
       <ZedIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -222,7 +225,7 @@ export function ProviderIcon({
       <WarpIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
@@ -232,12 +235,12 @@ export function ProviderIcon({
       <DeepSeekHarnessIcon
         className={className}
         size={size}
-        style={{ color }}
+        style={{ color: svgColor }}
       />
     );
   }
 
-  return <PlaceholderIcon className={className} size={size} style={{ color }} />;
+  return <PlaceholderIcon className={className} size={size} style={{ color: svgColor }} />;
 }
 
 function OmpIcon({


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄

新特性请提交至 feature 分支，其余可提交至 master 分支。
在维护者审核通过后会合并。
请确保填写以下 pull request 的信息，谢谢！~
-->

### 🤔 这个变动的性质是？

- [ ] 🆕 新特性提交
- [x] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [x] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

> 无关联 Issue。

### 💡 需求背景和解决方案

> 1. 「工具与模型用量」卡片里渠道 logo 放在 `bg-white` 白底徽章上，并传入 `onLightBackground`。Cursor / ZCode 等单色 `<img>` 在该场景下不会 `dark:invert`，保持黑色可见。
> 2. DeepSeek Harness（以及 droid / omp / zed / warp）走内联 SVG + `currentColor`，却未消费 `onLightBackground`，深色模式下继承浅色前景 → 白底白标，看起来像空白方块。
> 3. 在 `ProviderIcon` 中：未显式传 `color` 且 `onLightBackground` 时，内联 SVG 强制深色填充 `#111827`。`packages/dashboard` 与 `apps/desktop/src/renderer` 同步修改。

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Keep DeepSeek Harness and other inline SVG provider icons visible on light badges in dark mode (Desktop renderer synced). |
| 🇨🇳 中文 | 修复深色模式下「工具与模型用量」等白底徽章上 DeepSeek Harness 等内联 SVG 渠道图标变成空白方块的问题（Desktop renderer 已同步）。 |

### ✅ 验证

- 深色模式打开用量页「工具与模型用量」：DeepSeek Harness 白底徽章内应能看到鲸鱼轮廓，对比度与 Cursor / ZCode 接近。
- 浅色模式下同一卡片：图标仍为深色、正常可见。
- 其它使用 `onLightBackground` 的位置（排行榜卡片、平台筛选下拉）：dsh / droid / omp / zed / warp 图标在白底上可见。
- Desktop：打开桌面端用量页，确认同一修复生效。


Made with [Cursor](https://cursor.com)