### PR TITLE
feat(web): add contributors wall on download page

### DIFF
--- a/.changeset/download-contributors-wall.md
+++ b/.changeset/download-contributors-wall.md
@@ -1,0 +1,5 @@
+---
+"@juejin-opensource/jusage-dashboard": patch
+---
+
+下载页 Star 旁新增贡献者墙卡片（复用 README 的 contrib.rocks），展示「感谢掘友们的贡献支持」并链到 GitHub contributors。

--- a/packages/dashboard/src/components/ContributorsWall.tsx
+++ b/packages/dashboard/src/components/ContributorsWall.tsx
@@ -1,0 +1,66 @@
+import { cn } from '@/lib/utils';
+
+/** Same source as README Contributing section (`contrib.rocks`). */
+const DEFAULT_REPO = 'juejin-cn/juejin-usage';
+
+export function ContributorsWall({
+  className,
+  repo = DEFAULT_REPO,
+  max = 500,
+  columns = 20,
+}: {
+  className?: string;
+  repo?: string;
+  max?: number;
+  columns?: number;
+}) {
+  const imageSrc = `https://contrib.rocks/image?repo=${encodeURIComponent(repo)}&max=${max}&columns=${columns}`;
+  const contributorsPage = `https://github.com/${repo}/graphs/contributors`;
+
+  return (
+    <a
+      aria-label="感谢掘友们的贡献支持，查看 GitHub 贡献者"
+      className={cn(
+        'group block overflow-hidden rounded-2xl border border-border',
+        'bg-surface-secondary/80 shadow-[0_1px_2px_rgb(0_0_0/0.06)]',
+        'outline-offset-2 transition-[background-color,box-shadow,border-color] duration-200',
+        'hover:border-border hover:bg-surface-secondary hover:shadow-[0_8px_24px_-12px_rgb(15_23_42/0.28)]',
+        'focus-visible:outline-2 focus-visible:outline-accent',
+        'dark:bg-overlay/60 dark:hover:bg-overlay/80 dark:hover:shadow-[0_8px_24px_-12px_rgb(0_0_0/0.55)]',
+        className,
+      )}
+      href={contributorsPage}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <div className="flex items-start justify-between gap-3 border-b border-border/70 px-5 py-3.5">
+        <div className="min-w-0">
+          <p className="text-base font-medium tracking-tight text-foreground">
+            感谢掘友们的贡献支持
+            <span aria-hidden="true" className="ml-1">
+              🎉
+            </span>
+          </p>
+          <p className="mt-0.5 text-sm leading-6 text-muted">
+            提交 PR 即可上榜
+          </p>
+        </div>
+        <span
+          aria-hidden="true"
+          className="mt-0.5 shrink-0 text-muted transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-foreground/70"
+        >
+          →
+        </span>
+      </div>
+      <div className="bg-surface/40 px-4 py-3.5 dark:bg-black/10">
+        <img
+          alt="Juejin Usage contributors"
+          className="h-auto w-full scale-[1.01] transition-transform duration-300 ease-out group-hover:scale-[1.03]"
+          decoding="async"
+          loading="lazy"
+          src={imageSrc}
+        />
+      </div>
+    </a>
+  );
+}

--- a/packages/dashboard/src/components/InstallGuidePage.tsx
+++ b/packages/dashboard/src/components/InstallGuidePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Check, ChevronDown, Copy } from '@gravity-ui/icons';
 import { Button, Popover } from '@heroui/react';
+import { ContributorsWall } from '@/components/ContributorsWall';
 import { SupportedToolsGrid } from '@/components/SupportedToolsGrid';
 import { WeChatSupportTrigger } from '@/components/WeChatSupportTrigger';
 import {
@@ -474,30 +475,33 @@ export function InstallGuidePage({ reason }: InstallGuidePageProps) {
             <WeChatSupportTrigger variant="link" />
           </p>
 
-          <a
-            aria-label="在 GitHub 上 Star 本项目"
-            className="mt-4 flex w-full max-w-xl items-center gap-4 rounded-2xl border border-border bg-surface-secondary/80 px-5 py-4 shadow-[0_1px_2px_rgb(0_0_0/0.06)] outline-offset-2 transition-colors hover:bg-surface-secondary focus-visible:outline-2 focus-visible:outline-accent dark:bg-overlay/60 dark:hover:bg-overlay/80"
-            href={GITHUB_REPO_URL}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <GithubMark className="size-8 shrink-0" />
-            <span className="min-w-0">
-              <span className="flex items-baseline gap-2">
-                <span className="text-base font-medium text-foreground">
-                  ⭐️ Star
-                </span>
-                {starLabel ? (
-                  <span className="text-sm font-medium tabular-nums text-foreground/55">
-                    {starLabel}
+          <div className="mt-4 flex w-full max-w-xl flex-col gap-3">
+            <a
+              aria-label="在 GitHub 上 Star 本项目"
+              className="flex w-full items-center gap-4 rounded-2xl border border-border bg-surface-secondary/80 px-5 py-4 shadow-[0_1px_2px_rgb(0_0_0/0.06)] outline-offset-2 transition-colors hover:bg-surface-secondary focus-visible:outline-2 focus-visible:outline-accent dark:bg-overlay/60 dark:hover:bg-overlay/80"
+              href={GITHUB_REPO_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <GithubMark className="size-8 shrink-0" />
+              <span className="min-w-0">
+                <span className="flex items-baseline gap-2">
+                  <span className="text-base font-medium text-foreground">
+                    ⭐️ Star
                   </span>
-                ) : null}
+                  {starLabel ? (
+                    <span className="text-sm font-medium tabular-nums text-foreground/55">
+                      {starLabel}
+                    </span>
+                  ) : null}
+                </span>
+                <span className="mt-0.5 block text-sm leading-6 text-muted">
+                  开源共享，欢迎提 Issue 与贡献代码
+                </span>
               </span>
-              <span className="mt-0.5 block text-sm leading-6 text-muted">
-                开源共享，欢迎提 Issue 与贡献代码
-              </span>
-            </span>
-          </a>
+            </a>
+            <ContributorsWall />
+          </div>
         </div>
 
         <div className="min-w-0 motion-safe:animate-[fade-up_520ms_ease-out]">


### PR DESCRIPTION
### 🏷️ 变动类型

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 🔌 新增 / 修复数据源解析器（parser）
- [x] 💄 样式与交互改进
- [ ] ⚡️ 性能优化
- [ ] 🛠 重构
- [ ] 🤖 TypeScript 类型改进
- [ ] 📝 文档改进
- [ ] 📦 构建 / 打包 / 依赖
- [ ] ✅ 测试用例
- [ ] ⏩ 工作流 / CI
- [ ] 🔒 安全修复
- [ ] ❓ 其他（请说明是关于什么的改动）

### 🖥️ 影响范围

- [ ] Desktop
- [ ] CLI
- [x] Web

### 🔗 关联 Issue

下载页 Star 旁缺少与 README 一致的贡献者墙展示。

### 💡 改动说明

1. 下载页（`InstallGuidePage`）Star 卡片下方补充贡献者墙。
2. 新增可复用组件 `ContributorsWall`，复用 README 的 `contrib.rocks` 图源，点击跳转 GitHub contributors。
3. 标题文案参考 README：「感谢掘友们的贡献支持」，副文案「提交 PR 即可上榜」。
4. Desktop renderer 无同名下载页副本，无需同步。

### 📝 Changelog

| 包 | 版本类型 | 变更描述（面向用户） |
| --- | --- | --- |
| `@juejin-opensource/jusage-dashboard` | patch | 下载页 Star 旁新增贡献者墙卡片（复用 README 的 contrib.rocks），展示「感谢掘友们的贡献支持」并链到 GitHub contributors。 |

### ☑️ 自查清单

- [ ] 分支命名符合 `<type>/<end>/<short-desc>`（见 [CONTRIBUTING.md](https://github.com/juejin-cn/juejin-usage/blob/main/CONTRIBUTING.md#分支规范)）
- [x] 已在受影响的端本地自测通过
- [x] 若改动了面板 UI：已确认 `packages/dashboard/src` 与 `apps/desktop/src/renderer` 这两份同构但独立的代码是否都需要改
- [x] 已执行 `pnpm changeset`（纯文档 / CI 改动可跳过）
- [ ] `pnpm build` 通过


Made with [Cursor](https://cursor.com)